### PR TITLE
Added function to get ID Token

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -276,6 +276,22 @@ export default class Auth0Client {
   }
 
   /**
+  * Get JWT ID token
+  */
+  public getIdToken(options: GetTokenSilentlyOptions = {
+    audience: this.options.audience,
+    scope: this.options.scope || this.DEFAULT_SCOPE,
+    ignoreCache: false
+  }) {
+    const cache = this.cache.get({
+      scope: options.scope,
+      audience: options.audience || 'default'
+    });
+    return cache.id_token;
+  }
+
+
+  /**
    * ```js
    * const token = await auth0.getTokenSilently(options);
    * ```


### PR DESCRIPTION
### Description

This PR purpose is to add a getter for id_token. This is currently unavailable but there are cases when it's required. I've seen that other people are asking for this too.

### Testing
It can be accessed simply by calling `auth0Client.getIdToken()`

- [ -] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [- ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [*] All active GitHub checks for tests, formatting, and security are passing
- [*] The correct base branch is being used, if not `master`
