### PR TITLE
add import part to Getting started to make the document clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ yarn add @auth0/auth0-spa-js
 Create an `Auth0Client` instance before rendering or initializing your application. You should only have one instance of the client.
 
 ```js
+import createAuth0Client from '@auth0/auth0-spa-js';
+
 //with async/await
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',


### PR DESCRIPTION
### Description
Add ```import createAuth0Client from '@auth0/auth0-spa-js';``` to README to make documentation more friendly for npm users.

### References
Fixes #293 
