### PR TITLE
Make id_token available via Auth0Client.getIdToken()

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -611,6 +611,47 @@ describe('Auth0', () => {
       );
     });
   });
+  describe('getIdToken()', () => {
+    it('returns undefined if there is no cache', async () => {
+      const { auth0, cache } = await setup();
+      cache.get.mockReturnValue(undefined);
+      const id_token = await auth0.getIdToken();
+      expect(id_token).toBeUndefined();
+    });
+    it('returns actual token if there is a cache entry', async () => {
+      const { auth0, cache } = await setup();
+      cache.get.mockReturnValue({ id_token: TEST_ID_TOKEN });
+      const id_token = await auth0.getIdToken();
+      expect(id_token).toEqual(TEST_ID_TOKEN);
+    });
+    it('uses default options', async () => {
+      const { auth0, utils, cache } = await setup();
+      await auth0.getIdToken();
+      expect(cache.get).toHaveBeenCalledWith({
+        audience: 'default',
+        scope: TEST_SCOPES
+      });
+      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
+        'openid profile email',
+        'openid profile email'
+      );
+    });
+    it('uses custom options when provided', async () => {
+      const { auth0, utils, cache } = await setup();
+      await auth0.getIdToken({
+        audience: 'the-audience',
+        scope: 'the-scope'
+      });
+      expect(cache.get).toHaveBeenCalledWith({
+        audience: 'the-audience',
+        scope: TEST_SCOPES
+      });
+      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
+        'openid profile email',
+        'the-scope'
+      );
+    });
+  });
   describe('isAuthenticated()', () => {
     it('returns true if there is an user', async () => {
       const { auth0 } = await setup();

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -165,7 +165,7 @@ export default class Auth0Client {
    * const user = await auth0.getIdToken();
    * ```
    *
-   * Returns the user information if available.
+   * Returns the id_token if available.
    *
    * @param options
    */
@@ -185,7 +185,7 @@ export default class Auth0Client {
    * const claims = await auth0.getIdTokenClaims();
    * ```
    *
-   * Returns the id_token if available.
+   * Returns all claims from the id_token if available.
    *
    * @param options
    */

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -162,10 +162,30 @@ export default class Auth0Client {
 
   /**
    * ```js
+   * const user = await auth0.getIdToken();
+   * ```
+   *
+   * Returns the user information if available.
+   *
+   * @param options
+   */
+  public async getIdToken(
+    options: GetUserOptions = {
+      audience: this.options.audience || 'default',
+      scope: this.options.scope || this.DEFAULT_SCOPE
+    }
+  ) {
+    options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
+    const cache = this.cache.get(options);
+    return cache && cache.id_token;
+  }
+
+  /**
+   * ```js
    * const claims = await auth0.getIdTokenClaims();
    * ```
    *
-   * Returns all claims from the id_token if available.
+   * Returns the id_token if available.
    *
    * @param options
    */

--- a/static/index.html
+++ b/static/index.html
@@ -14,9 +14,9 @@
     <button id="login_popup">Login popup</button>
     <button id="login_redirect">Login redirect</button>
     <button id="login_redirect_callback">Login redirect callback</button>
-    <button id="login">Login</button>
     <button id="getUser">Get user</button>
     <button id="getIdTokenClaims">Get id_token decoded</button>
+    <button id="getIdToken">Get id_token</button>
     <button id="getToken">Get access token with no interaction</button>
     <button id="getTokenPopup">Get access token with a popup</button>
     <button id="getToken_audience">
@@ -45,6 +45,7 @@
         });
         $('#getToken').click(async () => {
           const token = await auth0.getTokenSilently();
+          console.log(token);
         });
 
         $('#getTokenPopup').click(async () => {
@@ -52,12 +53,19 @@
             audience: 'https://brucke.auth0.com/api/v2/',
             scope: 'read:rules'
           });
+          console.log(token);
         });
         $('#getUser').click(async () => {
           const user = await auth0.getUser();
+          console.log(user);
         });
         $('#getIdTokenClaims').click(async () => {
           const claims = await auth0.getIdTokenClaims();
+          console.log(claims);
+        });
+        $('#getIdToken').click(async () => {
+          const id_token = await auth0.getIdToken();
+          console.log(id_token);
         });
         $('#getToken_audience').click(async () => {
           const differentAudienceOptions = {
@@ -66,6 +74,7 @@
             redirect_uri: 'http://localhost:3000/callback.html'
           };
           const token = await auth0.getTokenSilently(differentAudienceOptions);
+          console.log(token);
         });
         $('#logout').click(async () => {
           auth0.logout({


### PR DESCRIPTION
### Description

This PR makes the id_token directly available via Auth0Client.getIdToken(). This is very useful for anyone using JWT authentication in their server (for example, Hasura has JWT mode, which is seamless to use... if you have the id_token to send).

### References

A brief discussion occurred in the [Auth0 Community Forum](https://community.auth0.com/t/how-to-obtain-id-token-with-auth0-spa-js/27574).

### Testing

Unit tests are included.

The app produced by `npm run dev` will fascilitate manual testing, which can be done by simply calling the `.getIdToken()` method after successfully calling
1. `.getTokenSilently()`
2. `.getTokenWithPopup()`
3. `.loginWithPopup()`
4. If there is some specific reason why the popup returns the id_token, but redirect doesn't, I would be interested to find out why.

Additional manual testing was done on Chrome from a Mac in a React app, following the quick start guide for auth0-spa-js.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`

I verified that the auto-generated docs are accurate, but didn't venture much further than that.
