### PR TITLE
Fix for race condition when using `sha256` on IE11

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -187,6 +187,31 @@ describe('utils', () => {
 
       return sha;
     });
+    it('handles ie11 digest.result error scenario', () => {
+      (<any>global).msCrypto = {};
+
+      const digest = {
+        onerror: (e: any) => {}
+      };
+
+      (<any>global).crypto = {
+        subtle: {
+          digest: jest.fn((alg, encoded) => {
+            expect(alg).toMatchObject({ name: 'SHA-256' });
+            expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
+            return digest;
+          })
+        }
+      };
+
+      const sha = sha256('test').catch(e => {
+        expect(e).toBe('An error occurred');
+      });
+
+      digest.onerror({ error: 'An error occurred' });
+
+      return sha;
+    });
   });
   describe('bufferToBase64UrlEncoded ', () => {
     it('generates correct base64 encoded value from a buffer', async () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -162,18 +162,30 @@ describe('utils', () => {
       const result = await sha256('test');
       expect(result).toBe(true);
     });
-    it('handles ie11 digest.result scenario', async () => {
+    it('handles ie11 digest.result scenario', () => {
+      (<any>global).msCrypto = {};
+
+      const digest = {
+        oncomplete: (e: any) => {}
+      };
+
       (<any>global).crypto = {
         subtle: {
           digest: jest.fn((alg, encoded) => {
             expect(alg).toMatchObject({ name: 'SHA-256' });
             expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
-            return { result: true };
+            return digest;
           })
         }
       };
-      const result = await sha256('test');
-      expect(result).toBe(true);
+
+      const sha = sha256('test').then(r => {
+        expect(r).toBe(true);
+      });
+
+      digest.oncomplete({ target: { result: true } });
+
+      return sha;
     });
   });
   describe('bufferToBase64UrlEncoded ', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -166,7 +166,7 @@ describe('utils', () => {
       (<any>global).msCrypto = {};
 
       const digest = {
-        oncomplete: (e: any) => {}
+        oncomplete: null
       };
 
       (<any>global).crypto = {
@@ -191,7 +191,7 @@ describe('utils', () => {
       (<any>global).msCrypto = {};
 
       const digest = {
-        onerror: (e: any) => {}
+        onerror: null
       };
 
       (<any>global).crypto = {
@@ -209,6 +209,32 @@ describe('utils', () => {
       });
 
       digest.onerror({ error: 'An error occurred' });
+
+      return sha;
+    });
+
+    it('handles ie11 digest.result abort scenario', () => {
+      (<any>global).msCrypto = {};
+
+      const digest = {
+        onabort: null
+      };
+
+      (<any>global).crypto = {
+        subtle: {
+          digest: jest.fn((alg, encoded) => {
+            expect(alg).toMatchObject({ name: 'SHA-256' });
+            expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
+            return digest;
+          })
+        }
+      };
+
+      const sha = sha256('test').catch(e => {
+        expect(e).toBe('The digest operation was aborted');
+      });
+
+      digest.onabort({});
 
       return sha;
     });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -165,16 +165,14 @@ describe('utils', () => {
     it('handles ie11 digest.result scenario', () => {
       (<any>global).msCrypto = {};
 
-      const digest = {
+      const digestResult = {
         oncomplete: null
       };
 
       (<any>global).crypto = {
         subtle: {
-          digest: jest.fn((alg, encoded) => {
-            expect(alg).toMatchObject({ name: 'SHA-256' });
-            expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
-            return digest;
+          digest: jest.fn(() => {
+            return digestResult;
           })
         }
       };
@@ -183,23 +181,21 @@ describe('utils', () => {
         expect(r).toBe(true);
       });
 
-      digest.oncomplete({ target: { result: true } });
+      digestResult.oncomplete({ target: { result: true } });
 
       return sha;
     });
     it('handles ie11 digest.result error scenario', () => {
       (<any>global).msCrypto = {};
 
-      const digest = {
+      const digestResult = {
         onerror: null
       };
 
       (<any>global).crypto = {
         subtle: {
-          digest: jest.fn((alg, encoded) => {
-            expect(alg).toMatchObject({ name: 'SHA-256' });
-            expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
-            return digest;
+          digest: jest.fn(() => {
+            return digestResult;
           })
         }
       };
@@ -208,7 +204,7 @@ describe('utils', () => {
         expect(e).toBe('An error occurred');
       });
 
-      digest.onerror({ error: 'An error occurred' });
+      digestResult.onerror({ error: 'An error occurred' });
 
       return sha;
     });
@@ -216,16 +212,14 @@ describe('utils', () => {
     it('handles ie11 digest.result abort scenario', () => {
       (<any>global).msCrypto = {};
 
-      const digest = {
+      const digestResult = {
         onabort: null
       };
 
       (<any>global).crypto = {
         subtle: {
-          digest: jest.fn((alg, encoded) => {
-            expect(alg).toMatchObject({ name: 'SHA-256' });
-            expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
-            return digest;
+          digest: jest.fn(() => {
+            return digestResult;
           })
         }
       };
@@ -234,7 +228,7 @@ describe('utils', () => {
         expect(e).toBe('The digest operation was aborted');
       });
 
-      digest.onabort({});
+      digestResult.onabort();
 
       return sha;
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,9 +126,13 @@ export const sha256 = async (s: string) => {
   // Instead of returning a promise, it returns a CryptoOperation
   // with a result property in it
   if ((<any>window).msCrypto) {
-    return new Promise(res => {
-      digestOp.oncomplete = function(e) {
+    return new Promise((res, rej) => {
+      digestOp.oncomplete = e => {
         res(e.target.result);
+      };
+
+      digestOp.onerror = (e: ErrorEvent) => {
+        rej(e.error);
       };
     });
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,7 +167,6 @@ export const urlDecodeB64 = (input: string) =>
   decodeB64(input.replace(/_/g, '/').replace(/-/g, '+'));
 
 export const bufferToBase64UrlEncoded = input => {
-  console.log(input);
   const ie11SafeInput = new Uint8Array(input);
   return urlEncodeB64(
     window.btoa(String.fromCharCode(...Array.from(ie11SafeInput)))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,6 +134,10 @@ export const sha256 = async (s: string) => {
       digestOp.onerror = (e: ErrorEvent) => {
         rej(e.error);
       };
+
+      digestOp.onabort = () => {
+        rej('The digest operation was aborted');
+      };
     });
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,7 +124,10 @@ export const sha256 = async (s: string) => {
   // msCrypto (IE11) uses the old spec, which is not Promise based
   // https://msdn.microsoft.com/en-us/expression/dn904640(v=vs.71)
   // Instead of returning a promise, it returns a CryptoOperation
-  // with a result property in it
+  // with a result property in it.
+  // As a result, the various events need to be handled in the event that we're
+  // working in IE11 (hence the msCrypto check). These events just call resolve
+  // or reject depending on their intention.
   if ((<any>window).msCrypto) {
     return new Promise((res, rej) => {
       digestOp.oncomplete = e => {

--- a/static/index.html
+++ b/static/index.html
@@ -62,8 +62,8 @@
               Promise.all([
                 auth0.getTokenSilently({ ignoreCache: true }),
                 auth0.getTokenSilently({ ignoreCache: true })
-              ]).then(function([token1, token2]) {
-                console.log(token1, token2);
+              ]).then(function(tokens) {
+                console.log(tokens[0], tokens[1]);
               });
             });
             $('#getTokenPopup').click(function() {


### PR DESCRIPTION
### Description

This PR fixes an issue with resolving SHA256 operations in IE11.

msCrypto (IE11) uses the old spec, which [is not Promise based](https://msdn.microsoft.com/en-us/expression/dn904640(v=vs.71)). Instead of returning a promise, it returns a CryptoOperation
with a result property in it.

As a result, the various events need to be handled in the event that we're working in IE11 (hence the msCrypto check). These events just call resolve or reject depending on the handler.

The `sha256` function essentially now has two clear paths depending on IE11 vs. not-IE11 - either return the promise from the browser's crypto API, or return a new promise which is resolved or rejected based on the events raised by `msCrypto`.

### References

CryptoOperation reference: https://msdn.microsoft.com/en-us/expression/dn904640(v=vs.71)

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
