### PR TITLE
Replace promise polyfill for a pure one

### DIFF
--- a/__mocks__/promise-polyfill/src/polyfill.js
+++ b/__mocks__/promise-polyfill/src/polyfill.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8028,8 +8028,7 @@
     "promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-      "dev": true
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
     },
     "prompts": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "core-js": "^3.2.1",
     "es-cookie": "^1.2.0",
     "fast-text-encoding": "^1.0.0",
+    "promise-polyfill": "^8.1.3",
     "qss": "^2.0.3",
     "unfetch": "^4.1.0"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import 'core-js/es/string/starts-with';
 import 'core-js/es/array/from';
 import 'core-js/es/typed-array/slice';
 import 'core-js/es/array/includes';
-import 'core-js/es/promise';
+import 'promise-polyfill/src/polyfill';
 import 'fast-text-encoding';
 import 'unfetch/polyfill/index';
 


### PR DESCRIPTION
### Description

This PR replaces the `core-js` promise polyfill  by the `promise-polyfill` package.

According to [this comment](https://github.com/zloirock/core-js/pull/608#issuecomment-525247749) `zone.js`'s promise doesn't pass the feature detection that `core-js` does, which causes `core-js` to try to polyfill it again. This throws an error in zone.js. The new `promise-polyfill` just checks if there's a global 'Promise' object available or not, instead of doing feature detection. As a bonus, it reduces the final bundle size in ~3kb.

### References

fix #179 
https://github.com/zloirock/core-js/pull/608#issuecomment-525247749