### PR TITLE
Expose raw id_token in the getIdTokenClaims method

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -18,7 +18,7 @@ describe('cache', () => {
       access_token: 'accesstoken',
       expires_in: 1,
       decodedToken: {
-        claims: { exp: 1, name: 'Test' },
+        claims: { __raw: 'idtoken', exp: 1, name: 'Test' },
         user: { name: 'Test' }
       }
     });
@@ -32,7 +32,7 @@ describe('cache', () => {
       access_token: 'accesstoken',
       expires_in: 1,
       decodedToken: {
-        claims: { name: 'Test' },
+        claims: { __raw: 'idtoken', name: 'Test' },
         user: { name: 'Test' }
       }
     });
@@ -46,7 +46,11 @@ describe('cache', () => {
       access_token: 'accesstoken',
       expires_in: 1,
       decodedToken: {
-        claims: { name: 'Test', exp: new Date().getTime() / 1000 + 2 },
+        claims: {
+          __raw: 'idtoken',
+          name: 'Test',
+          exp: new Date().getTime() / 1000 + 2
+        },
         user: { name: 'Test' }
       }
     });
@@ -61,7 +65,11 @@ describe('cache', () => {
       access_token: 'accesstoken',
       expires_in: 2,
       decodedToken: {
-        claims: { name: 'Test', exp: new Date().getTime() / 1000 + 1 },
+        claims: {
+          __raw: 'idtoken',
+          name: 'Test',
+          exp: new Date().getTime() / 1000 + 1
+        },
         user: { name: 'Test' }
       }
     });

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -74,6 +74,7 @@ describe('jwt', async () => {
         payload: true
       },
       claims: {
+        __raw: id_token,
         aud: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
         exp: 1551365990,
         iat: 1551362390,

--- a/src/global.ts
+++ b/src/global.ts
@@ -242,6 +242,7 @@ interface JWTVerifyOptions {
  * @ignore
  */
 interface IdToken {
+  __raw: string;
   name?: string;
   given_name?: string;
   family_name?: string;

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -36,7 +36,7 @@ const idTokendecoded = [
 export const decode = (token: string) => {
   const [header, payload, signature] = token.split('.');
   const payloadJSON = JSON.parse(urlDecodeB64(payload));
-  const claims: IdToken = {};
+  const claims: IdToken = { __raw: token };
   const user = {};
   Object.keys(payloadJSON).forEach(k => {
     claims[k] = payloadJSON[k];


### PR DESCRIPTION
### Description

Some scenarios still need the id_token available. This PR exposes the raw id_token in the `getIdTokenClaims` method.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
