### PR TITLE
Included the polyfill for String.includes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import 'core-js/es/string/starts-with';
 import 'core-js/es/array/from';
 import 'core-js/es/typed-array/slice';
 import 'core-js/es/array/includes';
+import 'core-js/es/string/includes';
 import 'promise-polyfill/src/polyfill';
 import 'fast-text-encoding';
 


### PR DESCRIPTION
### Description

This fixes a problem with [`browser-tabs-lock`](https://github.com/supertokens/browser-tabs-lock) sometimes failing because `.includes` is not a valid method in IE11. [The offending code](https://github.com/supertokens/browser-tabs-lock/blob/bd6710630f9d290beff2f420381692554094df1a/index.ts#L250) seems to only execute under certain circumstances, making this error appear intermittently in IE11.

### Testing

Tested manually in IE11 + Browserstack using the SPA JS playground app.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
