### PR TITLE
Add early expiration of Access Token in cache

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -54,7 +54,9 @@ describe('cache', () => {
         user: { name: 'Test' }
       }
     });
-    jest.advanceTimersByTime(1001);
+    jest.advanceTimersByTime(799);
+    expect(Object.keys(cache.cache).length).toBe(1);
+    jest.advanceTimersByTime(1);
     expect(Object.keys(cache.cache).length).toBe(0);
   });
   it('expires after `user.exp` when `user.exp` < `expires_in`', () => {
@@ -73,7 +75,9 @@ describe('cache', () => {
         user: { name: 'Test' }
       }
     });
-    jest.advanceTimersByTime(1001);
+    jest.advanceTimersByTime(799);
+    expect(Object.keys(cache.cache).length).toBe(1);
+    jest.advanceTimersByTime(1);
     expect(Object.keys(cache.cache).length).toBe(0);
   });
 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -24,7 +24,7 @@ const createKey = (e: CacheKeyData) => `${e.audience}::${e.scope}`;
 const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
   const expTime =
     (new Date(exp * 1000).getTime() - new Date().getTime()) / 1000;
-  return Math.min(expiresIn, expTime) * 1000 - 5000;
+  return Math.min(expiresIn, expTime) * 1000 * 0.8;
 };
 
 export default class Cache {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -24,7 +24,7 @@ const createKey = (e: CacheKeyData) => `${e.audience}::${e.scope}`;
 const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
   const expTime =
     (new Date(exp * 1000).getTime() - new Date().getTime()) / 1000;
-  return Math.min(expiresIn, expTime) * 1000;
+  return Math.min(expiresIn, expTime) * 1000 - 5000;
 };
 
 export default class Cache {


### PR DESCRIPTION
### Description

Hello, 

**Problem:** In my case the access token provided by Auth0 is valid for 30 seconds and from time to time I would have 401 when trying to call the resource server.

![image](https://user-images.githubusercontent.com/895123/66131982-a389aa80-e5f4-11e9-9bee-a5d9126e1195.png)

**Proprosed solution:** this PR expires the access token 5 seconds before it really expires so that we can be more sure 
the access token used against the resource server is not expired by the time it reaches it.

Let me know what you think.



### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`

