### PR TITLE
Broken typings - updated the typings path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "version": "1.0.0-beta.1",
   "main": "dist/lib/auth0-spa-js.cjs.js",
-  "types": "dist/typings/src/index.d.ts",
+  "types": "dist/typings/index.d.ts",
   "browser": "dist/auth0-spa-js.production.js",
   "module": "dist/auth0-spa-js.production.esm.js",
   "scripts": {


### PR DESCRIPTION
The TypeScript typings when built now seem to appear in the folder `dist/typings/*.d.ts` as opposed to `dist/typings/src/*.d.ts` which is what the path in the `package.json` file points to. This appears to be a change from `0.0.1-alpha.19` to `1.0.0-beta.1`.

It's not obvious from the history exactly when this regressed but perhaps it could be somewhere within a Rollup plugin? (I'm not 100% familiar with Rollup or how the typings are generated).

It would be useful to understand how/where/why the change occurred and what the correct path should ultimately be.