### PR TITLE
Handle oauth/token request errors

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,8 +115,22 @@ export const bufferToBase64UrlEncoded = input =>
     window.btoa(String.fromCharCode(...Array.from(new Uint8Array(input))))
   );
 
+const getJSON = async (url, options) => {
+  const response = await fetch(url, options);
+  const { error, error_description, ...success } = await response.json();
+  if (!response.ok) {
+    const errorMessage =
+      error_description || `HTTP error. Unable to fetch ${url}`;
+    const e = <any>new Error(errorMessage);
+    e.error = error || 'request_error';
+    e.error_description = errorMessage;
+    throw e;
+  }
+  return success;
+};
+
 export const oauthToken = async ({ baseUrl, ...options }: OAuthTokenOptions) =>
-  await fetch(`${baseUrl}/oauth/token`, {
+  await getJSON(`${baseUrl}/oauth/token`, {
     method: 'POST',
     body: JSON.stringify({
       grant_type: 'authorization_code',
@@ -126,4 +140,4 @@ export const oauthToken = async ({ baseUrl, ...options }: OAuthTokenOptions) =>
     headers: {
       'Content-type': 'application/json'
     }
-  }).then(r => r.json());
+  });


### PR DESCRIPTION
### Description

Our http request library doesn't throw an error if the request is 401, 403 etc, so it's up to us to implement the error handling logic. This PR adds logic to catch unsuccessful requests (non 2xx status code) and throws the appropriate error to inform developers what's going on.

### References

This greatly improves DX when dealing with issues like https://github.com/auth0/auth0-spa-js/issues/70

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality