### PR TITLE
Reverted typings fix, added a file move step before publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2457,6 +2457,17 @@
             "supports-color": "^5.3.0"
           }
         },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3617,17 +3628,6 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
-      }
-    },
-    "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "version": "1.4.1",
   "main": "dist/lib/auth0-spa-js.cjs.js",
-  "types": "dist/typings/src/index.d.ts",
+  "types": "dist/typings/index.d.ts",
   "browser": "dist/auth0-spa-js.production.js",
   "module": "dist/auth0-spa-js.production.esm.js",
   "scripts": {
@@ -28,7 +28,8 @@
     "prepack": "npm run build && npm run test:es-check && npm run test",
     "precommit": "pretty-quick --staged",
     "release": "node ./scripts/release",
-    "publish:cdn": "ccu --trace"
+    "publish:cdn": "ccu --trace",
+    "prepublish": "node ./scripts/prepublish"
   },
   "devDependencies": {
     "@auth0/component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "precommit": "pretty-quick --staged",
     "release": "node ./scripts/release",
     "publish:cdn": "ccu --trace",
-    "prepublish": "node ./scripts/prepublish"
+    "prepublishOnly": "node ./scripts/prepublish"
   },
   "devDependencies": {
     "@auth0/component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.2",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -2,15 +2,15 @@ const fs = require('fs');
 const { join } = require('path');
 const rimraf = require('rimraf');
 
-const files = fs.readdirSync('./dist/typings/src');
+const source = './dist/typings/src';
+const dest = './dist/typings';
+
+const files = fs.readdirSync(source);
 
 files.forEach(file => {
-  const src = join('./dist/typings/src', file);
+  const src = join(source, file);
 
-  fs.copyFileSync(
-    join('./dist/typings/src', file),
-    join('./dist/typings', file)
-  );
+  fs.copyFileSync(join(source, file), join(dest, file));
 });
 
-rimraf.sync('./dist/typings/src');
+rimraf.sync(source);

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const { join } = require('path');
+const rimraf = require('rimraf');
+
+const files = fs.readdirSync('./dist/typings/src');
+
+files.forEach(file => {
+  const src = join('./dist/typings/src', file);
+
+  fs.copyFileSync(
+    join('./dist/typings/src', file),
+    join('./dist/typings', file)
+  );
+});
+
+rimraf.sync('./dist/typings/src');

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -5,12 +5,20 @@ const rimraf = require('rimraf');
 const source = './dist/typings/src';
 const dest = './dist/typings';
 
+if (!fs.existsSync(source)) {
+  return;
+}
+
 const files = fs.readdirSync(source);
+let fileCount = 0;
 
 files.forEach(file => {
   const src = join(source, file);
 
   fs.copyFileSync(join(source, file), join(dest, file));
+  fileCount++;
 });
 
 rimraf.sync(source);
+
+console.log(`Moved ${fileCount} type definition files`);


### PR DESCRIPTION
### Description

The typings files have, until now, assumed to be in the `./dist/typings` folder, but a recent upgrade to TypeScript caused these files to be emitted to `./dist/typings/src`. The path in `package.json` was not updated until 1.4.1.

v1.4.1 fixed the path that typings are included in the packaged build, but could break TypeScript apps that directly import typings for particular classes. For example:

`import Auth0Client from "@auth0/auth0-spa-js/dist/typings/Auth0Client";`

This PR reverts that path, and adds a pre-publish step that copies the typings files to the right place to maintain backwards compatibility.

### References

#259 

### Testing

Tested by manually running `npm run build` then `npm run prepublishOnly` to test the file move. Confirmed that files once again appear in `./dist/typings`.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
