### PR TITLE
CODEOWNERS group name fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	dx-sdks-approver
+*	@auth0/dx-sdks-approver


### PR DESCRIPTION
### Description

This PR corrects the group name in the CODEOWNERS file (a previous PR wasn't picking up the correct group automatically when they were submitted.

### References

I got the correct group from here: https://github.com/auth0/auth0.js/blob/master/.github/CODEOWNERS

Assume they should be the same.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
