### PR TITLE
Add ?federated logout param

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -917,12 +917,26 @@ describe('Auth0', () => {
         returnTo: 'https://return.to'
       });
     });
+    it('creates correct query params when `options.federated` is true', async () => {
+      const { auth0, utils } = await setup();
+
+      auth0.logout({ federated: true, client_id: null });
+      expect(utils.createQueryParams).toHaveBeenCalledWith({});
+    });
     it('calls `window.location.assign` with the correct url', async () => {
       const { auth0 } = await setup();
 
       auth0.logout();
       expect(window.location.assign).toHaveBeenCalledWith(
         `https://test.auth0.com/v2/logout?query=params${TEST_TELEMETRY_QUERY_STRING}`
+      );
+    });
+    it('calls `window.location.assign` with the correct url when `options.federated` is true', async () => {
+      const { auth0 } = await setup();
+
+      auth0.logout({ federated: true });
+      expect(window.location.assign).toHaveBeenCalledWith(
+        `https://test.auth0.com/v2/logout?query=params${TEST_TELEMETRY_QUERY_STRING}&federated`
       );
     });
   });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -403,7 +403,9 @@ export default class Auth0Client {
       delete options.client_id;
     }
     ClientStorage.remove('auth0.is.authenticated');
-    const url = this._url(`/v2/logout?${createQueryParams(options)}`);
-    window.location.assign(url);
+    const { federated, ...logoutOptions } = options;
+    const federatedQuery = federated ? `&federated` : '';
+    const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
+    window.location.assign(`${url}${federatedQuery}`);
   }
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -176,6 +176,14 @@ interface LogoutOptions {
    * The `client_id` of your application.
    */
   client_id?: string;
+
+  /**
+   * When supported by the upstream identity provider,
+   * forces the user to logout of their identity provider
+   * and from Auth0.
+   * [Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)
+   */
+  federated?: boolean;
 }
 
 /**


### PR DESCRIPTION
fix #126 

### Description

Adds option to send the `federated` query param to /logout


### References

https://auth0.com/docs/logout/guides/logout-idps

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality