### PR TITLE
Mark redirect_uri optional on RedirectLoginOptions

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -102,7 +102,7 @@ interface RedirectLoginOptions extends BaseLoginOptions {
    * the "Allowed Callback URLs" field in your Auth0 Application's
    * settings.
    */
-  redirect_uri: string;
+  redirect_uri?: string;
   /**
    * Used to store state before doing the redirect
    */


### PR DESCRIPTION
### Description

When configuring a global redirect_uri (by passing it as a property on Auth0ClientOptions to the Auth0Client constructor), passing a redirect uri is not required when calling `loginWithRedirect` (I think it will even be ignored if you do so: https://github.com/auth0/auth0-spa-js/blob/master/src/Auth0Client.ts#L67).

However, the typings have marked redirect_uri as required for `RedirectLoginOptions`.

This PR ensures the property is marked optional.

### Testing

The samples from the Angular quickstart guide don't compile for me, for example the AuthGuard has this code:

```
client.loginWithRedirect({
  appState: { target: state.url }
});
```

Which gives me the following TSC error:
![image](https://user-images.githubusercontent.com/2146903/60772260-0782fc80-a0f4-11e9-9fbd-89f85c8bcfbe.png)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
