### PR TITLE
Add optional token issuer config

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -310,6 +310,19 @@ describe('Auth0', () => {
         iss: 'https://test.auth0.com/'
       });
     });
+    it('calls `tokenVerifier.verify` with the `issuer` from in the oauth/token response', async () => {
+      const { auth0, tokenVerifier } = await setup({
+        issuer: 'test-123.auth0.com'
+      });
+
+      await auth0.loginWithPopup({});
+      expect(tokenVerifier).toHaveBeenCalledWith({
+        aud: 'test-client-id',
+        id_token: TEST_ID_TOKEN,
+        nonce: TEST_RANDOM_STRING,
+        iss: 'https://test-123.auth0.com/'
+      });
+    });
     it('calls `tokenVerifier.verify` with the `leeway` from constructor', async () => {
       const { auth0, tokenVerifier } = await setup({ leeway: 10 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -27,12 +27,16 @@ export default class Auth0Client {
   private cache: Cache;
   private transactionManager: TransactionManager;
   private domainUrl: string;
+  private tokenIssuer: string;
   private readonly DEFAULT_SCOPE = 'openid profile email';
 
   constructor(private options: Auth0ClientOptions) {
     this.cache = new Cache();
     this.transactionManager = new TransactionManager();
     this.domainUrl = `https://${this.options.domain}`;
+    this.tokenIssuer = this.options.issuer
+      ? `https://${this.options.issuer}/`
+      : `${this.domainUrl}/`;
   }
   private _url(path) {
     const telemetry = encodeURIComponent(
@@ -75,7 +79,7 @@ export default class Auth0Client {
   }
   private _verifyIdToken(id_token: string, nonce?: string) {
     return verifyIdToken({
-      iss: `${this.domainUrl}/`,
+      iss: this.tokenIssuer,
       aud: this.options.client_id,
       id_token,
       nonce,

--- a/src/global.ts
+++ b/src/global.ts
@@ -69,6 +69,10 @@ interface Auth0ClientOptions extends BaseLoginOptions {
    */
   domain: string;
   /**
+   * The issuer to be used for validation of JWTs, optionally defaults to the domain above
+   */
+  issuer?: string;
+  /**
    * The Client ID found on your Application settings page
    */
   client_id: string;


### PR DESCRIPTION
### Description

In some Auth0 distributions, especially those using the appliance, the `issuer` may be different from the custom domain.

This PR provides an option for specifying a separate issuer.

### Testing

Best approach to test is to provide an `issuer` referencing a domain different to the authorize domain.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
