### PR TITLE
Allow users to send custom params to the AS

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -53,6 +53,12 @@ interface BaseLoginOptions {
    * the Login Widget.
    */
   connection?: string;
+
+  /**
+   * If you need to send custom parameters to the Authorization Server,
+   * make sure to use the original parameter name.
+   */
+  [key: string]: any;
 }
 
 interface Auth0ClientOptions extends BaseLoginOptions {
@@ -164,6 +170,12 @@ interface GetTokenSilentlyOptions extends GetUserOptions {
    * Auth0 Application's settings.
    */
   redirect_uri?: string;
+
+  /**
+   * If you need to send custom parameters to the Authorization Server,
+   * make sure to use the original parameter name.
+   */
+  [key: string]: any;
 }
 interface GetTokenWithPopupOptions extends PopupLoginOptions {}
 


### PR DESCRIPTION
### Description

If you're using typescript, you can't pass custom params to send to an upstream IdP or to customize your ULP. This PR enables devs to send whatever param they want while still providing a great autocomplete experience for the OOTB params (mostly from the spec).