### PR TITLE
Clear transaction data on error

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -603,6 +603,19 @@ describe('Auth0', () => {
           'Invalid state'
         );
       });
+      it('clears the transaction data when an error occurs', async () => {
+        const { auth0, utils, transactionManager } = await localSetup();
+        const queryResult = { error: 'unauthorized', state: '897dfuksdfuo' };
+        utils.parseQueryResult.mockReturnValue(queryResult);
+
+        try {
+          await auth0.handleRedirectCallback();
+        } catch (e) {
+          expect(transactionManager.remove).toHaveBeenCalledWith(
+            queryResult.state
+          );
+        }
+      });
       it('uses `state` from parsed query to remove the transaction', async () => {
         const { auth0, utils, transactionManager } = await localSetup();
         const queryState = 'the-state';
@@ -753,6 +766,19 @@ describe('Auth0', () => {
         expect(errorThrown.error_description).toEqual(
           queryResult.error_description
         );
+      });
+      it('clears the transaction data when an error occurs', async () => {
+        const { auth0, utils, transactionManager } = await localSetup();
+        const queryResult = { error: 'unauthorized', state: '897dfuksdfuo' };
+        utils.parseQueryResult.mockReturnValue(queryResult);
+
+        try {
+          await auth0.handleRedirectCallback();
+        } catch (e) {
+          expect(transactionManager.remove).toHaveBeenCalledWith(
+            queryResult.state
+          );
+        }
       });
       it('throws error when there is no transaction', async () => {
         const { auth0, transactionManager } = await localSetup();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.2.4",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -246,6 +246,7 @@ export default class Auth0Client {
     );
 
     if (error) {
+      this.transactionManager.remove(state);
       throw new AuthenticationError(error, error_description, state);
     }
 


### PR DESCRIPTION
### Description

This PR fixes #217 by cleaning up the transaction data when an error occurs. As highlighted in #217, a build up of transaction cookies is occuring because this data is not cleared/reset when an error occurs. Customers have reported that in this scenario (when an error is raised) their apps simply retry the authentication step. Over a short period of time, this can cause problems with cookie data becoming too large and breaking applications. This PR helps with that by cleaning up data on error.

### References

#217 

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
