### PR TITLE
[SDK-1178] Local Storage caching mechanism

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest (current file)",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest (all tests)",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -164,6 +164,25 @@ document.getElementById('logout').addEventListener('click', () => {
 });
 ```
 
+### Caching strategy
+
+The SDK can be configured to cache data either in memory or in local storage. The default is in memory. This setting can be controlled using the `cacheStrategy` option when creating the Auth0 client.
+
+To use the in-memory mode, no additional options need to be passed as this is the default setting. To configure the SDK to cache data using local storage, set `cacheStrategy` as follows:
+
+```js
+await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  client_id: '<AUTH0_CLIENT_ID>',
+  redirect_uri: '<MY_CALLBACK_URL>',
+  cacheStrategy: 'localstorage' // valid values are: 'memory' or 'localstorage'
+}).then(auth0 => {
+  // ...
+});
+```
+
+**Important:** This feature will allow the caching of data **such as ID and access tokens** to be stored in local storage. Exercising this option changes the security characteristics of your application and **should not be used lightly**. Extra care should be taken to mitigate against XSS attacks and minimize the risk of tokens being stolen from local storage.
+
 ## Contributing
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ document.getElementById('logout').addEventListener('click', () => {
 
 ### Caching strategy
 
-The SDK can be configured to cache data either in memory or in local storage. The default is in memory. This setting can be controlled using the `cacheStrategy` option when creating the Auth0 client.
+The SDK can be configured to cache ID tokens and access tokens either in memory or in local storage. The default is in memory. This setting can be controlled using the `cacheStrategy` option when creating the Auth0 client.
 
 To use the in-memory mode, no additional options need are required as this is the default setting. To configure the SDK to cache data using local storage, set `cacheStrategy` as follows:
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ document.getElementById('logout').addEventListener('click', () => {
 
 The SDK can be configured to cache data either in memory or in local storage. The default is in memory. This setting can be controlled using the `cacheStrategy` option when creating the Auth0 client.
 
-To use the in-memory mode, no additional options need to be passed as this is the default setting. To configure the SDK to cache data using local storage, set `cacheStrategy` as follows:
+To use the in-memory mode, no additional options need are required as this is the default setting. To configure the SDK to cache data using local storage, set `cacheStrategy` as follows:
 
 ```js
 await createAuth0Client({

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -13,11 +13,14 @@ describe('InMemoryCache', () => {
   afterEach(jest.useRealTimers);
 
   it('returns undefined when there is no data', () => {
-    expect(cache.get({ audience: 'a', scope: 's' })).toBeUndefined();
+    expect(
+      cache.get({ client_id: 'test-client', audience: 'a', scope: 's' })
+    ).toBeUndefined();
   });
 
   it('builds key correctly', () => {
     cache.save({
+      client_id: 'test-client',
       audience: 'the_audience',
       scope: 'the_scope',
       id_token: 'idtoken',
@@ -28,13 +31,15 @@ describe('InMemoryCache', () => {
         user: { name: 'Test' }
       }
     });
+
     expect(Object.keys(cache.cache)[0]).toBe(
-      '@@auth0spajs@@::the_audience::the_scope'
+      '@@auth0spajs@@::test-client::the_audience::the_scope'
     );
   });
 
   it('expires after `expires_in` when `expires_in` < `user.exp`', () => {
     cache.save({
+      client_id: 'test-client',
       audience: 'the_audiene',
       scope: 'the_scope',
       id_token: 'idtoken',
@@ -51,11 +56,14 @@ describe('InMemoryCache', () => {
     });
     jest.advanceTimersByTime(799);
     expect(Object.keys(cache.cache).length).toBe(1);
+
     jest.advanceTimersByTime(1);
     expect(Object.keys(cache.cache).length).toBe(0);
   });
+
   it('expires after `user.exp` when `user.exp` < `expires_in`', () => {
     cache.save({
+      client_id: 'test-client',
       audience: 'the_audiene',
       scope: 'the_scope',
       id_token: 'idtoken',
@@ -96,6 +104,7 @@ describe('LocalStorageCache', () => {
     global.Date.now = dateStub;
 
     defaultEntry = {
+      client_id: '__TEST_CLIENT_ID__',
       audience: '__TEST_AUDIENCE__',
       scope: '__TEST_SCOPE__',
       id_token: '__ID_TOKEN__',
@@ -122,7 +131,7 @@ describe('LocalStorageCache', () => {
     cache.save(defaultEntry);
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
-      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: defaultEntry,
         expiresAt: nowSeconds() + 86400 - 60
@@ -143,7 +152,7 @@ describe('LocalStorageCache', () => {
     cache.save(entry);
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
-      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: entry,
         expiresAt: nowSeconds() + 40
@@ -153,7 +162,7 @@ describe('LocalStorageCache', () => {
 
   it('can retrieve an item from the cache', () => {
     localStorage.setItem(
-      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: defaultEntry,
         expiresAt: nowSeconds() + 86400
@@ -161,7 +170,11 @@ describe('LocalStorageCache', () => {
     );
 
     expect(
-      cache.get({ audience: '__TEST_AUDIENCE__', scope: '__TEST_SCOPE__' })
+      cache.get({
+        client_id: '__TEST_CLIENT_ID__',
+        audience: '__TEST_AUDIENCE__',
+        scope: '__TEST_SCOPE__'
+      })
     ).toStrictEqual(defaultEntry);
   });
 
@@ -171,9 +184,10 @@ describe('LocalStorageCache', () => {
 
   it('expires after cache `expiresAt` when expiresAt < current time', () => {
     localStorage.setItem(
-      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: {
+          client_id: '__TEST_CLIENT_ID__',
           audience: '__TEST_AUDIENCE__',
           scope: '__TEST_SCOPE__',
           id_token: '__ID_TOKEN__',
@@ -193,11 +207,15 @@ describe('LocalStorageCache', () => {
     );
 
     expect(
-      cache.get({ audience: '__TEST_AUDIENCE__', scope: '__TEST_SCOPE__' })
+      cache.get({
+        client_id: '__TEST_CLIENT_ID__',
+        audience: '__TEST_AUDIENCE__',
+        scope: '__TEST_SCOPE__'
+      })
     ).toBeUndefined();
 
     expect(localStorage.removeItem).toHaveBeenCalledWith(
-      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__'
+      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__'
     );
   });
 

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -18,7 +18,7 @@ describe('InMemoryCache', () => {
 
   it('builds key correctly', () => {
     cache.save({
-      audience: 'the_audiene',
+      audience: 'the_audience',
       scope: 'the_scope',
       id_token: 'idtoken',
       access_token: 'accesstoken',
@@ -28,22 +28,11 @@ describe('InMemoryCache', () => {
         user: { name: 'Test' }
       }
     });
-    expect(Object.keys(cache.cache)[0]).toBe('the_audiene::the_scope');
+    expect(Object.keys(cache.cache)[0]).toBe(
+      '@@auth0spajs@@::the_audience::the_scope'
+    );
   });
-  it('builds key correctly', () => {
-    cache.save({
-      audience: 'the_audience',
-      scope: 'the_scope',
-      id_token: 'idtoken',
-      access_token: 'accesstoken',
-      expires_in: 1,
-      decodedToken: {
-        claims: { __raw: 'idtoken', name: 'Test' },
-        user: { name: 'Test' }
-      }
-    });
-    expect(Object.keys(cache.cache)[0]).toBe('the_audience::the_scope');
-  });
+
   it('expires after `expires_in` when `expires_in` < `user.exp`', () => {
     cache.save({
       audience: 'the_audiene',
@@ -133,7 +122,7 @@ describe('LocalStorageCache', () => {
     cache.save(defaultEntry);
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
-      '@@auth0@@__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: defaultEntry,
         expiresAt: nowSeconds() + 86400 - 60
@@ -154,7 +143,7 @@ describe('LocalStorageCache', () => {
     cache.save(entry);
 
     expect(localStorage.setItem).toHaveBeenCalledWith(
-      '@@auth0@@__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: entry,
         expiresAt: nowSeconds() + 40
@@ -164,7 +153,7 @@ describe('LocalStorageCache', () => {
 
   it('can retrieve an item from the cache', () => {
     localStorage.setItem(
-      '@@auth0@@__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: defaultEntry,
         expiresAt: nowSeconds() + 86400
@@ -182,7 +171,7 @@ describe('LocalStorageCache', () => {
 
   it('expires after cache `expiresAt` when expiresAt < current time', () => {
     localStorage.setItem(
-      '@@auth0@@__TEST_AUDIENCE__::__TEST_SCOPE__',
+      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__',
       JSON.stringify({
         body: {
           audience: '__TEST_AUDIENCE__',
@@ -208,7 +197,7 @@ describe('LocalStorageCache', () => {
     ).toBeUndefined();
 
     expect(localStorage.removeItem).toHaveBeenCalledWith(
-      '@@auth0@@__TEST_AUDIENCE__::__TEST_SCOPE__'
+      '@@auth0spajs@@::__TEST_AUDIENCE__::__TEST_SCOPE__'
     );
   });
 
@@ -231,7 +220,12 @@ describe('LocalStorageCache', () => {
   });
 
   it('removes the correct items when the cache is cleared', () => {
-    const keys = ['some-key', '@@auth0@@key-1', 'some-key-2', '@@auth0@@key-2'];
+    const keys = [
+      'some-key',
+      '@@auth0spajs@@::key-1',
+      'some-key-2',
+      '@@auth0spajs@@::key-2'
+    ];
 
     for (const key of keys) {
       localStorage.setItem(key, "doesn't matter what the data is");
@@ -240,7 +234,11 @@ describe('LocalStorageCache', () => {
     cache.clear();
 
     expect(localStorage.removeItem).toHaveBeenCalledTimes(2);
-    expect(localStorage.removeItem).toHaveBeenCalledWith('@@auth0@@key-1');
-    expect(localStorage.removeItem).toHaveBeenCalledWith('@@auth0@@key-2');
+    expect(localStorage.removeItem).toHaveBeenCalledWith(
+      '@@auth0spajs@@::key-1'
+    );
+    expect(localStorage.removeItem).toHaveBeenCalledWith(
+      '@@auth0spajs@@::key-2'
+    );
   });
 });

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,15 +1,19 @@
-import Cache from '../src/cache';
+import { InMemoryCache, ICache } from '../src/cache';
 
-describe('cache', () => {
-  let cache: Cache;
+describe('InMemoryCache', () => {
+  let cache: InMemoryCache;
+
   beforeEach(() => {
-    cache = new Cache();
+    cache = new InMemoryCache();
     jest.useFakeTimers();
   });
+
   afterEach(jest.useRealTimers);
+
   it('returns undefined when there is no data', () => {
     expect(cache.get({ audience: 'a', scope: 's' })).toBeUndefined();
   });
+
   it('builds key correctly', () => {
     cache.save({
       audience: 'the_audiene',

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1411,6 +1411,7 @@ describe('Auth0', () => {
       auth0.logout();
       expect(storage.remove).toHaveBeenCalledWith('auth0.is.authenticated');
     });
+
     it('creates correct query params with empty options', async () => {
       const { auth0, utils } = await setup();
 
@@ -1419,12 +1420,14 @@ describe('Auth0', () => {
         client_id: TEST_CLIENT_ID
       });
     });
+
     it('creates correct query params with `options.client_id` is null', async () => {
       const { auth0, utils } = await setup();
 
       auth0.logout({ client_id: null });
       expect(utils.createQueryParams).toHaveBeenCalledWith({});
     });
+
     it('creates correct query params with `options.client_id` defined', async () => {
       const { auth0, utils } = await setup();
 
@@ -1433,6 +1436,7 @@ describe('Auth0', () => {
         client_id: 'another-client-id'
       });
     });
+
     it('creates correct query params with `options.returnTo` defined', async () => {
       const { auth0, utils } = await setup();
 
@@ -1441,12 +1445,14 @@ describe('Auth0', () => {
         returnTo: 'https://return.to'
       });
     });
+
     it('creates correct query params when `options.federated` is true', async () => {
       const { auth0, utils } = await setup();
 
       auth0.logout({ federated: true, client_id: null });
       expect(utils.createQueryParams).toHaveBeenCalledWith({});
     });
+
     it('calls `window.location.assign` with the correct url', async () => {
       const { auth0 } = await setup();
 
@@ -1455,6 +1461,7 @@ describe('Auth0', () => {
         `https://test.auth0.com/v2/logout?query=params${TEST_TELEMETRY_QUERY_STRING}`
       );
     });
+
     it('calls `window.location.assign` with the correct url when `options.federated` is true', async () => {
       const { auth0 } = await setup();
 
@@ -1462,6 +1469,14 @@ describe('Auth0', () => {
       expect(window.location.assign).toHaveBeenCalledWith(
         `https://test.auth0.com/v2/logout?query=params${TEST_TELEMETRY_QUERY_STRING}&federated`
       );
+    });
+
+    it('clears the cache', async () => {
+      const { auth0, cache } = await setup();
+
+      auth0.logout();
+
+      expect(cache.clear).toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -122,6 +122,7 @@ describe('Auth0', () => {
       }
     };
   });
+
   describe('createAuth0Client()', () => {
     it('should create an Auth0 client', async () => {
       const auth0 = await createAuth0Client({
@@ -130,11 +131,23 @@ describe('Auth0', () => {
       });
       expect(auth0).toBeInstanceOf(Auth0Client);
     });
+
     it('should call `utils.validateCrypto`', async () => {
       const { utils } = await setup();
       expect(utils.validateCrypto).toHaveBeenCalled();
     });
+
+    it('should fail if an invalid cache strategy was given', async () => {
+      await expect(
+        createAuth0Client({
+          domain: TEST_DOMAIN,
+          client_id: TEST_CLIENT_ID,
+          cacheStrategy: 'dummy'
+        } as any)
+      ).rejects.toThrow(new Error('Invalid cache strategy "dummy"'));
+    });
   });
+
   describe('loginWithPopup()', () => {
     it('opens popup', async () => {
       const { auth0, utils } = await setup();
@@ -401,6 +414,7 @@ describe('Auth0', () => {
       expect(utils.openPopup).toHaveBeenCalled();
     });
   });
+
   describe('buildAuthorizeUrl()', () => {
     const REDIRECT_OPTIONS = {
       redirect_uri: 'https://redirect.uri',
@@ -551,6 +565,7 @@ describe('Auth0', () => {
       );
     });
   });
+
   describe('loginWithRedirect()', () => {
     const REDIRECT_OPTIONS = {
       redirect_uri: 'https://redirect.uri',
@@ -586,6 +601,7 @@ describe('Auth0', () => {
       );
     });
   });
+
   describe('handleRedirectCallback()', () => {
     it('throws when there is no query string', async () => {
       const { auth0 } = await setup();
@@ -945,6 +961,7 @@ describe('Auth0', () => {
       });
     });
   });
+
   describe('getUser()', () => {
     it('returns undefined if there is no cache', async () => {
       const { auth0, cache } = await setup();
@@ -993,6 +1010,7 @@ describe('Auth0', () => {
       );
     });
   });
+
   describe('getIdTokenClaims()', () => {
     it('returns undefined if there is no cache', async () => {
       const { auth0, cache } = await setup();
@@ -1044,6 +1062,7 @@ describe('Auth0', () => {
       );
     });
   });
+
   describe('isAuthenticated()', () => {
     it('returns true if there is an user', async () => {
       const { auth0 } = await setup();
@@ -1062,6 +1081,7 @@ describe('Auth0', () => {
       expect(result).toBe(false);
     });
   });
+
   describe('getTokenSilently()', () => {
     describe('when `options.ignoreCache` is false', async () => {
       it('calls `cache.get` with the correct options', async () => {
@@ -1319,6 +1339,7 @@ describe('Auth0', () => {
       });
     });
   });
+
   describe('getTokenWithPopup()', async () => {
     const localSetup = async () => {
       const result = await setup();
@@ -1383,6 +1404,7 @@ describe('Auth0', () => {
       expect(token).toBe(TEST_ACCESS_TOKEN);
     });
   });
+
   describe('logout()', () => {
     it('removes `auth0.is.authenticated` key from storage', async () => {
       const { auth0, storage } = await setup();
@@ -1443,18 +1465,23 @@ describe('Auth0', () => {
     });
   });
 });
+
 describe('default creation function', () => {
   it('does nothing if there is nothing storage', async () => {
     Auth0Client.prototype.getTokenSilently = jest.fn();
+
     const auth0 = await createAuth0Client({
       domain: TEST_DOMAIN,
       client_id: TEST_CLIENT_ID
     });
+
     expect(require('../src/storage').get).toHaveBeenCalledWith(
       'auth0.is.authenticated'
     );
+
     expect(auth0.getTokenSilently).not.toHaveBeenCalled();
   });
+
   it('calls getTokenSilently if there is a storage item with key `auth0.is.authenticated`', async () => {
     Auth0Client.prototype.getTokenSilently = jest.fn();
     require('../src/storage').get = () => true;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -387,6 +387,7 @@ describe('Auth0', () => {
 
       await auth0.loginWithPopup({});
       expect(cache.save).toHaveBeenCalledWith({
+        client_id: TEST_CLIENT_ID,
         access_token: TEST_ACCESS_TOKEN,
         audience: 'default',
         id_token: TEST_ID_TOKEN,
@@ -609,6 +610,7 @@ describe('Auth0', () => {
         'There are no query params available for parsing.'
       );
     });
+
     describe('when there is a valid query string in the url', async () => {
       const localSetup = async () => {
         window.history.pushState(
@@ -749,6 +751,7 @@ describe('Auth0', () => {
         await auth0.handleRedirectCallback();
 
         expect(cache.save).toHaveBeenCalledWith({
+          client_id: TEST_CLIENT_ID,
           access_token: TEST_ACCESS_TOKEN,
           audience: 'default',
           id_token: TEST_ID_TOKEN,
@@ -929,6 +932,7 @@ describe('Auth0', () => {
         await auth0.handleRedirectCallback();
 
         expect(cache.save).toHaveBeenCalledWith({
+          client_id: TEST_CLIENT_ID,
           access_token: TEST_ACCESS_TOKEN,
           audience: 'default',
           id_token: TEST_ID_TOKEN,
@@ -987,23 +991,31 @@ describe('Auth0', () => {
     });
     it('uses default options', async () => {
       const { auth0, utils, cache } = await setup();
+
       await auth0.getUser();
+
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'default',
-        scope: TEST_SCOPES
+        scope: TEST_SCOPES,
+        client_id: TEST_CLIENT_ID
       });
+
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
         'openid profile email',
         'openid profile email'
       );
     });
+
     it('uses custom options when provided', async () => {
       const { auth0, utils, cache } = await setup();
       await auth0.getUser({ audience: 'the-audience', scope: 'the-scope' });
+
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'the-audience',
-        scope: TEST_SCOPES
+        scope: TEST_SCOPES,
+        client_id: TEST_CLIENT_ID
       });
+
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
         'openid profile email',
         'the-scope'
@@ -1036,26 +1048,35 @@ describe('Auth0', () => {
     });
     it('uses default options', async () => {
       const { auth0, utils, cache } = await setup();
+
       await auth0.getIdTokenClaims();
+
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'default',
-        scope: TEST_SCOPES
+        scope: TEST_SCOPES,
+        client_id: TEST_CLIENT_ID
       });
+
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
         'openid profile email',
         'openid profile email'
       );
     });
+
     it('uses custom options when provided', async () => {
       const { auth0, utils, cache } = await setup();
+
       await auth0.getIdTokenClaims({
         audience: 'the-audience',
         scope: 'the-scope'
       });
+
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'the-audience',
-        scope: TEST_SCOPES
+        scope: TEST_SCOPES,
+        client_id: TEST_CLIENT_ID
       });
+
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
         'openid profile email',
         'the-scope'
@@ -1092,13 +1113,16 @@ describe('Auth0', () => {
 
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'default',
-          scope: TEST_SCOPES
+          scope: TEST_SCOPES,
+          client_id: TEST_CLIENT_ID
         });
+
         expect(utils.getUniqueScopes).toHaveBeenCalledWith(
           'openid profile email',
           'openid profile email'
         );
       });
+
       it('returns cached access_token when there is a cache', async () => {
         const { auth0, cache } = await setup();
         cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
@@ -1128,6 +1152,7 @@ describe('Auth0', () => {
         expect(utils.encodeState).toHaveBeenCalledWith(TEST_RANDOM_STRING);
       });
     });
+
     describe('when `options.ignoreCache` is true', () => {
       const defaultOptionsIgnoreCacheTrue: GetTokenSilentlyOptions = {
         audience: 'test:audience',
@@ -1158,6 +1183,7 @@ describe('Auth0', () => {
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
         expect(utils.encodeState).toHaveBeenCalledWith(TEST_RANDOM_STRING);
       });
+
       it('creates `code_challenge` by using `utils.sha256` with the result of `utils.createRandomString`', async () => {
         const { auth0, utils } = await setup();
 
@@ -1167,6 +1193,7 @@ describe('Auth0', () => {
           TEST_ARRAY_BUFFER
         );
       });
+
       it('creates correct query params', async () => {
         const { auth0, utils } = await setup();
 
@@ -1185,6 +1212,7 @@ describe('Auth0', () => {
           code_challenge_method: 'S256'
         });
       });
+
       it('creates correct query params without leeway', async () => {
         const { auth0, utils } = await setup({ leeway: 10 });
 
@@ -1203,6 +1231,7 @@ describe('Auth0', () => {
           code_challenge_method: 'S256'
         });
       });
+
       it('creates correct query params when providing a default redirect_uri', async () => {
         const redirect_uri = 'https://custom-redirect-uri/callback';
         const { auth0, utils } = await setup({
@@ -1224,6 +1253,7 @@ describe('Auth0', () => {
           code_challenge_method: 'S256'
         });
       });
+
       it('creates correct query params with custom params', async () => {
         const { auth0, utils } = await setup();
 
@@ -1247,6 +1277,7 @@ describe('Auth0', () => {
           defaultOptionsIgnoreCacheTrue.scope
         );
       });
+
       it('opens iframe with correct urls', async () => {
         const { auth0, utils } = await setup();
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
@@ -1304,6 +1335,7 @@ describe('Auth0', () => {
 
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
         expect(cache.save).toHaveBeenCalledWith({
+          client_id: TEST_CLIENT_ID,
           access_token: TEST_ACCESS_TOKEN,
           audience: defaultOptionsIgnoreCacheTrue.audience,
           id_token: TEST_ID_TOKEN,
@@ -1364,6 +1396,7 @@ describe('Auth0', () => {
         'openid profile email'
       );
     });
+
     it('calls `loginWithPopup` with the correct custom options', async () => {
       const { auth0, utils } = await localSetup();
       const loginOptions = {
@@ -1383,20 +1416,25 @@ describe('Auth0', () => {
         'other-scope'
       );
     });
+
     it('calls `cache.get` with the correct options', async () => {
       const { auth0, cache, utils } = await localSetup();
 
       await auth0.getTokenWithPopup();
+
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'default',
-        scope: TEST_SCOPES
+        scope: TEST_SCOPES,
+        client_id: TEST_CLIENT_ID
       });
+
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
         'openid profile email',
         undefined,
         'openid profile email'
       );
     });
+
     it('returns cached access_token', async () => {
       const { auth0 } = await localSetup();
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -137,14 +137,14 @@ describe('Auth0', () => {
       expect(utils.validateCrypto).toHaveBeenCalled();
     });
 
-    it('should fail if an invalid cache strategy was given', async () => {
+    it('should fail if an invalid cache location was given', async () => {
       await expect(
         createAuth0Client({
           domain: TEST_DOMAIN,
           client_id: TEST_CLIENT_ID,
-          cacheStrategy: 'dummy'
+          cacheLocation: 'dummy'
         } as any)
-      ).rejects.toThrow(new Error('Invalid cache strategy "dummy"'));
+      ).rejects.toThrow(new Error('Invalid cache location "dummy"'));
     });
   });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -45,39 +45,52 @@ const setup = async (options = {}) => {
     client_id: TEST_CLIENT_ID,
     ...options
   });
-  const getInstance = m => require(m).default.mock.instances[0];
+
+  // Return the specific instance you want from the module by supplying fn
+  // e.g. getInstance('../module', m => m.SomeInstance)
+  const getInstance = (m, fn) => fn(require(m)).mock.instances[0];
+
+  const getDefaultInstance = m => require(m).default.mock.instances[0];
+
   const storage = {
     get: require('../src/storage').get,
     save: require('../src/storage').save,
     remove: require('../src/storage').remove
   };
+
   const lock = require('browser-tabs-lock');
-  const cache = getInstance('../src/cache');
+  const cache = getInstance('../src/cache', m => m.InMemoryCache);
   const tokenVerifier = require('../src/jwt').verify;
-  const transactionManager = getInstance('../src/transaction-manager');
+  const transactionManager = getDefaultInstance('../src/transaction-manager');
   const utils = require('../src/utils');
+
   utils.createQueryParams.mockReturnValue(TEST_QUERY_PARAMS);
   utils.getUniqueScopes.mockReturnValue(TEST_SCOPES);
   utils.encodeState.mockReturnValue(TEST_ENCODED_STATE);
   utils.createRandomString.mockReturnValue(TEST_RANDOM_STRING);
   utils.sha256.mockReturnValue(Promise.resolve(TEST_ARRAY_BUFFER));
   utils.bufferToBase64UrlEncoded.mockReturnValue(TEST_BASE64_ENCODED_STRING);
+
   utils.parseQueryResult.mockReturnValue({
     state: TEST_ENCODED_STATE,
     code: TEST_CODE
   });
+
   utils.runPopup.mockReturnValue(
     Promise.resolve({ state: TEST_ENCODED_STATE, code: TEST_CODE })
   );
+
   utils.runIframe.mockReturnValue(
     Promise.resolve({ state: TEST_ENCODED_STATE, code: TEST_CODE })
   );
+
   utils.oauthToken.mockReturnValue(
     Promise.resolve({
       id_token: TEST_ID_TOKEN,
       access_token: TEST_ACCESS_TOKEN
     })
   );
+
   tokenVerifier.mockReturnValue({
     user: {
       sub: TEST_USER_ID
@@ -87,6 +100,7 @@ const setup = async (options = {}) => {
       aud: TEST_CLIENT_ID
     }
   });
+
   return {
     auth0,
     storage,

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -28,7 +28,7 @@ describe('getTokenSilently', function() {
         );
         return win.auth0.getTokenSilently().then(() => {
           const parsedUrl = new URL(iframe.src);
-          shouldBe(parsedUrl.host, 'auth.brucke.club');
+          shouldBe(parsedUrl.host, 'brucke.auth0.com');
           const pageParams = decode(parsedUrl.search.substr(1));
           shouldBeUndefined(pageParams.code_verifier);
           shouldNotBeUndefined(pageParams.code_challenge);

--- a/cypress/integration/loginWithRedirect.js
+++ b/cypress/integration/loginWithRedirect.js
@@ -18,7 +18,7 @@ describe('loginWithRedirect', function() {
     cy.wait(2000);
     cy.url().then(url => {
       const parsedUrl = new URL(url);
-      shouldBe(parsedUrl.host, 'auth.brucke.club');
+      shouldBe(parsedUrl.host, 'brucke.auth0.com');
       const pageParams = decode(parsedUrl.search.substr(1));
       shouldBeUndefined(pageParams.code_verifier);
       shouldNotBeUndefined(pageParams.code_challenge);

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
     './jest.config.js'
   ],
   coverageReporters: ['lcov', 'text', 'text-summary'],
-  preset: 'ts-jest'
+  preset: 'ts-jest',
+  setupFiles: ['jest-localstorage-mock']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4332,9 +4332,9 @@
       }
     },
     "handlebars": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
-      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -9898,20 +9898,20 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
-      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5638,6 +5638,12 @@
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
       }
+    },
+    "jest-localstorage-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz",
+      "integrity": "sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==",
+      "dev": true
     },
     "jest-matcher-utils": {
       "version": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "husky": "^3.0.0",
     "idtoken-verifier": "^1.4.1",
     "jest": "^24.9.0",
+    "jest-localstorage-mock": "^2.4.0",
     "jsonwebtoken": "^8.5.1",
     "pem": "^1.14.2",
     "prettier": "^1.18.2",

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -485,7 +485,9 @@ export default class Auth0Client {
     } else {
       delete options.client_id;
     }
+
     ClientStorage.remove('auth0.is.authenticated');
+    this.cache.clear();
     const { federated, ...logoutOptions } = options;
     const federatedQuery = federated ? `&federated` : '';
     const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -14,7 +14,7 @@ import {
   openPopup
 } from './utils';
 
-import Cache from './cache';
+import { InMemoryCache, ICache } from './cache';
 import TransactionManager from './transaction-manager';
 import { verify as verifyIdToken } from './jwt';
 import { AuthenticationError } from './errors';
@@ -29,20 +29,22 @@ const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
  * Auth0 SDK for Single Page Applications using [Authorization Code Grant Flow with PKCE](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce).
  */
 export default class Auth0Client {
-  private cache: Cache;
+  private cache: ICache;
   private transactionManager: TransactionManager;
   private domainUrl: string;
   private tokenIssuer: string;
   private readonly DEFAULT_SCOPE = 'openid profile email';
 
   constructor(private options: Auth0ClientOptions) {
-    this.cache = new Cache();
+    this.cache = new InMemoryCache();
     this.transactionManager = new TransactionManager();
     this.domainUrl = `https://${this.options.domain}`;
+
     this.tokenIssuer = this.options.issuer
       ? `https://${this.options.issuer}/`
       : `${this.domainUrl}/`;
   }
+
   private _url(path) {
     const telemetry = encodeURIComponent(
       btoa(
@@ -54,6 +56,7 @@ export default class Auth0Client {
     );
     return `${this.domainUrl}${path}&auth0Client=${telemetry}`;
   }
+
   private _getParams(
     authorizeOptions: BaseLoginOptions,
     state: string,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -213,7 +213,8 @@ export default class Auth0Client {
       ...authResult,
       decodedToken,
       scope: params.scope,
-      audience: params.audience || 'default'
+      audience: params.audience || 'default',
+      client_id: this.options.client_id
     };
     this.cache.save(cacheEntry);
     ClientStorage.save('auth0.is.authenticated', true, { daysUntilExpire: 1 });
@@ -236,7 +237,12 @@ export default class Auth0Client {
     }
   ) {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
-    const cache = this.cache.get(options);
+
+    const cache = this.cache.get({
+      client_id: this.options.client_id,
+      ...options
+    });
+
     return cache && cache.decodedToken.user;
   }
 
@@ -256,7 +262,12 @@ export default class Auth0Client {
     }
   ) {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
-    const cache = this.cache.get(options);
+
+    const cache = this.cache.get({
+      client_id: this.options.client_id,
+      ...options
+    });
+
     return cache && cache.decodedToken.claims;
   }
 
@@ -316,14 +327,19 @@ export default class Auth0Client {
       authResult.id_token,
       transaction.nonce
     );
+
     const cacheEntry = {
       ...authResult,
       decodedToken,
       audience: transaction.audience,
-      scope: transaction.scope
+      scope: transaction.scope,
+      client_id: this.options.client_id
     };
+
     this.cache.save(cacheEntry);
+
     ClientStorage.save('auth0.is.authenticated', true, { daysUntilExpire: 1 });
+
     return {
       appState: transaction.appState
     };
@@ -357,7 +373,8 @@ export default class Auth0Client {
       if (!options.ignoreCache) {
         const cache = this.cache.get({
           scope: options.scope,
-          audience: options.audience || 'default'
+          audience: options.audience || 'default',
+          client_id: this.options.client_id
         });
 
         if (cache) {
@@ -411,7 +428,8 @@ export default class Auth0Client {
         ...authResult,
         decodedToken,
         scope: params.scope,
-        audience: params.audience || 'default'
+        audience: params.audience || 'default',
+        client_id: this.options.client_id
       };
 
       this.cache.save(cacheEntry);
@@ -451,11 +469,15 @@ export default class Auth0Client {
       this.options.scope,
       options.scope
     );
+
     await this.loginWithPopup(options, config);
+
     const cache = this.cache.get({
       scope: options.scope,
-      audience: options.audience || 'default'
+      audience: options.audience || 'default',
+      client_id: this.options.client_id
     });
+
     return cache.access_token;
   }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -45,7 +45,7 @@ export default class Auth0Client {
   constructor(private options: Auth0ClientOptions) {
     this.cacheStrategy = options.cacheStrategy || 'memory';
 
-    if (!cacheStrategies[this.cacheStrategy]) {
+    if (!(this.cacheStrategy in cacheStrategies)) {
       throw new Error(`Invalid cache strategy "${this.cacheStrategy}"`);
     }
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,15 +8,22 @@ interface DecodedToken {
   user: any;
 }
 
-interface CacheEntry extends CacheKeyData {
+interface CacheEntry {
   id_token: string;
   access_token: string;
   expires_in: number;
   decodedToken: DecodedToken;
+  audience: string;
+  scope: string;
 }
 
 interface CachedTokens {
   [key: string]: CacheEntry;
+}
+
+export interface ICache {
+  save(entry: CacheEntry): void;
+  get(key: CacheKeyData): CacheEntry;
 }
 
 const createKey = (e: CacheKeyData) => `${e.audience}::${e.scope}`;
@@ -27,19 +34,23 @@ const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
   return Math.min(expiresIn, expTime) * 1000 * 0.8;
 };
 
-export default class Cache {
+export class InMemoryCache implements ICache {
   cache: CachedTokens = {};
+
   public save(entry: CacheEntry) {
     const key = createKey(entry);
     this.cache[key] = entry;
+
     const timeout = getExpirationTimeoutInMilliseconds(
       entry.expires_in,
       entry.decodedToken.claims.exp
     );
+
     setTimeout(() => {
       delete this.cache[key];
     }, timeout);
   }
+
   public get(key: CacheKeyData) {
     return this.cache[createKey(key)];
   }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -34,6 +34,16 @@ const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
   return Math.min(expiresIn, expTime) * 1000 * 0.8;
 };
 
+export class LocalStorageCache implements ICache {
+  public save(entry: CacheEntry): void {
+    throw 'Not implemented';
+  }
+
+  public get(key: CacheKeyData): CacheEntry {
+    throw 'Not implemented';
+  }
+}
+
 export class InMemoryCache implements ICache {
   cache: CachedTokens = {};
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,6 +1,7 @@
 interface CacheKeyData {
   audience: string;
   scope: string;
+  client_id: string;
 }
 
 interface DecodedToken {
@@ -15,6 +16,7 @@ interface CacheEntry {
   decodedToken: DecodedToken;
   audience: string;
   scope: string;
+  client_id: string;
 }
 
 interface CachedTokens {
@@ -29,7 +31,7 @@ export interface ICache {
 
 const keyPrefix = '@@auth0spajs@@';
 const createKey = (e: CacheKeyData) =>
-  `${keyPrefix}::${e.audience}::${e.scope}`;
+  `${keyPrefix}::${e.client_id}::${e.audience}::${e.scope}`;
 
 const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
   const expTime =

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -27,7 +27,9 @@ export interface ICache {
   clear(): void;
 }
 
-const createKey = (e: CacheKeyData) => `${e.audience}::${e.scope}`;
+const keyPrefix = '@@auth0spajs@@';
+const createKey = (e: CacheKeyData) =>
+  `${keyPrefix}::${e.audience}::${e.scope}`;
 
 const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
   const expTime =
@@ -37,7 +39,7 @@ const getExpirationTimeoutInMilliseconds = (expiresIn: number, exp: number) => {
 
 export class LocalStorageCache implements ICache {
   public save(entry: CacheEntry): void {
-    const cacheKey = `@@auth0@@${createKey(entry)}`;
+    const cacheKey = createKey(entry);
     const expiresInTime = Math.floor(Date.now() / 1000) + entry.expires_in;
 
     const expirySeconds =
@@ -61,7 +63,7 @@ export class LocalStorageCache implements ICache {
   }
 
   public get(key: CacheKeyData): CacheEntry {
-    const cacheKey = `@@auth0@@${createKey(key)}`;
+    const cacheKey = createKey(key);
     const json = window.localStorage.getItem(cacheKey);
     let payload;
 
@@ -83,7 +85,7 @@ export class LocalStorageCache implements ICache {
 
   public clear() {
     for (var i = localStorage.length - 1; i >= 0; i--) {
-      if (localStorage.key(i).startsWith('@@auth0@@')) {
+      if (localStorage.key(i).startsWith(keyPrefix)) {
         localStorage.removeItem(localStorage.key(i));
       }
     }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -82,16 +82,10 @@ export class LocalStorageCache implements ICache {
   }
 
   public clear() {
-    const keysToDelete = [];
-
-    for (var i = 0; i < localStorage.length; i++) {
+    for (var i = localStorage.length - 1; i >= 0; i--) {
       if (localStorage.key(i).startsWith('@@auth0@@')) {
-        keysToDelete.push(localStorage.key(i));
+        localStorage.removeItem(localStorage.key(i));
       }
-    }
-
-    for (var key of keysToDelete) {
-      localStorage.removeItem(key);
     }
   }
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -95,7 +95,7 @@ interface Auth0ClientOptions extends BaseLoginOptions {
    * The strategy to use when storing cache data. Valid values are `memory` or `localstorage`.
    * The default setting is `memory`.
    */
-  cacheStrategy?: 'memory' | 'localstorage';
+  cacheLocation?: 'memory' | 'localstorage';
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -90,6 +90,12 @@ interface Auth0ClientOptions extends BaseLoginOptions {
    * Defaults to 60s.
    */
   leeway?: number;
+
+  /**
+   * The strategy to use when storing cache data. Valid values are `memory` or `localstorage`.
+   * The default setting is `memory`.
+   */
+  cacheStrategy?: 'memory' | 'localstorage';
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
   if (!ClientStorage.get('auth0.is.authenticated')) {
     return auth0;
   }
+
   try {
     await auth0.getTokenSilently({
       audience: options.audience,
@@ -29,5 +30,6 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
   } catch (error) {
     // ignore
   }
+
   return auth0;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,10 @@
 
   <body>
     <div id="app" class="container">
+      <div style="visibility: hidden">
+        <span id="loaded">loaded</span>
+      </div>
+
       <h1 class="mb-5">Auth0 SPA JS Playground</h1>
 
       <div v-if="!loading">
@@ -21,7 +25,11 @@
             Login popup
           </button>
 
-          <button class="btn btn-primary" @click="loginRedirect">
+          <button
+            class="btn btn-primary"
+            @click="loginRedirect"
+            id="login_redirect"
+          >
             Login redirect
           </button>
 
@@ -49,7 +57,7 @@
         </div>
 
         <div class="btn-group mb-3">
-          <button class="btn btn-outline-primary" @click="logout">
+          <button class="btn btn-outline-primary" @click="logout" id="logout">
             logout (default)
           </button>
 
@@ -140,7 +148,7 @@
           return {
             auth0: null,
             loading: true,
-            useLocalStorage: true,
+            useLocalStorage: false,
             profile: null,
             access_tokens: [],
             id_token: '',
@@ -169,7 +177,6 @@
         methods: {
           initializeClient() {
             var _self = this;
-            // _self.loading = true;
 
             createAuth0Client({
               domain: _self.domain,
@@ -177,6 +184,7 @@
               cacheStrategy: _self.useLocalStorage ? 'localstorage' : 'memory'
             }).then(function(auth0) {
               _self.auth0 = auth0;
+              window.auth0 = auth0; // Cypress integration tests support
               _self.loading = false;
 
               auth0.isAuthenticated().then(function(isAuthenticated) {

--- a/static/index.html
+++ b/static/index.html
@@ -181,7 +181,7 @@
             createAuth0Client({
               domain: _self.domain,
               client_id: _self.clientId,
-              cacheStrategy: _self.useLocalStorage ? 'localstorage' : 'memory'
+              cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory'
             }).then(function(auth0) {
               _self.auth0 = auth0;
               window.auth0 = auth0; // Cypress integration tests support

--- a/static/index.html
+++ b/static/index.html
@@ -3,118 +3,216 @@
   <head>
     <title>Auth0</title>
     <meta charset="utf-8" />
-    <script src="/auth0-spa-js.development.js"></script>
-    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+      integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
+      crossorigin="anonymous"
+    />
   </head>
 
   <body>
-    <div style="visibility: hidden">
-      <span id="loaded">loaded</span>
+    <div id="app" class="container">
+      <h1 class="mb-5">Auth0 SPA JS Playground</h1>
+
+      <div v-if="!loading">
+        <div class="btn-group mb-3">
+          <button class="btn btn-primary" @click="loginPopup">
+            Login popup
+          </button>
+
+          <button class="btn btn-primary" @click="loginRedirect">
+            Login redirect
+          </button>
+
+          <button class="btn btn-success" @click="loginHandleRedirectCallback">
+            Login redirect callback
+          </button>
+        </div>
+
+        <div class="btn-group mb-3">
+          <button class="btn btn-secondary" @click="getToken">
+            Get access token with no interaction
+          </button>
+
+          <button class="btn btn-secondary" @click="getTokenPopup">
+            Get access token with a popup
+          </button>
+
+          <button class="btn btn-secondary" @click="getTokenAudience">
+            Get access token for a different audience
+          </button>
+        </div>
+
+        <div class="btn-group mb-3">
+          <button class="btn btn-outline-primary" @click="logout">
+            logout (default)
+          </button>
+
+          <button class="btn btn-outline-primary" @click="logoutNoClient">
+            logout (no client id)
+          </button>
+        </div>
+
+        <div class="card mb-3" v-if="profile">
+          <div class="card-header">Profile</div>
+          <div class="card-body">
+            {{ JSON.stringify(profile, null, 2) }}
+          </div>
+        </div>
+
+        <div class="card mb-3" v-if="access_tokens.length > 0">
+          <div class="card-header">Access Tokens</div>
+          <div class="card-body">
+            <ul v-for="token in access_tokens">
+              <li>{{token}}</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="card mb-3" v-if="id_token">
+          <div class="card-header">
+            ID Token
+          </div>
+          <div class="card-body">{{ id_token }}</div>
+        </div>
+      </div>
     </div>
-    <button id="login_popup">Login popup</button>
-    <button id="login_redirect">Login redirect</button>
-    <button id="login_redirect_callback">Login redirect callback</button>
-    <button id="getUser">Get user</button>
-    <button id="getToken">Get access token with no interaction</button>
-    <button id="getTokenPopup">Get access token with a popup</button>
-    <button id="getToken_audience">
-      Get access token for a different audience
-    </button>
-    <button id="logout">logout (default)</button>
-    <button id="logout-no-clientid">logout (no client id)</button>
+
+    <script src="/auth0-spa-js.development.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
     <script type="text/javascript">
-      $(function() {
-        createAuth0Client({
-          domain: 'auth.brucke.club',
-          client_id: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp'
-        })
-          .then(function(auth0) {
-            window.auth0 = auth0;
-            $('#login_popup').click(function() {
-              auth0
-                .loginWithPopup({
-                  redirect_uri: 'http://localhost:3000/callback.html'
-                })
-                .then(function() {
-                  auth0.getTokenSilently().then(function(token) {
-                    console.log(token);
-                  });
-                  auth0.getUser().then(function(user) {
-                    console.log(user);
-                  });
-                });
-            });
-            $('#login_redirect').click(function() {
-              auth0.loginWithRedirect({
-                redirect_uri: 'http://localhost:3000/'
+      var domain = 'brucke.auth0.com';
+      var clientId = 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp';
+
+      var app = new Vue({
+        el: '#app',
+        data() {
+          return {
+            auth0: null,
+            loading: true,
+            cacheStragegy: 'memory',
+            profile: null,
+            access_tokens: [],
+            id_token: '',
+            isAuthenticated: false
+          };
+        },
+        created() {
+          this.initializeClient();
+        },
+        methods: {
+          initializeClient() {
+            var _self = this;
+            _self.loading = true;
+
+            createAuth0Client({
+              domain: domain,
+              client_id: clientId,
+              cacheStragegy: _self.cacheStragegy
+            }).then(function(auth0) {
+              _self.auth0 = auth0;
+              _self.loading = false;
+
+              auth0.isAuthenticated().then(function(isAuthenticated) {
+                _self.isAuthenticated = isAuthenticated;
               });
             });
-            $('#login_redirect_callback').click(function() {
-              auth0.handleRedirectCallback().then(function() {
-                window.history.replaceState(
-                  {},
-                  document.title,
-                  window.location.origin + '/'
-                );
-              });
+          },
+          showAuth0Info() {
+            var _self = this;
+            _self.access_tokens = [];
+
+            _self.auth0.getTokenSilently().then(function(token) {
+              _self.access_tokens.push(token);
             });
-            $('#getToken').click(function() {
-              Promise.all([
-                auth0.getTokenSilently({ ignoreCache: true }),
-                auth0.getTokenSilently({ ignoreCache: true })
-              ]).then(function(tokens) {
-                console.log(tokens[0], tokens[1]);
-              });
+
+            _self.auth0.getUser().then(function(user) {
+              _self.profile = user;
             });
-            $('#getTokenPopup').click(function() {
-              auth0
-                .getTokenWithPopup({
-                  audience: 'https://brucke.auth0.com/api/v2/',
-                  scope: 'read:rules'
-                })
-                .then(function(token) {
-                  console.log(token);
-                });
+
+            _self.auth0.getIdTokenClaims().then(function(claims) {
+              _self.id_token = claims.__raw;
             });
-            $('#getUser').click(function() {
-              auth0.getUser().then(function(user) {
-                alert(JSON.stringify(user, null, 1));
-              });
-            });
-            $('#getIdTokenClaims').click(function() {
-              auth0.getIdTokenClaims().then(function(claims) {
-                console.log(claims);
-                //if you need the raw id_token, you can access it in the __raw property
-                const id_token = claims.__raw;
-              });
-            });
-            $('#getToken_audience').click(function() {
-              var differentAudienceOptions = {
-                audience: 'https://brucke.auth0.com/api/v2/',
-                scope: 'read:rules',
+          },
+          loginPopup() {
+            var _self = this;
+
+            _self.auth0
+              .loginWithPopup({
                 redirect_uri: 'http://localhost:3000/callback.html'
-              };
-              auth0
-                .getTokenSilently(differentAudienceOptions)
-                .then(function(token) {
-                  alert(token);
-                });
-            });
-            $('#logout').click(function() {
-              auth0.logout({
-                returnTo: 'http://localhost:3000/'
+              })
+              .then(function() {
+                _self.showAuth0Info();
               });
+          },
+          loginRedirect() {
+            this.auth0.loginWithRedirect({
+              redirect_uri: 'http://localhost:3000/'
             });
-            $('#logout-no-clientid').click(function() {
-              auth0.logout({
-                client_id: null,
-                returnTo: 'http://localhost:3000/'
+          },
+          loginHandleRedirectCallback() {
+            var _self = this;
+
+            _self.auth0.handleRedirectCallback().then(function() {
+              window.history.replaceState(
+                {},
+                document.title,
+                window.location.origin + '/'
+              );
+
+              _self.showAuth0Info();
+            });
+          },
+          getToken() {
+            var _self = this;
+
+            Promise.all([
+              _self.auth0.getTokenSilently({ ignoreCache: true }),
+              _self.auth0.getTokenSilently({ ignoreCache: true })
+            ]).then(function(tokens) {
+              _self.access_tokens = [tokens[0], tokens[1]];
+            });
+          },
+          getTokenPopup() {
+            var _self = this;
+
+            _self.auth0
+              .getTokenWithPopup({
+                audience: 'https://brucke.auth0.com/api/v2/',
+                scope: 'read:rules'
+              })
+              .then(function(token) {
+                _self.access_tokens = [token];
               });
+          },
+          getTokenAudience() {
+            var _self = this;
+
+            var differentAudienceOptions = {
+              audience: 'https://brucke.auth0.com/api/v2/',
+              scope: 'read:rules',
+              redirect_uri: 'http://localhost:3000/callback.html'
+            };
+
+            _self.auth0
+              .getTokenSilently(differentAudienceOptions)
+              .then(function(token) {
+                _self.access_tokens = [token];
+              });
+          },
+          logout() {
+            this.auth0.logout({
+              returnTo: 'http://localhost:3000/'
             });
-          })
-          .catch(function(err) {
-            console.error(err);
-          });
+          },
+          logoutNoClient() {
+            this.auth0.logout({
+              client_id: null,
+              returnTo: 'http://localhost:3000/'
+            });
+          }
+        }
       });
     </script>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -32,7 +32,11 @@
 
         <div class="btn-group mb-3">
           <button class="btn btn-secondary" @click="getToken">
-            Get access token with no interaction
+            Get access token
+          </button>
+
+          <button class="btn btn-secondary" @click="getMultipleTokens">
+            Get multiple tokens (ignoring cache)
           </button>
 
           <button class="btn btn-secondary" @click="getTokenPopup">
@@ -54,10 +58,16 @@
           </button>
         </div>
 
+        <hr />
+
         <div class="card mb-3" v-if="profile">
           <div class="card-header">Profile</div>
           <div class="card-body">
-            {{ JSON.stringify(profile, null, 2) }}
+            <pre>
+              <code>
+                {{ JSON.stringify(profile, null, 2).trim() }}
+              </code>
+            </pre>
           </div>
         </div>
 
@@ -77,13 +87,52 @@
           <div class="card-body">{{ id_token }}</div>
         </div>
       </div>
+
+      <form action="/" @submit.prevent="saveForm">
+        <div class="form-group">
+          <label for="domain">Domain</label>
+          <input
+            type="text"
+            class="form-control"
+            id="domain"
+            v-model="domain"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="client_id">Client ID</label>
+          <input
+            type="text"
+            class="form-control"
+            id="client_id"
+            v-model="clientId"
+          />
+        </div>
+
+        <div class="custom-control custom-switch mb-5">
+          <input
+            type="checkbox"
+            class="custom-control-input"
+            id="storage-switch"
+            v-model="useLocalStorage"
+          />
+          <label for="storage-switch" class="custom-control-label"
+            >Use local storage</label
+          >
+        </div>
+
+        <button type="submit" class="btn btn-primary">Save</button>
+        <button @click="resetForm" class="btn btn-outline-primary">
+          Reset
+        </button>
+      </form>
     </div>
 
     <script src="/auth0-spa-js.development.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
     <script type="text/javascript">
-      var domain = 'brucke.auth0.com';
-      var clientId = 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp';
+      var defaultDomain = 'brucke.auth0.com';
+      var defaultClientId = 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp';
 
       var app = new Vue({
         el: '#app',
@@ -91,25 +140,41 @@
           return {
             auth0: null,
             loading: true,
-            cacheStragegy: 'memory',
+            useLocalStorage: true,
             profile: null,
             access_tokens: [],
             id_token: '',
-            isAuthenticated: false
+            isAuthenticated: false,
+            domain: defaultDomain,
+            clientId: defaultClientId
           };
         },
         created() {
           this.initializeClient();
+
+          var savedData = localStorage.getItem('spa-playground-data');
+
+          if (savedData) {
+            var data = JSON.parse(savedData);
+            this.domain = data.domain;
+            this.clientId = data.clientId;
+            this.useLocalStorage = data.useLocalStorage || false;
+          }
+        },
+        watch: {
+          useLocalStorage() {
+            this.initializeClient();
+          }
         },
         methods: {
           initializeClient() {
             var _self = this;
-            _self.loading = true;
+            // _self.loading = true;
 
             createAuth0Client({
-              domain: domain,
-              client_id: clientId,
-              cacheStragegy: _self.cacheStragegy
+              domain: _self.domain,
+              client_id: _self.clientId,
+              cacheStrategy: _self.useLocalStorage ? 'localstorage' : 'memory'
             }).then(function(auth0) {
               _self.auth0 = auth0;
               _self.loading = false;
@@ -118,6 +183,21 @@
                 _self.isAuthenticated = isAuthenticated;
               });
             });
+          },
+          saveForm() {
+            localStorage.setItem(
+              'spa-playground-data',
+              JSON.stringify({
+                domain: this.domain,
+                clientId: this.clientId,
+                useLocalStorage: this.useLocalStorage
+              })
+            );
+          },
+          resetForm() {
+            this.domain = defaultDomain;
+            this.clientId = defaultClientId;
+            this.saveForm();
           },
           showAuth0Info() {
             var _self = this;
@@ -165,6 +245,13 @@
             });
           },
           getToken() {
+            var _self = this;
+
+            _self.auth0.getTokenSilently().then(function(token) {
+              _self.access_tokens.push(token);
+            });
+          },
+          getMultipleTokens() {
             var _self = this;
 
             Promise.all([


### PR DESCRIPTION
This PR adds functionality to allow the developer to store cache data in memory (as it currently does) or local storage.

It adds a new option `cacheStrategy` to `createAuth0Client`, which can either be set to `memory` (the default), or `localstorage`.

**Note:** This feature will allow the storage of data **such as ID and access tokens** to be stored in local storage. Exercising this option changes the security characteristics of your application and **should not be used lightly**.

In addition, the cache is now cleared on logout, which although is a change from previous behaviour, it would never have been apparent when using the in-memory cache.

In addition, the playground page (accessed by running `npm start`) has been updated and given a lick of paint. It now uses a Vue component to manage user interaction and 

### Testing

Additional unit tests were added to cover the new cache strategy.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
