### PR TITLE
Updated CDN link to latest patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Auth0 SDK for Single Page Applications using [Authorization Code Grant Flow with
 From the CDN:
 
 ```html
-<script src="https://cdn.auth0.com/js/auth0-spa-js/1.1.1/auth0-spa-js.production.js"></script>
+<script src="https://cdn.auth0.com/js/auth0-spa-js/1.2/auth0-spa-js.production.js"></script>
 ```
 
 Using [npm](https://npmjs.org):


### PR DESCRIPTION
### Description

This PR updates the CDN version of the library in the readme file.

From customer feedback. Figured this could just always point to the latest patch version?

As per the customer's comment, the VanilllaJS quickstart will be updated as well.

### References

https://github.com/auth0/auth0-spa-js/issues/218#issuecomment-532649658

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
