### PR TITLE
Use user provided params on silent login

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1213,6 +1213,29 @@ describe('Auth0', () => {
           defaultOptionsIgnoreCacheTrue.scope
         );
       });
+      it('creates correct query params when providing user specified custom query params', async () => {
+        const { auth0, utils } = await setup();
+
+        const customQueryParameterOptions = {
+          ...defaultOptionsIgnoreCacheTrue,
+          foo: 'bar'
+        };
+        await auth0.getTokenSilently(customQueryParameterOptions);
+        expect(utils.createQueryParams).toHaveBeenCalledWith({
+          audience: defaultOptionsIgnoreCacheTrue.audience,
+          client_id: TEST_CLIENT_ID,
+          scope: TEST_SCOPES,
+          response_type: TEST_CODE,
+          response_mode: 'web_message',
+          prompt: 'none',
+          state: TEST_ENCODED_STATE,
+          nonce: TEST_RANDOM_STRING,
+          redirect_uri: 'http://localhost',
+          code_challenge: TEST_BASE64_ENCODED_STRING,
+          code_challenge_method: 'S256',
+          foo: 'bar'
+        });
+      });
       it('opens iframe with correct urls', async () => {
         const { auth0, utils } = await setup();
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -334,10 +334,17 @@ export default class Auth0Client {
     try {
       await lock.acquireLock(GET_TOKEN_SILENTLY_LOCK_KEY, 5000);
 
-      if (!options.ignoreCache) {
+      const {
+        audience,
+        scope,
+        ignoreCache,
+        ...additionalQueryParams
+      } = options;
+
+      if (!ignoreCache) {
         const cache = this.cache.get({
-          scope: options.scope,
-          audience: options.audience || 'default'
+          scope,
+          audience: audience || 'default'
         });
 
         if (cache) {
@@ -353,8 +360,9 @@ export default class Auth0Client {
       const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);
 
       const authorizeOptions = {
-        audience: options.audience,
-        scope: options.scope
+        audience,
+        scope,
+        ...additionalQueryParams
       };
 
       const params = this._getParams(


### PR DESCRIPTION
### Description

This PR adds support for custom query parameters in `getTokenSilently` similar to how `loginWithRedirect` does this.

### References

- [Issue on Github](https://github.com/auth0/auth0-spa-js/issues/317)

### Testing

Add a custom property to the `getTokenSilently` method call and inspect the generated url.
```js
auth0.getTokenSilently({
    scope,
    audience,
    foo: 'bar',
});
```

I was looking at integration tests I noticed that `getTokenSilently > Builds URL correctly` test is skipped. Can someone provide some context on why is that? Should the test be updated to reflect custom parameters as well?

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing

