### PR TITLE
[SDK-1179] Support for rotating refresh tokens

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1338,6 +1338,26 @@ describe('Auth0', () => {
             }
           });
         });
+
+        it('fails with an error when no refresh token is available in the cache', async () => {
+          const { auth0, cache, utils } = await setup({
+            useRefreshTokens: true
+          });
+
+          utils.getUniqueScopes.mockReturnValue(
+            `${TEST_SCOPES} offline_access`
+          );
+
+          cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
+
+          await auth0.getTokenSilently({ ignoreCache: true }).catch(e => {
+            expect(e.error).toBe('missing_refresh_token');
+            expect(e.error_description).toBe(
+              'No refresh token is available to fetch a new access token. The user should be reauthenticated.'
+            );
+            expect(utils.oauthToken).not.toHaveBeenCalled();
+          });
+        });
       });
     });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -183,7 +183,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'web_message',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: 'http://localhost',
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -202,7 +202,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'web_message',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: 'http://localhost',
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -222,7 +222,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'web_message',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256'
@@ -239,7 +239,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'web_message',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: 'http://localhost',
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256'
@@ -310,7 +310,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup({});
       expect(tokenVerifier).toHaveBeenCalledWith({
         id_token: TEST_ID_TOKEN,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
@@ -326,7 +326,7 @@ describe('Auth0', () => {
       expect(tokenVerifier).toHaveBeenCalledWith({
         aud: 'test-client-id',
         id_token: TEST_ID_TOKEN,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         iss: 'https://test-123.auth0.com/',
         leeway: undefined,
         max_age: undefined
@@ -338,7 +338,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup({});
       expect(tokenVerifier).toHaveBeenCalledWith({
         id_token: TEST_ID_TOKEN,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: 10,
@@ -351,7 +351,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup({});
       expect(tokenVerifier).toHaveBeenCalledWith({
         id_token: TEST_ID_TOKEN,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
@@ -364,7 +364,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup({});
       expect(tokenVerifier).toHaveBeenCalledWith({
         id_token: TEST_ID_TOKEN,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
@@ -377,7 +377,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup({});
       expect(tokenVerifier).toHaveBeenCalledWith({
         id_token: TEST_ID_TOKEN,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
@@ -459,7 +459,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -491,7 +491,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -509,7 +509,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -532,7 +532,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -554,7 +554,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -574,7 +574,7 @@ describe('Auth0', () => {
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
-        nonce: TEST_RANDOM_STRING,
+        nonce: TEST_ENCODED_STATE,
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
@@ -592,7 +592,7 @@ describe('Auth0', () => {
           appState: TEST_APP_STATE,
           audience: 'default',
           code_verifier: TEST_RANDOM_STRING,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           scope: TEST_SCOPES
         }
       );
@@ -678,7 +678,7 @@ describe('Auth0', () => {
         const result = await setup();
         result.transactionManager.get.mockReturnValue({
           code_verifier: TEST_RANDOM_STRING,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           audience: 'default',
           scope: TEST_SCOPES,
           appState: TEST_APP_STATE
@@ -795,7 +795,7 @@ describe('Auth0', () => {
 
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           aud: 'test-client-id',
           iss: 'https://test.auth0.com/',
           leeway: undefined,
@@ -851,7 +851,7 @@ describe('Auth0', () => {
         const result = await setup();
         result.transactionManager.get.mockReturnValue({
           code_verifier: TEST_RANDOM_STRING,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           audience: 'default',
           scope: TEST_SCOPES,
           appState: TEST_APP_STATE
@@ -976,7 +976,7 @@ describe('Auth0', () => {
 
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           aud: 'test-client-id',
           iss: 'https://test.auth0.com/',
           leeway: undefined,
@@ -1426,7 +1426,7 @@ describe('Auth0', () => {
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
           code_challenge_method: 'S256'
@@ -1445,7 +1445,7 @@ describe('Auth0', () => {
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
           code_challenge_method: 'S256'
@@ -1467,7 +1467,7 @@ describe('Auth0', () => {
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           redirect_uri,
           code_challenge: TEST_BASE64_ENCODED_STRING,
           code_challenge_method: 'S256'
@@ -1487,7 +1487,7 @@ describe('Auth0', () => {
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
           code_challenge_method: 'S256'
@@ -1547,7 +1547,7 @@ describe('Auth0', () => {
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
-          nonce: TEST_RANDOM_STRING,
+          nonce: TEST_ENCODED_STATE,
           aud: 'test-client-id',
           iss: 'https://test.auth0.com/',
           leeway: undefined,

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -283,8 +283,8 @@ describe('Auth0', () => {
       const { auth0, utils } = await setup();
 
       await auth0.loginWithPopup({});
+
       expect(utils.oauthToken).toHaveBeenCalledWith({
-        audience: undefined,
         baseUrl: 'https://test.auth0.com',
         client_id: TEST_CLIENT_ID,
         code: TEST_CODE,
@@ -297,7 +297,6 @@ describe('Auth0', () => {
 
       await auth0.loginWithPopup({ audience: 'test-audience' });
       expect(utils.oauthToken).toHaveBeenCalledWith({
-        audience: 'test-audience',
         baseUrl: 'https://test.auth0.com',
         client_id: TEST_CLIENT_ID,
         code: TEST_CODE,
@@ -777,7 +776,6 @@ describe('Auth0', () => {
         await auth0.handleRedirectCallback();
 
         expect(utils.oauthToken).toHaveBeenCalledWith({
-          audience: undefined,
           baseUrl: 'https://test.auth0.com',
           client_id: TEST_CLIENT_ID,
           code: TEST_CODE,
@@ -959,7 +957,6 @@ describe('Auth0', () => {
         await auth0.handleRedirectCallback();
 
         expect(utils.oauthToken).toHaveBeenCalledWith({
-          audience: undefined,
           baseUrl: 'https://test.auth0.com',
           client_id: TEST_CLIENT_ID,
           code: TEST_CODE,
@@ -1520,8 +1517,8 @@ describe('Auth0', () => {
         const { auth0, utils } = await setup();
 
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
+
         expect(utils.oauthToken).toHaveBeenCalledWith({
-          audience: defaultOptionsIgnoreCacheTrue.audience,
           baseUrl: 'https://test.auth0.com',
           client_id: TEST_CLIENT_ID,
           code: TEST_CODE,
@@ -1529,6 +1526,7 @@ describe('Auth0', () => {
           grant_type: 'authorization_code'
         });
       });
+
       it('calls `tokenVerifier.verify` with the `id_token` from in the oauth/token response', async () => {
         const { auth0, tokenVerifier } = await setup();
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -67,7 +67,7 @@ const setup = async (options = {}) => {
 
   utils.createQueryParams.mockReturnValue(TEST_QUERY_PARAMS);
   utils.getUniqueScopes.mockReturnValue(TEST_SCOPES);
-  utils.encodeState.mockReturnValue(TEST_ENCODED_STATE);
+  utils.encode.mockReturnValue(TEST_ENCODED_STATE);
   utils.createRandomString.mockReturnValue(TEST_RANDOM_STRING);
   utils.sha256.mockReturnValue(Promise.resolve(TEST_ARRAY_BUFFER));
   utils.bufferToBase64UrlEncoded.mockReturnValue(TEST_BASE64_ENCODED_STRING);
@@ -160,7 +160,7 @@ describe('Auth0', () => {
       const { auth0, utils } = await setup();
 
       await auth0.loginWithPopup({});
-      expect(utils.encodeState).toHaveBeenCalledWith(TEST_RANDOM_STRING);
+      expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
     });
     it('creates `code_challenge` by using `utils.sha256` with the result of `utils.createRandomString`', async () => {
       const { auth0, utils } = await setup();
@@ -429,7 +429,7 @@ describe('Auth0', () => {
       const { auth0, utils } = await setup();
 
       await auth0.buildAuthorizeUrl(REDIRECT_OPTIONS);
-      expect(utils.encodeState).toHaveBeenCalledWith(TEST_RANDOM_STRING);
+      expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
     });
 
     it('creates `code_challenge` by using `utils.sha256` with the result of `utils.createRandomString`', async () => {
@@ -1268,7 +1268,7 @@ describe('Auth0', () => {
           await auth0.getTokenSilently();
 
           //we only evaluate that the code didn't bail out because of the cache
-          expect(utils.encodeState).toHaveBeenCalledWith(TEST_RANDOM_STRING);
+          expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
         });
       });
 
@@ -1400,7 +1400,7 @@ describe('Auth0', () => {
         const { auth0, utils } = await setup();
 
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
-        expect(utils.encodeState).toHaveBeenCalledWith(TEST_RANDOM_STRING);
+        expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
       });
 
       it('creates `code_challenge` by using `utils.sha256` with the result of `utils.createRandomString`', async () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -468,9 +468,14 @@ describe('Auth0', () => {
     });
 
     it('creates correct query params when using refresh tokens', async () => {
-      const { auth0, utils } = await setup({
+      const utils = require('../src/utils');
+      utils.getUniqueScopes.mockReturnValue('offline_access');
+
+      const { auth0 } = await setup({
         useRefreshTokens: true
       });
+
+      // utils.getUniqueScopes.mockReturnValue(`${TEST_SCOPES} offline_access`);
 
       await auth0.buildAuthorizeUrl(REDIRECT_OPTIONS);
 
@@ -482,7 +487,7 @@ describe('Auth0', () => {
 
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
-        scope: `${TEST_SCOPES}`,
+        scope: TEST_SCOPES,
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
@@ -1102,7 +1107,10 @@ describe('Auth0', () => {
 
     describe('when using refresh tokens', () => {
       it('uses default options with offine_access', async () => {
-        const { auth0, utils, cache } = await setup({
+        const utils = require('../src/utils');
+        utils.getUniqueScopes.mockReturnValue('offline_access');
+
+        const { auth0, cache } = await setup({
           useRefreshTokens: true
         });
 
@@ -1122,7 +1130,10 @@ describe('Auth0', () => {
       });
 
       it('uses custom options when provided with offline_access', async () => {
-        const { auth0, utils, cache } = await setup({
+        const utils = require('../src/utils');
+        utils.getUniqueScopes.mockReturnValue('offline_access');
+
+        const { auth0, cache } = await setup({
           useRefreshTokens: true
         });
 
@@ -1263,7 +1274,10 @@ describe('Auth0', () => {
 
       describe('when refresh tokens are used', () => {
         it('calls `cache.get` with the correct options', async () => {
-          const { auth0, cache, utils } = await setup({
+          const utils = require('../src/utils');
+          utils.getUniqueScopes.mockReturnValue('offline_access');
+
+          const { auth0, cache } = await setup({
             useRefreshTokens: true
           });
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -270,14 +270,16 @@ describe('utils', () => {
         )
       );
       await oauthToken({
+        grant_type: 'authorization_code',
         baseUrl: 'https://test.com',
         client_id: 'client_idIn',
         code: 'codeIn',
         code_verifier: 'code_verifierIn'
       });
+
       expect(mockUnfetch).toHaveBeenCalledWith('https://test.com/oauth/token', {
         body:
-          '{"grant_type":"authorization_code","redirect_uri":"http://localhost","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
+          '{"redirect_uri":"http://localhost","grant_type":"authorization_code","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
         headers: { 'Content-type': 'application/json' },
         method: 'POST'
       });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -5,8 +5,8 @@ import {
   createQueryParams,
   bufferToBase64UrlEncoded,
   createRandomString,
-  encodeState,
-  decodeState,
+  encode,
+  decode,
   sha256,
   openPopup,
   runPopup,
@@ -138,14 +138,14 @@ describe('utils', () => {
       expect(result.length).toBeLessThanOrEqual(128);
     });
   });
-  describe('encodeState', () => {
+  describe('encode', () => {
     it('encodes state', () => {
-      expect(encodeState('test')).toBe('dGVzdA==');
+      expect(encode('test')).toBe('dGVzdA==');
     });
   });
-  describe('decodeState', () => {
+  describe('decode', () => {
     it('decodes state', () => {
-      expect(decodeState('dGVzdA==')).toBe('test');
+      expect(decode('dGVzdA==')).toBe('test');
     });
   });
   describe('sha256', () => {

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -92,7 +92,7 @@ describe('getTokenSilently', function() {
 
               cy.get('[data-cy=error]').should(
                 'contain',
-                'missing_refresh_token'
+                'No refresh token is available to fetch a new access token'
               );
             });
           });

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -10,7 +10,7 @@ import {
 describe('getTokenSilently', function() {
   beforeEach(cy.resetTests);
 
-  it('return error when not logged in', function(done) {
+  it('returns an error when not logged in', function(done) {
     whenReady().then(win =>
       win.auth0.getTokenSilently().catch(error => {
         shouldBe('login_required', error.error);
@@ -19,73 +19,17 @@ describe('getTokenSilently', function() {
     );
   });
 
-  it.skip('Builds URL correctly', function(done) {
-    cy.login().then(() => {
-      whenReady().then(win => {
-        var iframe = win.document.createElement('iframe');
-        cy.stub(win.document, 'createElement', type =>
-          type === 'iframe' ? iframe : window.document.createElement
-        );
-        return win.auth0.getTokenSilently().then(() => {
-          const parsedUrl = new URL(iframe.src);
-          shouldBe(parsedUrl.host, 'brucke.auth0.com');
-          const pageParams = decode(parsedUrl.search.substr(1));
-          shouldBeUndefined(pageParams.code_verifier);
-          shouldNotBeUndefined(pageParams.code_challenge);
-          shouldNotBeUndefined(pageParams.code_challenge_method);
-          shouldNotBeUndefined(pageParams.state);
-          shouldNotBeUndefined(pageParams.nonce);
-          shouldBe(pageParams.redirect_uri, win.location.origin);
-          shouldBe(pageParams.response_mode, 'web_message');
-          shouldBe(pageParams.response_type, 'code');
-          shouldBe(pageParams.scope, 'openid profile email');
-          shouldBe(pageParams.client_id, 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp');
-          done();
-        });
-      });
+  describe('when using an iframe', () => {
+    beforeEach(() => {
+      return whenReady().then(() => cy.login());
     });
-  });
 
-  it('return cached token after login', function(done) {
-    cy.login().then(() => {
-      whenReady().then(win =>
-        win.auth0.getTokenSilently().then(token => {
-          shouldNotBeUndefined(token);
-          win.auth0.getTokenSilently().then(token2 => {
-            shouldNotBeUndefined(token2);
-            shouldBe(token, token2);
-            done();
-          });
-        })
-      );
-    });
-  });
+    afterEach(cy.logout);
 
-  it('ignores cache if `ignoreCache:true`', function(done) {
-    cy.login().then(() => {
-      whenReady().then(win =>
-        win.auth0.getTokenSilently().then(token => {
-          shouldNotBeUndefined(token);
-          win.auth0.getTokenSilently({ ignoreCache: true }).then(token2 => {
-            shouldNotBeUndefined(token2);
-            shouldNotBe(token, token2);
-            done();
-          });
-        })
-      );
-    });
-  });
-
-  it('returns consent_required when using an audience without consent', function(done) {
-    cy.login().then(() => {
-      whenReady().then(win =>
-        win.auth0
-          .getTokenSilently({ audience: 'https://brucke.auth0.com/api/v2/' })
-          .catch(error => {
-            shouldBe('consent_required', error.error);
-            done();
-          })
-      );
+    it('gets a new access token', () => {
+      cy.get('#getToken').click();
+      cy.get('[data-cy=access-token]').should('have.length', 2); // 1 from handleRedirectCallback, 1 from clicking "Get access token"
+      cy.get('[data-cy=error]').should('not.exist');
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -12,18 +12,31 @@ import { whenReady } from './utils';
 //
 //
 // -- This is a parent command --
+
 Cypress.Commands.add('login', () => {
   cy.get('#login_redirect').click();
 
   cy.get('.auth0-lock-input-username .auth0-lock-input')
     .clear()
     .type('johnfoo+integration@gmail.com');
+
   cy.get('.auth0-lock-input-password .auth0-lock-input')
     .clear()
     .type('1234');
   cy.get('.auth0-lock-submit').click();
-  return whenReady().then(win => win.auth0.handleRedirectCallback());
+
+  return whenReady().then(() => {
+    cy.get('#handle_redirect_callback').click();
+    return cy.wait(250);
+  });
 });
+
+Cypress.Commands.add('handleRedirectCallback', () => {
+  cy.get('#handle_redirect_callback').click();
+  return cy.wait(250);
+});
+
+Cypress.Commands.add('logout', () => cy.get('[data-cy=logout]').click());
 
 Cypress.Commands.add('loginNoCallback', () => {
   cy.get('#login_redirect').click();
@@ -39,5 +52,6 @@ Cypress.Commands.add('loginNoCallback', () => {
 
 Cypress.Commands.add('resetTests', () => {
   cy.visit('http://localhost:3000');
+  cy.get('#reset-config').click();
   cy.get('#logout').click();
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -38,6 +38,10 @@ Cypress.Commands.add('handleRedirectCallback', () => {
 
 Cypress.Commands.add('logout', () => cy.get('[data-cy=logout]').click());
 
+Cypress.Commands.add('toggleSwitch', name =>
+  cy.get(`[data-cy=switch-${name}]`).click()
+);
+
 Cypress.Commands.add('loginNoCallback', () => {
   cy.get('#login_redirect').click();
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -17,7 +17,7 @@ import {
 import { InMemoryCache, ICache, LocalStorageCache } from './cache';
 import TransactionManager from './transaction-manager';
 import { verify as verifyIdToken } from './jwt';
-import { AuthenticationError } from './errors';
+import { AuthenticationError, GenericError } from './errors';
 import * as ClientStorage from './storage';
 import { DEFAULT_POPUP_CONFIG_OPTIONS } from './constants';
 import version from './version';
@@ -571,6 +571,13 @@ export default class Auth0Client {
       client_id: this.options.client_id
     });
 
+    if (!cache || !cache.refresh_token) {
+      throw new GenericError(
+        'missing_refresh_token',
+        'No refresh token is available to fetch a new access token. The user should be reauthenticated.'
+      );
+    }
+
     const tokenResult = await oauthToken({
       baseUrl: this.domainUrl,
       client_id: this.options.client_id,
@@ -578,11 +585,7 @@ export default class Auth0Client {
       refresh_token: cache.refresh_token
     } as RefreshTokenOptions);
 
-    console.log(tokenResult);
-
     const decodedToken = this._verifyIdToken(tokenResult.id_token);
-
-    console.log(decodedToken);
 
     return {
       ...tokenResult,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -148,7 +148,7 @@ export default class Auth0Client {
     } = options;
 
     const stateIn = encodeState(createRandomString());
-    const nonceIn = createRandomString();
+    const nonceIn = encodeState(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);
@@ -198,7 +198,7 @@ export default class Auth0Client {
     const popup = await openPopup();
     const { ...authorizeOptions } = options;
     const stateIn = encodeState(createRandomString());
-    const nonceIn = createRandomString();
+    const nonceIn = encodeState(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);
@@ -511,7 +511,7 @@ export default class Auth0Client {
     options: GetTokenSilentlyOptions
   ): Promise<any> {
     const stateIn = encodeState(createRandomString());
-    const nonceIn = createRandomString();
+    const nonceIn = encodeState(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -224,7 +224,6 @@ export default class Auth0Client {
 
     const authResult = await oauthToken({
       baseUrl: this.domainUrl,
-      audience: options.audience || this.options.audience,
       client_id: this.options.client_id,
       code_verifier,
       code: codeResult.code,
@@ -347,7 +346,6 @@ export default class Auth0Client {
 
     const authResult = await oauthToken({
       baseUrl: this.domainUrl,
-      audience: this.options.audience,
       client_id: this.options.client_id,
       code_verifier: transaction.code_verifier,
       code,
@@ -545,7 +543,6 @@ export default class Auth0Client {
 
     const tokenResult = await oauthToken({
       baseUrl: this.domainUrl,
-      audience: options.audience || this.options.audience,
       client_id: this.options.client_id,
       code_verifier,
       code: codeResult.code,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -5,7 +5,7 @@ import {
   createQueryParams,
   runPopup,
   parseQueryResult,
-  encodeState,
+  encode,
   createRandomString,
   runIframe,
   sha256,
@@ -147,8 +147,8 @@ export default class Auth0Client {
       ...authorizeOptions
     } = options;
 
-    const stateIn = encodeState(createRandomString());
-    const nonceIn = encodeState(createRandomString());
+    const stateIn = encode(createRandomString());
+    const nonceIn = encode(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);
@@ -197,8 +197,8 @@ export default class Auth0Client {
   ) {
     const popup = await openPopup();
     const { ...authorizeOptions } = options;
-    const stateIn = encodeState(createRandomString());
-    const nonceIn = encodeState(createRandomString());
+    const stateIn = encode(createRandomString());
+    const nonceIn = encode(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);
@@ -510,8 +510,8 @@ export default class Auth0Client {
   private async _getTokenFromIFrame(
     options: GetTokenSilentlyOptions
   ): Promise<any> {
-    const stateIn = encodeState(createRandomString());
-    const nonceIn = encodeState(createRandomString());
+    const stateIn = encode(createRandomString());
+    const nonceIn = encode(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -17,6 +17,7 @@ interface CacheEntry {
   audience: string;
   scope: string;
   client_id: string;
+  refresh_token?: string;
 }
 
 interface CachedTokens {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,10 +1,13 @@
-export class AuthenticationError extends Error {
-  constructor(
-    public error: string,
-    public error_description: string,
-    public state: string
-  ) {
+export class GenericError extends Error {
+  constructor(public error: string, public error_description: string) {
     super(error_description);
+
+    Object.setPrototypeOf(this, GenericError.prototype);
+  }
+}
+export class AuthenticationError extends GenericError {
+  constructor(error: string, error_description: string, public state: string) {
+    super(error, error_description);
     //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, AuthenticationError.prototype);
   }

--- a/src/global.ts
+++ b/src/global.ts
@@ -175,7 +175,7 @@ interface getIdTokenClaimsOptions {
   audience: string;
 }
 
-interface GetTokenSilentlyOptions extends GetUserOptions {
+interface GetTokenSilentlyOptions {
   /**
    * When `true`, ignores the cache and always sends a
    * request to Auth0.
@@ -191,6 +191,16 @@ interface GetTokenSilentlyOptions extends GetUserOptions {
    * Auth0 Application's settings.
    */
   redirect_uri?: string;
+
+  /**
+   * The scope that was used in the authentication request
+   */
+  scope?: string;
+
+  /**
+   * The audience that was used in the authentication request
+   */
+  audience?: string;
 
   /**
    * If you need to send custom parameters to the Authorization Server,
@@ -237,15 +247,26 @@ interface AuthenticationResult {
   error_description?: string;
 }
 
+interface TokenEndpointOptions {
+  baseUrl: string;
+  client_id: string;
+  grant_type: string;
+}
+
 /**
  * @ignore
  */
-interface OAuthTokenOptions {
-  baseUrl: string;
-  client_id: string;
+interface OAuthTokenOptions extends TokenEndpointOptions {
   audience?: string;
   code_verifier: string;
   code: string;
+}
+
+/**
+ * @ignore
+ */
+interface RefreshTokenOptions extends TokenEndpointOptions {
+  refresh_token: string;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -92,10 +92,16 @@ interface Auth0ClientOptions extends BaseLoginOptions {
   leeway?: number;
 
   /**
-   * The strategy to use when storing cache data. Valid values are `memory` or `localstorage`.
+   * The location to use when storing cache data. Valid values are `memory` or `localstorage`.
    * The default setting is `memory`.
    */
   cacheLocation?: 'memory' | 'localstorage';
+
+  /**
+   * If true, refresh tokens are used to fetch new access tokens from the Auth0 server.
+   * The default setting is 'false'.
+   */
+  useRefreshTokens?: boolean;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -257,7 +257,6 @@ interface TokenEndpointOptions {
  * @ignore
  */
 interface OAuthTokenOptions extends TokenEndpointOptions {
-  audience?: string;
   code_verifier: string;
   code: string;
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -98,7 +98,7 @@ interface Auth0ClientOptions extends BaseLoginOptions {
   cacheLocation?: 'memory' | 'localstorage';
 
   /**
-   * If true, refresh tokens are used to fetch new access tokens from the Auth0 server.
+   * If true, refresh tokens are used to fetch new access tokens from the Auth0 server. If false, the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` is used.
    * The default setting is 'false'.
    */
   useRefreshTokens?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import * as ClientStorage from './storage';
 
 //this is necessary to export the type definitions used in this file
 import './global';
-import { validateCrypto } from './utils';
+import { validateCrypto, getUniqueScopes } from './utils';
 
 export default async function createAuth0Client(options: Auth0ClientOptions) {
   validateCrypto();
@@ -21,10 +21,15 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
     return auth0;
   }
 
+  const scope = getUniqueScopes(
+    options.scope,
+    options.useRefreshTokens ? 'offline_access' : undefined
+  );
+
   try {
     await auth0.getTokenSilently({
       audience: options.audience,
-      scope: options.scope,
+      scope,
       ignoreCache: true
     });
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,21 +15,22 @@ import { validateCrypto, getUniqueScopes } from './utils';
 export default async function createAuth0Client(options: Auth0ClientOptions) {
   validateCrypto();
 
+  if (options.useRefreshTokens) {
+    options.scope = options.scope
+      ? getUniqueScopes(options.scope, 'offline_access')
+      : 'offline_access';
+  }
+
   const auth0 = new Auth0Client(options);
 
   if (!ClientStorage.get('auth0.is.authenticated')) {
     return auth0;
   }
 
-  const scope = getUniqueScopes(
-    options.scope,
-    options.useRefreshTokens ? 'offline_access' : undefined
-  );
-
   try {
     await auth0.getTokenSilently({
       audience: options.audience,
-      scope,
+      scope: options.scope,
       ignoreCache: true
     });
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,7 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
   validateCrypto();
 
   if (options.useRefreshTokens) {
-    options.scope = options.scope
-      ? getUniqueScopes(options.scope, 'offline_access')
-      : 'offline_access';
+    options.scope = getUniqueScopes(options.scope, 'offline_access');
   }
 
   const auth0 = new Auth0Client(options);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -187,11 +187,13 @@ const getJSON = async (url, options) => {
   return success;
 };
 
-export const oauthToken = async ({ baseUrl, ...options }: OAuthTokenOptions) =>
+export const oauthToken = async ({
+  baseUrl,
+  ...options
+}: TokenEndpointOptions) =>
   await getJSON(`${baseUrl}/oauth/token`, {
     method: 'POST',
     body: JSON.stringify({
-      grant_type: 'authorization_code',
       redirect_uri: window.location.origin,
       ...options
     }),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,8 +105,8 @@ export const createRandomString = () => {
   return random;
 };
 
-export const encodeState = (state: string) => btoa(state);
-export const decodeState = (state: string) => atob(state);
+export const encode = (value: string) => btoa(value);
+export const decode = (value: string) => atob(value);
 
 export const createQueryParams = (params: any) => {
   return Object.keys(params)

--- a/static/index.html
+++ b/static/index.html
@@ -153,6 +153,10 @@
           >
         </div>
 
+        <button @click="saveForm" class="btn btn-primary">
+          Save
+        </button>
+
         <button @click="resetForm" class="btn btn-outline-primary">
           Reset
         </button>
@@ -254,6 +258,7 @@
             });
 
             _self.auth0.getIdTokenClaims().then(function(claims) {
+              console.log(claims);
               _self.id_token = claims.__raw;
             });
           },

--- a/static/index.html
+++ b/static/index.html
@@ -66,6 +66,12 @@
           </button>
         </div>
 
+        <template v-if="error">
+          <hr />
+          <h3>Last error</h3>
+          <pre><code>{{JSON.stringify(error, null, 2)}}</code></pre>
+        </template>
+
         <hr />
 
         <div class="card mb-3" v-if="profile">
@@ -187,7 +193,8 @@
             id_token: '',
             isAuthenticated: false,
             domain: data.domain || defaultDomain,
-            clientId: data.clientId || defaultClientId
+            clientId: data.clientId || defaultClientId,
+            error: null
           };
         },
         created() {
@@ -298,7 +305,9 @@
               .getTokenSilently({ ignoreCache: !_self.useCache })
               .then(function(token) {
                 _self.access_tokens.push(token);
-              });
+                _self.error = null;
+              })
+              .catch(e => (_self.error = e));
           },
           getMultipleTokens() {
             var _self = this;

--- a/static/index.html
+++ b/static/index.html
@@ -129,7 +129,30 @@
           >
         </div>
 
-        <button type="submit" class="btn btn-primary">Save</button>
+        <div class="custom-control custom-switch mb-5">
+          <input
+            type="checkbox"
+            class="custom-control-input"
+            id="refresh_token_switch"
+            v-model="useRefreshTokens"
+          />
+          <label for="refresh_token_switch" class="custom-control-label"
+            >Use refresh tokens</label
+          >
+        </div>
+
+        <div class="custom-control custom-switch mb-5">
+          <input
+            type="checkbox"
+            class="custom-control-input"
+            id="cache-switch"
+            v-model="useCache"
+          />
+          <label for="cache-switch" class="custom-control-label"
+            >Use token cache when fetching new tokens</label
+          >
+        </div>
+
         <button @click="resetForm" class="btn btn-outline-primary">
           Reset
         </button>
@@ -145,33 +168,38 @@
       var app = new Vue({
         el: '#app',
         data() {
+          var savedData = localStorage.getItem('spa-playground-data');
+
+          var data = savedData ? JSON.parse(savedData) : {};
+
           return {
             auth0: null,
             loading: true,
-            useLocalStorage: false,
+            useLocalStorage: data.useLocalStorage || false,
+            useRefreshTokens: data.useRefreshTokens || false,
+            useCache: data.useCache === false ? false : true,
             profile: null,
             access_tokens: [],
             id_token: '',
             isAuthenticated: false,
-            domain: defaultDomain,
-            clientId: defaultClientId
+            domain: data.domain || defaultDomain,
+            clientId: data.clientId || defaultClientId
           };
         },
         created() {
           this.initializeClient();
-
-          var savedData = localStorage.getItem('spa-playground-data');
-
-          if (savedData) {
-            var data = JSON.parse(savedData);
-            this.domain = data.domain;
-            this.clientId = data.clientId;
-            this.useLocalStorage = data.useLocalStorage || false;
-          }
         },
         watch: {
           useLocalStorage() {
             this.initializeClient();
+            this.saveForm();
+          },
+          useRefreshTokens() {
+            this.initializeClient();
+            this.saveForm();
+          },
+          useCache() {
+            this.saveForm();
           }
         },
         methods: {
@@ -181,7 +209,8 @@
             createAuth0Client({
               domain: _self.domain,
               client_id: _self.clientId,
-              cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory'
+              cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory',
+              useRefreshTokens: _self.useRefreshTokens
             }).then(function(auth0) {
               _self.auth0 = auth0;
               window.auth0 = auth0; // Cypress integration tests support
@@ -198,13 +227,18 @@
               JSON.stringify({
                 domain: this.domain,
                 clientId: this.clientId,
-                useLocalStorage: this.useLocalStorage
+                useLocalStorage: this.useLocalStorage,
+                useRefreshTokens: this.useRefreshTokens,
+                useCache: this.useCache
               })
             );
           },
           resetForm() {
             this.domain = defaultDomain;
             this.clientId = defaultClientId;
+            this.useLocalStorage = false;
+            this.useRefreshTokens = false;
+            this.useCache = true;
             this.saveForm();
           },
           showAuth0Info() {
@@ -255,9 +289,11 @@
           getToken() {
             var _self = this;
 
-            _self.auth0.getTokenSilently().then(function(token) {
-              _self.access_tokens.push(token);
-            });
+            _self.auth0
+              .getTokenSilently({ ignoreCache: !_self.useCache })
+              .then(function(token) {
+                _self.access_tokens.push(token);
+              });
           },
           getMultipleTokens() {
             var _self = this;
@@ -287,7 +323,8 @@
             var differentAudienceOptions = {
               audience: 'https://brucke.auth0.com/api/v2/',
               scope: 'read:rules',
-              redirect_uri: 'http://localhost:3000/callback.html'
+              redirect_uri: 'http://localhost:3000/callback.html',
+              ignoreCache: !_self.useCache
             };
 
             _self.auth0

--- a/static/index.html
+++ b/static/index.html
@@ -229,6 +229,10 @@
 
               auth0.isAuthenticated().then(function(isAuthenticated) {
                 _self.isAuthenticated = isAuthenticated;
+
+                if (isAuthenticated) {
+                  _self.showAuth0Info();
+                }
               });
             });
           },
@@ -265,7 +269,6 @@
             });
 
             _self.auth0.getIdTokenClaims().then(function(claims) {
-              console.log(claims);
               _self.id_token = claims.__raw;
             });
           },
@@ -295,7 +298,10 @@
                 window.location.origin + '/'
               );
 
-              _self.showAuth0Info();
+              auth0.isAuthenticated().then(function(isAuthenticated) {
+                _self.isAuthenticated = isAuthenticated;
+                _self.showAuth0Info();
+              });
             });
           },
           getToken: function() {

--- a/static/index.html
+++ b/static/index.html
@@ -43,7 +43,11 @@
         </div>
 
         <div class="btn-group mb-3">
-          <button class="btn btn-secondary" @click="getToken" id="getToken">
+          <button
+            class="btn btn-secondary"
+            @click="getToken"
+            data-cy="get-token"
+          >
             Get access token
           </button>
 
@@ -139,7 +143,10 @@
             id="storage-switch"
             v-model="useLocalStorage"
           />
-          <label for="storage-switch" class="custom-control-label"
+          <label
+            for="storage-switch"
+            class="custom-control-label"
+            data-cy="switch-local-storage"
             >Use local storage</label
           >
         </div>
@@ -151,7 +158,10 @@
             id="refresh_token_switch"
             v-model="useRefreshTokens"
           />
-          <label for="refresh_token_switch" class="custom-control-label"
+          <label
+            for="refresh_token_switch"
+            class="custom-control-label"
+            data-cy="switch-refresh-tokens"
             >Use refresh tokens</label
           >
         </div>
@@ -163,7 +173,10 @@
             id="cache-switch"
             v-model="useCache"
           />
-          <label for="cache-switch" class="custom-control-label"
+          <label
+            for="cache-switch"
+            class="custom-control-label"
+            data-cy="switch-use-cache"
             >Use token cache when fetching new tokens</label
           >
         </div>
@@ -242,10 +255,6 @@
 
               auth0.isAuthenticated().then(function(isAuthenticated) {
                 _self.isAuthenticated = isAuthenticated;
-
-                if (isAuthenticated) {
-                  _self.showAuth0Info();
-                }
               });
             });
           },

--- a/static/index.html
+++ b/static/index.html
@@ -336,7 +336,13 @@
                 _self.error = null;
               })
               .catch(function(e) {
-                _self.error = e;
+                console.error(e);
+
+                if (e.message) {
+                  _self.error = e.message;
+                } else {
+                  _self.error = e;
+                }
               });
           },
           getMultipleTokens: function() {

--- a/static/index.html
+++ b/static/index.html
@@ -33,13 +33,17 @@
             Login redirect
           </button>
 
-          <button class="btn btn-success" @click="loginHandleRedirectCallback">
+          <button
+            class="btn btn-success"
+            @click="loginHandleRedirectCallback"
+            id="handle_redirect_callback"
+          >
             Login redirect callback
           </button>
         </div>
 
         <div class="btn-group mb-3">
-          <button class="btn btn-secondary" @click="getToken">
+          <button class="btn btn-secondary" @click="getToken" id="getToken">
             Get access token
           </button>
 
@@ -57,7 +61,12 @@
         </div>
 
         <div class="btn-group mb-3">
-          <button class="btn btn-outline-primary" @click="logout" id="logout">
+          <button
+            class="btn btn-outline-primary"
+            @click="logout"
+            id="logout"
+            data-cy="logout"
+          >
             logout (default)
           </button>
 
@@ -69,7 +78,7 @@
         <template v-if="error">
           <hr />
           <h3>Last error</h3>
-          <pre><code>{{JSON.stringify(error, null, 2)}}</code></pre>
+          <pre><code data-cy="error">{{JSON.stringify(error, null, 2)}}</code></pre>
         </template>
 
         <hr />
@@ -89,7 +98,7 @@
           <div class="card-header">Access Tokens</div>
           <div class="card-body">
             <ul v-for="token in access_tokens">
-              <li>{{token}}</li>
+              <li data-cy="access-token">{{token}}</li>
             </ul>
           </div>
         </div>
@@ -163,7 +172,11 @@
           Save
         </button>
 
-        <button @click="resetForm" class="btn btn-outline-primary">
+        <button
+          @click="resetForm"
+          class="btn btn-outline-primary"
+          id="reset-config"
+        >
           Reset
         </button>
       </form>

--- a/static/index.html
+++ b/static/index.html
@@ -177,7 +177,7 @@
 
       var app = new Vue({
         el: '#app',
-        data() {
+        data: function() {
           var savedData = localStorage.getItem('spa-playground-data');
 
           var data = savedData ? JSON.parse(savedData) : {};
@@ -197,24 +197,24 @@
             error: null
           };
         },
-        created() {
+        created: function() {
           this.initializeClient();
         },
         watch: {
-          useLocalStorage() {
+          useLocalStorage: function() {
             this.initializeClient();
             this.saveForm();
           },
-          useRefreshTokens() {
+          useRefreshTokens: function() {
             this.initializeClient();
             this.saveForm();
           },
-          useCache() {
+          useCache: function() {
             this.saveForm();
           }
         },
         methods: {
-          initializeClient() {
+          initializeClient: function() {
             var _self = this;
 
             createAuth0Client({
@@ -232,7 +232,7 @@
               });
             });
           },
-          saveForm() {
+          saveForm: function() {
             localStorage.setItem(
               'spa-playground-data',
               JSON.stringify({
@@ -244,7 +244,7 @@
               })
             );
           },
-          resetForm() {
+          resetForm: function() {
             this.domain = defaultDomain;
             this.clientId = defaultClientId;
             this.useLocalStorage = false;
@@ -252,7 +252,7 @@
             this.useCache = true;
             this.saveForm();
           },
-          showAuth0Info() {
+          showAuth0Info: function() {
             var _self = this;
             _self.access_tokens = [];
 
@@ -269,7 +269,7 @@
               _self.id_token = claims.__raw;
             });
           },
-          loginPopup() {
+          loginPopup: function() {
             var _self = this;
 
             _self.auth0
@@ -280,12 +280,12 @@
                 _self.showAuth0Info();
               });
           },
-          loginRedirect() {
+          loginRedirect: function() {
             this.auth0.loginWithRedirect({
               redirect_uri: 'http://localhost:3000/'
             });
           },
-          loginHandleRedirectCallback() {
+          loginHandleRedirectCallback: function() {
             var _self = this;
 
             _self.auth0.handleRedirectCallback().then(function() {
@@ -298,7 +298,7 @@
               _self.showAuth0Info();
             });
           },
-          getToken() {
+          getToken: function() {
             var _self = this;
 
             _self.auth0
@@ -307,9 +307,11 @@
                 _self.access_tokens.push(token);
                 _self.error = null;
               })
-              .catch(e => (_self.error = e));
+              .catch(function(e) {
+                _self.error = e;
+              });
           },
-          getMultipleTokens() {
+          getMultipleTokens: function() {
             var _self = this;
 
             Promise.all([
@@ -319,7 +321,7 @@
               _self.access_tokens = [tokens[0], tokens[1]];
             });
           },
-          getTokenPopup() {
+          getTokenPopup: function() {
             var _self = this;
 
             _self.auth0
@@ -331,7 +333,7 @@
                 _self.access_tokens = [token];
               });
           },
-          getTokenAudience() {
+          getTokenAudience: function() {
             var _self = this;
 
             var differentAudienceOptions = {
@@ -347,12 +349,12 @@
                 _self.access_tokens = [token];
               });
           },
-          logout() {
+          logout: function() {
             this.auth0.logout({
               returnTo: 'http://localhost:3000/'
             });
           },
-          logoutNoClient() {
+          logoutNoClient: function() {
             this.auth0.logout({
               client_id: null,
               returnTo: 'http://localhost:3000/'


### PR DESCRIPTION
### Description

This PR adds support for rotating refresh tokens. Some highlights:

* A new option on `createAuth0Client` called `useRefreshTokens` has been implemented and set to `false` by default. When this is `true`, the SDK will attempt to call the `/token` endpoint using the `refresh_token` grant type along with a refresh token from the cache.
* When `useRefreshTokens` is `false`, the existing code path that attempts to retrieve a new access token using a hidden iframe and `prompt=none` remains.

**Note:** This PR does not yet implement a retry mechanism for when there is a network error when trying to retrieve a new access token.

**Note 2:** This PR builds upon https://github.com/auth0/auth0-spa-js/tree/feature/storage. The two PRs will likely go in together and will be merged into https://github.com/auth0/auth0-spa-js/tree/release/rtr

### Testing

For manual testing, the playground as enhanced by feature/storage has been extended to support toggling the use of refresh tokens. This helps when visualizing the network traffic so you can see what network requests are being made. Clone, `npm install` then `npm start` to run the playground on `http://localhost:3000`. To make use of the RTR feature, your Auth0 tenant must have the feature flag enabled, and RTR turned on for a specific client using a call to API 2.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
