### PR TITLE
Fix IE msCrypto.subtle usage

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -527,6 +527,13 @@ describe('utils', () => {
       const theSubtle = getCryptoSubtle();
       expect(theSubtle).toBe('window');
     });
+    it('should use msCrypto.subtle when available', () => {
+      (<any>global).crypto = undefined;
+      (<any>global).msCrypto = { subtle: 'ms' };
+
+      const theSubtle = getCryptoSubtle();
+      expect(theSubtle).toBe('ms');
+    });
   });
   describe('validateCrypto', () => {
     it('should throw error if crypto is unavailable', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -531,7 +531,7 @@ describe('utils', () => {
       (<any>global).crypto = undefined;
       (<any>global).msCrypto = { subtle: 'ms' };
 
-      const theSubtle = getCryptoSubtle();
+      const cryptoSubtle = getCryptoSubtle();
       expect(theSubtle).toBe('ms');
     });
   });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -532,7 +532,7 @@ describe('utils', () => {
       (<any>global).msCrypto = { subtle: 'ms' };
 
       const cryptoSubtle = getCryptoSubtle();
-      expect(theSubtle).toBe('ms');
+      expect(cryptoSubtle).toBe('ms');
     });
   });
   describe('validateCrypto', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,9 +183,9 @@ export const getCrypto = () => {
 };
 
 export const getCryptoSubtle = () => {
-  const theCrypto = getCrypto();
+  const crypto = getCrypto();
   //safari 10.x uses webkitSubtle
-  return theCrypto.subtle || (<any>theCrypto).webkitSubtle;
+  return crypto.subtle || (<any>crypto).webkitSubtle;
 };
 
 export const validateCrypto = () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,8 +183,9 @@ export const getCrypto = () => {
 };
 
 export const getCryptoSubtle = () => {
+  const theCrypto = getCrypto();
   //safari 10.x uses webkitSubtle
-  return window.crypto.subtle || (<any>window.crypto).webkitSubtle;
+  return theCrypto.subtle || (<any>theCrypto).webkitSubtle;
 };
 
 export const validateCrypto = () => {


### PR DESCRIPTION
### Description

When abstracting the `crypto` and `subtle` calls, we introduced a bug that prevented IE11 to get the correct instance of `subtle` (which comes from `msCrypto` and not `crypto`. This PR fixes this by using our internal abstraction `getCrypto` which already takes that into consideration.

### References

Fix #241 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
