### PR TITLE
fast-text-encoder now always imported by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'fast-text-encoding';
 import Auth0Client from './Auth0Client';
 import * as ClientStorage from './storage';
 

--- a/src/legacy.ts
+++ b/src/legacy.ts
@@ -1,5 +1,4 @@
 import 'ts-polyfill';
-import 'fast-text-encoding';
 import 'unfetch/polyfill/index';
 if (!window.crypto && (<any>window).msCrypto) {
   (<any>window).crypto = (<any>window).msCrypto;


### PR DESCRIPTION
### Description

Microsoft Edge requires a polyfill for TextEncoder (used by `auth0-spa-js` in its hashing function). The change in this PR ensures that a polyfill [`fast-text-encoding`](https://github.com/samthor/fast-text-encoding) is always included when the SDK is imported, not just for legacy usage.

### References

https://github.com/auth0-samples/auth0-angular-samples/issues/155

### Testing

Tested manually in Edge, after verifying that the error occurred before the polyfill was imported.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
