### PR TITLE
Fix SSR errors with fetch polyfill usage

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -9,7 +9,6 @@ import {
   decodeState,
   sha256,
   openPopup,
-  oauthToken,
   runPopup,
   runIframe,
   urlDecodeB64
@@ -164,12 +163,19 @@ describe('utils', () => {
     });
   });
   describe('oauthToken', () => {
+    let oauthToken;
+    let mockUnfetch;
+    beforeEach(() => {
+      jest.resetModules();
+      jest.mock('unfetch');
+      mockUnfetch = require('unfetch');
+      oauthToken = require('../src/utils').oauthToken;
+    });
     it('calls oauth/token with the correct url', async () => {
-      (<any>global).fetch = jest.fn(
-        () =>
-          new Promise(res =>
-            res({ ok: true, json: () => new Promise(ress => ress(true)) })
-          )
+      mockUnfetch.mockReturnValue(
+        new Promise(res =>
+          res({ ok: true, json: () => new Promise(ress => ress(true)) })
+        )
       );
       await oauthToken({
         baseUrl: 'https://test.com',
@@ -177,7 +183,7 @@ describe('utils', () => {
         code: 'codeIn',
         code_verifier: 'code_verifierIn'
       });
-      expect(fetch).toHaveBeenCalledWith('https://test.com/oauth/token', {
+      expect(mockUnfetch).toHaveBeenCalledWith('https://test.com/oauth/token', {
         body:
           '{"grant_type":"authorization_code","redirect_uri":"http://localhost","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
         headers: { 'Content-type': 'application/json' },
@@ -189,14 +195,13 @@ describe('utils', () => {
         error: 'the-error',
         error_description: 'the-error-description'
       };
-      (<any>global).fetch = jest.fn(
-        () =>
-          new Promise(res =>
-            res({
-              ok: false,
-              json: () => new Promise(ress => ress(theError))
-            })
-          )
+      mockUnfetch.mockReturnValue(
+        new Promise(res =>
+          res({
+            ok: false,
+            json: () => new Promise(ress => ress(theError))
+          })
+        )
       );
       try {
         await oauthToken({
@@ -212,14 +217,13 @@ describe('utils', () => {
       }
     });
     it('handles error without error response', async () => {
-      (<any>global).fetch = jest.fn(
-        () =>
-          new Promise(res =>
-            res({
-              ok: false,
-              json: () => new Promise(ress => ress(false))
-            })
-          )
+      mockUnfetch.mockReturnValue(
+        new Promise(res =>
+          res({
+            ok: false,
+            json: () => new Promise(ress => ress(false))
+          })
+        )
       );
       try {
         await oauthToken({

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import 'core-js/es/typed-array/slice';
 import 'core-js/es/array/includes';
 import 'promise-polyfill/src/polyfill';
 import 'fast-text-encoding';
-import 'unfetch/polyfill/index';
 
 import Auth0Client from './Auth0Client';
 import * as ClientStorage from './storage';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import * as qs from 'qss';
+import fetch from 'unfetch';
+
 import { DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS } from './constants';
 
 const dedupe = arr => arr.filter((x, i) => arr.indexOf(x) === i);


### PR DESCRIPTION


### Description

The fetch polyfill was trying to access `self` directly and this breaks Server Rendered apps. This PR changes the usage of the `unfetch` library to not polyfill the global `fetch` property. Instead, it only requires and uses it when needed.


### References

fix #181 

### Testing

- [ x] This change adds test coverage for new/changed/fixed functionality