### PR TITLE
Improve readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,81 @@ yarn add @auth0/auth0-spa-js
 
 ## Getting Started
 
-```js
-import createAuth0Client from '@auth0/auth0-spa-js';
+### 1 - Login
 
-const auth0 = await createAuth0Client({
-  domain: '<AUTH0_DOMAIN>',
-  client_id: '<AUTH0_CLIENT_ID>'
+```html
+<button id="login">Click to Login</button>
+```
+
+```js
+//with async/await
+document.getElementById('login').addEventListener('click', async () => {
+  await auth0.loginWithPopup();
+  //logged in. you can get the user profile like this:
+  const user = await auth0.getUser();
+  console.log(user);
 });
-await auth0.loginWithPopup();
-const user = await auth0.getUser();
-const accessToken = await auth0.getTokenSilently();
+
+//with promises
+document.getElementById('login').addEventListener('click', () => {
+  auth0.loginWithPopup().then(token => {
+    //logged in. you can get the user profile like this:
+    auth0.getUser().then(user => {
+      console.log(user);
+    });
+  });
+});
+```
+
+### 2 - Calling an API
+
+```html
+<button id="call-api">Call an API</button>
+```
+
+```js
+//with async/await
+document.getElementById('call-api').addEventListener('click', async () => {
+  const accessToken = await auth0.getTokenSilently();
+  const result = await fetch('https://myapi.com', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  });
+  const data = await result.json();
+  console.log(data);
+});
+
+//with promises
+document.getElementById('call-api').addEventListener('click', () => {
+  auth0
+    .getTokenSilently()
+    .then(accessToken =>
+      fetch('https://myapi.com', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      })
+    )
+    .then(result => result.json())
+    .then(data => {
+      console.log(data);
+    });
+});
+```
+
+### 3 - Logout
+
+```html
+<button id="logout">Logout</button>
+```
+
+```js
+document.getElementById('logout').addEventListener('click', () => {
+  auth0.logout();
+});
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ yarn add @auth0/auth0-spa-js
 
 ## Getting Started
 
+### Creating the client
+
+> Ideally, you should have only one instance of the client. Create one
+> before rendering / initializing your application.
+
+```js
+//with async/await
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  client_id: '<AUTH0_CLIENT_ID>'
+});
+
+//with promises
+createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  client_id: '<AUTH0_CLIENT_ID>'
+}).then(auth0 => {
+  //...
+});
+```
+
 ### 1 - Login
 
 ```html
@@ -116,6 +137,8 @@ document.getElementById('call-api').addEventListener('click', () => {
 ```
 
 ```js
+import createAuth0Client from '@auth0/auth0-spa-js';
+
 document.getElementById('logout').addEventListener('click', () => {
   auth0.logout();
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -91,6 +91,10 @@ export default class Auth0Client {
    * parameters will be auto-generated. If the response is successful,
    * results will be valid according to their expiration times.
    *
+   * IMPORTANT: This method has to be called from an event handler
+   * that was started by the user like a button click, for example,
+   * otherwise the popup will be blocked in most browsers.
+   *
    * @param options
    */
   public async loginWithPopup(options: PopupLoginOptions) {


### PR DESCRIPTION
- Instead of one large generic getting started  block, replace it with 3 task-specific blocks: Login (login with redirect), Calling an API (acquire/renew AT, fake API call or reference to doing API call), Logout (sample call to logout method)

- Change example from popup to redirect or include a warning about popups getting blocked by the browser if not triggered by user event.

- Provide guidance on how to use with promises
