### PR TITLE
fix: rename type to PascalCase

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -230,7 +230,7 @@ export default class Auth0Client {
    * @param options
    */
   public async getIdTokenClaims(
-    options: getIdTokenClaimsOptions = {
+    options: GetIdTokenClaimsOptions = {
       audience: this.options.audience || 'default',
       scope: this.options.scope || this.DEFAULT_SCOPE
     }

--- a/src/global.ts
+++ b/src/global.ts
@@ -152,7 +152,7 @@ interface GetUserOptions {
   audience: string;
 }
 
-interface getIdTokenClaimsOptions {
+interface GetIdTokenClaimsOptions {
   /**
    * The scope that was used in the authentication request
    */


### PR DESCRIPTION
BREAKING CHANGE: renames getIdTokenClaimsOptions to GetIdTokenClaimsOptions

GetIdTokenClaimsOptions type was typed in camelCase. All other types are
in PascalCase. Types naming should be consistent.
