### PR TITLE
Get id token silently

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "prepack": "npm run build && npm run test:es-check && npm run test && node ./scripts/prepack",
     "precommit": "pretty-quick --staged",
     "release": "node ./scripts/release",
-    "publish:cdn": "ccu --trace"
+    "publish:cdn": "ccu --trace",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@auth0/component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.2",

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -305,7 +305,8 @@ export default class Auth0Client {
     options: GetTokenSilentlyOptions = {
       audience: this.options.audience,
       scope: this.options.scope || this.DEFAULT_SCOPE,
-      ignoreCache: false
+      ignoreCache: false,
+      tokenType: 'access_token'
     }
   ) {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
@@ -318,7 +319,7 @@ export default class Auth0Client {
       });
       if (cache) {
         lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
-        return cache.access_token;
+        return cache[options.tokenType];
       }
     }
     const stateIn = encodeState(createRandomString());
@@ -364,7 +365,7 @@ export default class Auth0Client {
     this.cache.save(cacheEntry);
     ClientStorage.save('auth0.is.authenticated', true, { daysUntilExpire: 1 });
     lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
-    return authResult.access_token;
+    return authResult[options.tokenType];
   }
 
   /**


### PR DESCRIPTION
- Enables silent fetching of `id_token` instead of `access_token`.
- Adds prepare script to package.json to enable installation as a dependency from git repository

**Context**
By default, when fetching the token silently (`Auth0Client.getTokenSilently`), the **access** token is returned. In some cases, it might be useful to retrieve the **id** token instead, which may contain some complementary information, which may in turned be forwarded to a third-party API.

**Use case**
- SPA authenticates the user
- Auth0 returns permissions attached to the `id_token`
- SPA attaches the `id_token` in the 'Authorization` header, and queries an API
- API uses the token to authenticate the user **AND** to validate it has the right permissions to access the requested route

**Benefits**
- No additional call is required from the API to Auth0
- Only one token decoding is required to perform both authentication and authorization of the user on a resource

**Breaking changes**
No breaking change - token type is passed as an option

