### PR TITLE
Add default scope information to tsdoc

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -40,6 +40,7 @@ interface BaseLoginOptions {
   acr_values?: string;
   /**
    * The default scope to be used on authentication requests.
+   * `openid profile email` is always added to all requests.
    */
   scope?: string;
   /**


### PR DESCRIPTION
### Description

Add info about default scope to the auto generated docs.