### PR TITLE
Remove leeway from /authorize URL

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -186,6 +186,25 @@ describe('Auth0', () => {
         connection: 'test-connection'
       });
     });
+    it('creates correct query params without leeway', async () => {
+      const { auth0, utils } = await setup({ leeway: 10 });
+
+      await auth0.loginWithPopup({
+        connection: 'test-connection'
+      });
+      expect(utils.createQueryParams).toHaveBeenCalledWith({
+        client_id: TEST_CLIENT_ID,
+        scope: TEST_SCOPES,
+        response_type: TEST_CODE,
+        response_mode: 'web_message',
+        state: TEST_ENCODED_STATE,
+        nonce: TEST_RANDOM_STRING,
+        redirect_uri: 'http://localhost',
+        code_challenge: TEST_BASE64_ENCODED_STRING,
+        code_challenge_method: 'S256',
+        connection: 'test-connection'
+      });
+    });
     it('creates correct query params when providing a default redirect_uri', async () => {
       const redirect_uri = 'https://custom-redirect-uri/callback';
       const { auth0, utils } = await setup({
@@ -358,6 +377,23 @@ describe('Auth0', () => {
     });
     it('creates correct query params', async () => {
       const { auth0, utils } = await setup();
+
+      await auth0.loginWithRedirect(REDIRECT_OPTIONS);
+      expect(utils.createQueryParams).toHaveBeenCalledWith({
+        client_id: TEST_CLIENT_ID,
+        scope: TEST_SCOPES,
+        response_type: TEST_CODE,
+        response_mode: 'query',
+        state: TEST_ENCODED_STATE,
+        nonce: TEST_RANDOM_STRING,
+        redirect_uri: REDIRECT_OPTIONS.redirect_uri,
+        code_challenge: TEST_BASE64_ENCODED_STRING,
+        code_challenge_method: 'S256',
+        connection: 'test-connection'
+      });
+    });
+    it('creates correct query params without leeway', async () => {
+      const { auth0, utils } = await setup({ leeway: 10 });
 
       await auth0.loginWithRedirect(REDIRECT_OPTIONS);
       expect(utils.createQueryParams).toHaveBeenCalledWith({
@@ -805,6 +841,24 @@ describe('Auth0', () => {
       });
       it('creates correct query params', async () => {
         const { auth0, utils } = await setup();
+
+        await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
+        expect(utils.createQueryParams).toHaveBeenCalledWith({
+          audience: defaultOptionsIgnoreCacheTrue.audience,
+          client_id: TEST_CLIENT_ID,
+          scope: TEST_SCOPES,
+          response_type: TEST_CODE,
+          response_mode: 'web_message',
+          prompt: 'none',
+          state: TEST_ENCODED_STATE,
+          nonce: TEST_RANDOM_STRING,
+          redirect_uri: 'http://localhost',
+          code_challenge: TEST_BASE64_ENCODED_STRING,
+          code_challenge_method: 'S256'
+        });
+      });
+      it('creates correct query params without leeway', async () => {
+        const { auth0, utils } = await setup({ leeway: 10 });
 
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
         expect(utils.createQueryParams).toHaveBeenCalledWith({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -52,7 +52,7 @@ export default class Auth0Client {
     code_challenge: string,
     redirect_uri: string
   ): AuthorizeOptions {
-    const { domain, ...withoutDomain } = this.options;
+    const { domain, leeway, ...withoutDomain } = this.options;
     return {
       ...withoutDomain,
       ...authorizeOptions,


### PR DESCRIPTION
### Description

Removes the `leeway` param from the final authorize url.


### References

Fix https://github.com/auth0/auth0-spa-js/issues/188

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality