### PR TITLE
Check for type of MessageEvent source before closing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export const runIframe = (authorizeUrl: string, eventOrigin: string) => {
     const iframeEventHandler = function(e: MessageEvent) {
       if (e.origin != eventOrigin) return;
       if (!e.data || e.data.type !== 'authorization_response') return;
-      (<any>e.source).close();
+      if (e.source instanceof Window) (<any>e.source).close();
       e.data.response.error ? rej(e.data.response) : res(e.data.response);
       clearTimeout(timeoutSetTimeoutId);
       window.removeEventListener('message', iframeEventHandler, false);


### PR DESCRIPTION
Make sure it is a Window before attempting to `close()` it.

Prevents a fatal error when using `getTokenSilently()`.