### PR TITLE
Add default leeway of 60s

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -72,8 +72,8 @@ export const verify = (options: JWTVerifyOptions) => {
   const expDate = new Date(0);
   const iatDate = new Date(0);
   const nbfDate = new Date(0);
-  const leeway = options.leeway || 0;
-  expDate.setUTCSeconds(decoded.claims.exp + leeway);
+  const leeway = options.leeway || 60;
+  expDate.setUTCSeconds(decoded.claims.exp);
   iatDate.setUTCSeconds(decoded.claims.iat - leeway);
   nbfDate.setUTCSeconds(decoded.claims.nbf - leeway);
   if (now > expDate) {


### PR DESCRIPTION
This will prevent the 'token was issued in the future' error.