### PR TITLE
`parseQueryString` now removes hash fragment on query before parsing

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -45,6 +45,14 @@ describe('utils', () => {
         otherValue: 'another-test'
       });
     });
+    it('strips off hash values', () => {
+      expect(
+        parseQueryResult('code=some-code&state=some-state#__')
+      ).toMatchObject({
+        code: 'some-code',
+        state: 'some-state'
+      });
+    });
     it('converts `expires_in` to int', () => {
       expect(parseQueryResult('value=test&expires_in=10')).toMatchObject({
         value: 'test',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,12 @@ export const getUniqueScopes = (...scopes: string[]) => {
 };
 
 export const parseQueryResult = (queryString: string) => {
+  if (queryString.indexOf('#') > -1) {
+    queryString = queryString.substr(0, queryString.indexOf('#'));
+  }
+
   let queryParams = queryString.split('&');
+
   let parsedQuery: any = {};
   queryParams.forEach(qp => {
     let [key, val] = qp.split('=');


### PR DESCRIPTION
fix #245 