### PR TITLE
Add noRedirect flag, Add custom URL parameter

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -538,6 +538,29 @@ describe('Auth0', () => {
         `https://test.auth0.com/authorize?query=params${TEST_TELEMETRY_QUERY_STRING}#/reset`
       );
     });
+    it('returns the url', async () => {
+      const { auth0 } = await setup();
+
+      const url = await auth0.loginWithRedirect({
+        ...REDIRECT_OPTIONS
+      });
+
+      expect(url).toBe(
+        `https://test.auth0.com/authorize?query=params${TEST_TELEMETRY_QUERY_STRING}`
+      );
+    });
+    it('returns the url without changing window location', async () => {
+      const { auth0 } = await setup();
+
+      const url = await auth0.loginWithRedirect({
+        ...REDIRECT_OPTIONS,
+        noRedirect: true
+      });
+      expect(window.location.href).toBe('http://localhost/');
+      expect(url).toBe(
+        `https://test.auth0.com/authorize?query=params${TEST_TELEMETRY_QUERY_STRING}`
+      );
+    });
     it('can be called with no arguments', async () => {
       const { auth0 } = await setup();
 
@@ -748,6 +771,14 @@ describe('Auth0', () => {
       it('calls parseQueryResult correctly', async () => {
         const { auth0, utils } = await localSetup();
         await auth0.handleRedirectCallback();
+        expect(utils.parseQueryResult).toHaveBeenCalledWith(
+          `code=${TEST_CODE}&state=${TEST_ENCODED_STATE}`
+        );
+      });
+      it('calls parseQueryResult with a passed URL', async () => {
+        const { auth0, utils } = await localSetup();
+        const customUrl = `https://test.auth0.com?code=${TEST_CODE}&state=${TEST_ENCODED_STATE}`;
+        await auth0.handleRedirectCallback(customUrl);
         expect(utils.parseQueryResult).toHaveBeenCalledWith(
           `code=${TEST_CODE}&state=${TEST_ENCODED_STATE}`
         );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -211,7 +211,9 @@ export default class Auth0Client {
    *
    * @param options
    */
-  public async loginWithRedirect(options: RedirectLoginOptions = {}) {
+  public async loginWithRedirect(
+    options: RedirectLoginOptions = {}
+  ): Promise<string> {
     const { redirect_uri, appState, ...authorizeOptions } = options;
     const stateIn = encodeState(createRandomString());
     const nonceIn = createRandomString();
@@ -234,7 +236,8 @@ export default class Auth0Client {
       scope: params.scope,
       audience: params.audience || 'default'
     });
-    window.location.assign(url + fragment);
+    if (!options.noRedirect) window.location.assign(url + fragment);
+    return url;
   }
 
   /**
@@ -243,8 +246,10 @@ export default class Auth0Client {
    * responses from Auth0. If the response is successful, results
    * will be valid according to their expiration times.
    */
-  public async handleRedirectCallback(): Promise<RedirectLoginResult> {
-    const queryStringFragments = window.location.href.split('?').slice(1);
+  public async handleRedirectCallback(
+    url: string = window.location.href
+  ): Promise<RedirectLoginResult> {
+    const queryStringFragments = url.split('?').slice(1);
     if (queryStringFragments.length === 0) {
       throw new Error('There are no query params available for parsing.');
     }

--- a/src/global.ts
+++ b/src/global.ts
@@ -122,6 +122,10 @@ interface RedirectLoginOptions extends BaseLoginOptions {
    * Used to add to the URL fragment before redirecting
    */
   fragment?: string;
+  /**
+   * Used to cancel browser redirect behavior, in case only URL retrieval is needed
+   */
+  noRedirect?: boolean;
 }
 
 interface RedirectLoginResult {

--- a/src/global.ts
+++ b/src/global.ts
@@ -122,10 +122,6 @@ interface RedirectLoginOptions extends BaseLoginOptions {
    * Used to add to the URL fragment before redirecting
    */
   fragment?: string;
-  /**
-   * Used to cancel browser redirect behavior, in case only URL retrieval is needed
-   */
-  noRedirect?: boolean;
 }
 
 interface RedirectLoginResult {


### PR DESCRIPTION
### Description

Currently, the URL which is generated by loginWithRedirect is generated but never returned.  This is fine for all web app use cases, but more flexibility is required for hybrid frameworks such as ionic running on native platforms.  By returning the URL only in a no-op fashion with loginWithRedirect, and allowing custom URLs to be passed to handleRedirectCallback, ionic users can facilitate custom browser based flows while still using mostly the same code as the SPA react quickstart.

- add noRedirect flag for loginWithRedirect for URL return only
- add custom URL parameter to handleRedirectCallback

### Testing

To test, run `await loginWithRedirect({ noRedirect: true })`;
This should return a URL without running `window.location.assign`

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
