### PR TITLE
Allow redirect_uri override in loginWithRedirect

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -293,11 +293,13 @@ describe('Auth0', () => {
     });
     it('creates correct query params when providing a default redirect_uri', async () => {
       const redirect_uri = 'https://custom-redirect-uri/callback';
+      const { redirect_uri: _ignore, ...options } = REDIRECT_OPTIONS;
       const { auth0, utils } = await setup({
         redirect_uri
       });
 
-      await auth0.loginWithRedirect(REDIRECT_OPTIONS);
+      await auth0.loginWithRedirect(options);
+
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
@@ -306,6 +308,27 @@ describe('Auth0', () => {
         state: TEST_ENCODED_STATE,
         nonce: TEST_RANDOM_STRING,
         redirect_uri,
+        code_challenge: TEST_BASE64_ENCODED_STRING,
+        code_challenge_method: 'S256',
+        connection: 'test-connection'
+      });
+    });
+    it('creates correct query params when overriding redirect_uri', async () => {
+      const redirect_uri = 'https://custom-redirect-uri/callback';
+      const { auth0, utils } = await setup({
+        redirect_uri
+      });
+
+      await auth0.loginWithRedirect(REDIRECT_OPTIONS);
+
+      expect(utils.createQueryParams).toHaveBeenCalledWith({
+        client_id: TEST_CLIENT_ID,
+        scope: TEST_SCOPES,
+        response_type: TEST_CODE,
+        response_mode: 'query',
+        state: TEST_ENCODED_STATE,
+        nonce: TEST_RANDOM_STRING,
+        redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
         connection: 'test-connection'

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -64,7 +64,7 @@ export default class Auth0Client {
       response_mode: 'query',
       state,
       nonce,
-      redirect_uri: this.options.redirect_uri || redirect_uri,
+      redirect_uri: redirect_uri || this.options.redirect_uri,
       code_challenge,
       code_challenge_method: 'S256'
     };
@@ -111,7 +111,7 @@ export default class Auth0Client {
       stateIn,
       nonceIn,
       code_challenge,
-      window.location.origin
+      this.options.redirect_uri || window.location.origin
     );
     const url = this._authorizeUrl({
       ...params,
@@ -311,7 +311,7 @@ export default class Auth0Client {
       stateIn,
       nonceIn,
       code_challenge,
-      window.location.origin
+      this.options.redirect_uri || window.location.origin
     );
     const url = this._authorizeUrl({
       ...params,


### PR DESCRIPTION
### Description

The developer should be able to override the default redirect_uri when calling `loginWithRedirect`. Today, we were actually overriding anything passed in the `loginWithRedirect` method with the default redirect_uri provided in the `createAuth0Client` function, which doesn't make sense and it's a bug. This PR fixes that.

### References

Bug found in this thread: https://github.com/auth0/auth0-spa-js/issues/52#issuecomment-509021424

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
