### PR TITLE
Updates browser-tabs-lock to fix issue of long acquired lock.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1582,9 +1582,9 @@
       }
     },
     "browser-tabs-lock": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.1.9.tgz",
-      "integrity": "sha512-HxXEI+QCNBixUUgdVcXIqbwpR+cl3H2y6JKRkldq5kO28qZiwzmdws+JRfc59mKPHS8biX7lzy8FrEZddetblw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/browser-tabs-lock/-/browser-tabs-lock-1.2.1.tgz",
+      "integrity": "sha512-3NFpbd8cBwXNvAxzmomvNze2nSi3y2Q3DtNxytAY7+olhm7V21qicKDY90A2LxuAUesQMQcSGm8uQgBy9P5lOA=="
     },
     "bs-logger": {
       "version": "0.2.6",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "wait-on": "^3.3.0"
   },
   "dependencies": {
-    "browser-tabs-lock": "^1.1.9",
+    "browser-tabs-lock": "^1.2.1",
     "core-js": "^3.2.1",
     "es-cookie": "^1.2.0",
     "fast-text-encoding": "^1.0.0",

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -320,7 +320,7 @@ export default class Auth0Client {
         });
 
         if (cache) {
-          lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
+          await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
           return cache.access_token;
         }
       }
@@ -383,7 +383,7 @@ export default class Auth0Client {
     } catch (e) {
       throw e;
     } finally {
-      lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
+      await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
     }
   }
 


### PR DESCRIPTION
### Description
- This updates browser-tabs-lock to version 1.2.1 which fixes a bug with locking. Resolves #278 

### References
- https://github.com/auth0/auth0-spa-js/issues/278
- This explains the issue with older versions of browser-tabs-lock: https://github.com/supertokens/browser-tabs-lock#migrating-from-11x-to-12x

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
