### PR TITLE
Updated types path in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "version": "1.4.0",
   "main": "dist/lib/auth0-spa-js.cjs.js",
-  "types": "dist/typings/index.d.ts",
+  "types": "dist/typings/src/index.d.ts",
   "browser": "dist/auth0-spa-js.production.js",
   "module": "dist/auth0-spa-js.production.esm.js",
   "scripts": {


### PR DESCRIPTION
### Description

It seems that updating the TypeScript version in the latest release of this library has caused the typings to be emitted in a sub folder relative to where they used to be. This PR updates the types path in `package.json` to match.

### References

Fixes #259 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
