### PR TITLE
Fix incorrect state extraction from query string

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -52,7 +52,12 @@ describe('utils', () => {
   describe('createQueryParams', () => {
     it('creates query string from object', () => {
       expect(
-        createQueryParams({ id: 1, value: 'test', url: 'http://example.com' })
+        createQueryParams({
+          id: 1,
+          value: 'test',
+          url: 'http://example.com',
+          nope: undefined
+        })
       ).toBe('id=1&value=test&url=http%3A%2F%2Fexample.com');
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8071,6 +8071,12 @@
         "escape-goat": "^2.0.0"
       }
     },
+    "qss": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/qss/-/qss-2.0.3.tgz",
+      "integrity": "sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ==",
+      "dev": true
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -841,12 +841,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-      "dev": true
-    },
-    "@types/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
       "dev": true
     },
     "@types/resolve": {
@@ -8076,11 +8070,6 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
-    },
-    "qss": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/qss/-/qss-2.0.3.tgz",
-      "integrity": "sha512-j48ZBT5IZbSqJiSU8EX4XrN8nXiflHvmMvv2XpFc31gh7n6EpSs75bNr6+oj3FOLWyT8m09pTmqLNl34L7/uPQ=="
     },
     "querystring": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "pem": "^1.14.2",
     "prettier": "^1.18.2",
     "pretty-quick": "^1.11.1",
+    "qss": "^2.0.3",
     "rimraf": "^3.0.0",
     "rollup": "^1.17.0",
     "rollup-plugin-commonjs": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@auth0/component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.2",
     "@types/cypress": "^1.1.3",
     "@types/jest": "^24.0.15",
-    "@types/qs": "^6.5.3",
     "@typescript-eslint/eslint-plugin-tslint": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "cli-table": "^0.3.1",
@@ -73,7 +72,6 @@
     "es-cookie": "^1.2.0",
     "fast-text-encoding": "^1.0.0",
     "promise-polyfill": "^8.1.3",
-    "qss": "^2.0.3",
     "unfetch": "^4.1.0"
   },
   "files": [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import * as qs from 'qss';
 import fetch from 'unfetch';
 
 import { DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS } from './constants';
@@ -14,7 +13,13 @@ export const getUniqueScopes = (...scopes: string[]) => {
 };
 
 export const parseQueryResult = (hash: string) => {
-  var hashed = <any>qs.decode(hash);
+  let hashes = hash.split('&');
+  let hashed: any = {};
+  hashes.map(hash => {
+    let [key, val] = hash.split('=');
+    hashed[key] = decodeURIComponent(val);
+  });
+
   return <AuthenticationResult>{
     ...hashed,
     expires_in: parseInt(hashed.expires_in)
@@ -96,7 +101,11 @@ export const createRandomString = () => {
 export const encodeState = (state: string) => btoa(state);
 export const decodeState = (state: string) => atob(state);
 
-export const createQueryParams = (params: any) => qs.encode(params);
+export const createQueryParams = (params: any) => {
+  return Object.keys(params)
+    .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
+    .join('&');
+};
 
 export const sha256 = (s: string) =>
   window.crypto.subtle.digest({ name: 'SHA-256' }, new TextEncoder().encode(s));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,6 +103,7 @@ export const decodeState = (state: string) => atob(state);
 
 export const createQueryParams = (params: any) => {
   return Object.keys(params)
+    .filter(k => typeof params[k] !== 'undefined')
     .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
     .join('&');
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,17 +12,17 @@ export const getUniqueScopes = (...scopes: string[]) => {
     .trim();
 };
 
-export const parseQueryResult = (hash: string) => {
-  let hashes = hash.split('&');
-  let hashed: any = {};
-  hashes.map(hash => {
-    let [key, val] = hash.split('=');
-    hashed[key] = decodeURIComponent(val);
+export const parseQueryResult = (queryString: string) => {
+  let queryParams = queryString.split('&');
+  let parsedQuery: any = {};
+  queryParams.forEach(qp => {
+    let [key, val] = qp.split('=');
+    parsedQuery[key] = decodeURIComponent(val);
   });
 
   return <AuthenticationResult>{
-    ...hashed,
-    expires_in: parseInt(hashed.expires_in)
+    ...parsedQuery,
+    expires_in: parseInt(parsedQuery.expires_in)
   };
 };
 


### PR DESCRIPTION
### Description

CLIs that are aggressively trying to minify our already minified code (like vue-cli and ng-cli) are causing issues with one of our dependencies (`qss`).

What happens is that the second minification pass modifies the content or our dependency making it run a different function.
![image](https://user-images.githubusercontent.com/941075/64050408-4fe7f500-cb4e-11e9-82ad-127ad2f9a88f.png)

Because of this bug, when our code tries to get the query string from the URL, it doesn't find the `state` param and fails.

This PR removes `qss` as dependency and just encodes/decodes query strings manually.

`qss` is still used as a dev dependency for integration tests.

### References

Fix #186 

### Testing

No test change because we were already testing the result of the parsed/encoded results.
- [x] This change adds test coverage for new/changed/fixed functionality