### PR TITLE
[SDK-1258] Remove future iat check

### DIFF
--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -210,17 +210,6 @@ describe('jwt', async () => {
       'Issued At (iat) claim must be a number present in the ID token'
     );
   });
-  it('validates iat', async () => {
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const id_token = await createJWT({
-      ...DEFAULT_PAYLOAD,
-      iat: tomorrow.getTime()
-    });
-    expect(() => verify({ ...verifyOptions, id_token })).toThrow(
-      'Issued At (iat) claim error in the ID token'
-    );
-  });
   it('does not validate nonce is present when options.nonce is undefined', async () => {
     const id_token = await createJWT({ ...DEFAULT_PAYLOAD, nonce: undefined });
     expect(() =>

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -160,24 +160,17 @@ export const verify = (options: JWTVerifyOptions) => {
   const leeway = options.leeway || 60;
   const now = new Date();
   const expDate = new Date(0);
-  const iatDate = new Date(0);
   const nbfDate = new Date(0);
   const authTimeDate = new Date(0);
   authTimeDate.setUTCSeconds(
     (parseInt(decoded.claims.auth_time) + options.max_age) / 1000 + leeway
   );
   expDate.setUTCSeconds(decoded.claims.exp + leeway);
-  iatDate.setUTCSeconds(decoded.claims.iat - leeway);
   nbfDate.setUTCSeconds(decoded.claims.nbf - leeway);
 
   if (now > expDate) {
     throw new Error(
       `Expiration Time (exp) claim error in the ID token; current time (${now}) is after expiration time (${expDate})`
-    );
-  }
-  if (now < iatDate) {
-    throw new Error(
-      `Issued At (iat) claim error in the ID token; current time (${now}) is before issued at time (${iatDate})`
     );
   }
   if (isNumber(decoded.claims.nbf) && now < nbfDate) {


### PR DESCRIPTION
### Description

Remove iat claim value check for ID token validation; continue to check for presence.

### References

Closes #320 
Closes #322 

### Testing

Tests for iat future check have been removed

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
