### PR TITLE
Enchancements to the build process - changelog generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 stats.html
 cypress/screenshots
 cypress/videos
+.release

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prepack": "npm run build && npm run test:es-check && npm run test && node ./scripts/prepack",
     "precommit": "pretty-quick --staged",
     "release": "node ./scripts/release",
+    "release:clean": "node ./scripts/cleanup",
     "publish:cdn": "ccu --trace"
   },
   "devDependencies": {

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,0 +1,59 @@
+if (process.platform === 'win32') {
+  console.error('Must be run on a Unix OS');
+  process.exit(1);
+}
+
+const repo = 'auth0-spa-js';
+const library = require('../package.json');
+const fs = require('fs');
+const path = require('path');
+const execSync = require('child_process').execSync;
+const moment = require('moment');
+
+const tmp = fs.readFileSync('.release', 'utf-8');
+const currentVersion = fs.readFileSync(
+  path.resolve(tmp, 'current-version'),
+  'utf-8'
+);
+
+const changelogPath = path.resolve(tmp, 'CHANGELOG.md');
+const stream = fs.createWriteStream(changelogPath);
+
+const webtask = `https://webtask.it.auth0.com/api/run/wt-hernan-auth0_com-0/oss-changelog.js?webtask_no_cache=1&repo=${repo}&milestone=v${library.version}`;
+const command = `curl -f -s -H "Accept: text/markdown" "${webtask}"`;
+const changes = execSync(command, { encoding: 'utf-8' });
+const previous = execSync('sed "s/# Change Log//" CHANGELOG.md | sed \'1,2d\'');
+
+module.exports = function() {
+  return new Promise((resolve, reject) => {
+    stream.once('open', function(fd) {
+      stream.write('# Change Log');
+      stream.write('\n');
+      stream.write('\n');
+
+      stream.write(
+        `## [v${library.version}](https://github.com/auth0/${repo}/tree/v${
+          library.version
+        }) (${moment().format('YYYY-MM-DD')})`
+      );
+
+      stream.write('\n');
+
+      stream.write(
+        `[Full Changelog](https://github.com/auth0/${repo}/compare/v${currentVersion}...v${library.version})`
+      );
+
+      stream.write('\n');
+      stream.write(changes);
+      stream.write('\n');
+      stream.write(previous);
+      stream.end();
+    });
+
+    stream.once('close', function(fd) {
+      execSync(`mv ${changelogPath} CHANGELOG.md`, { stdio: 'inherit' });
+      execSync('git add CHANGELOG.md', { stdio: 'inherit' });
+      resolve();
+    });
+  });
+};

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -4,13 +4,12 @@ if (process.platform === 'win32') {
 }
 
 const repo = 'auth0-spa-js';
-const library = require('../package.json');
 const fs = require('fs');
 const path = require('path');
 const execSync = require('child_process').execSync;
 const moment = require('moment');
 
-module.exports = function() {
+module.exports = function(newVersion) {
   return new Promise((resolve, reject) => {
     const tmp = fs.readFileSync('.release', 'utf-8');
 
@@ -21,8 +20,7 @@ module.exports = function() {
 
     const changelogPath = path.resolve(tmp, 'CHANGELOG.md');
     const stream = fs.createWriteStream(changelogPath);
-    library.version = '1.6.2';
-    const webtask = `https://webtask.it.auth0.com/api/run/wt-hernan-auth0_com-0/oss-changelog.js?webtask_no_cache=1&repo=${repo}&milestone=v${library.version}`;
+    const webtask = `https://webtask.it.auth0.com/api/run/wt-hernan-auth0_com-0/oss-changelog.js?webtask_no_cache=1&repo=${repo}&milestone=v${newVersion}`;
     const command = `curl -f -s -H "Accept: text/markdown" "${webtask}"`;
     const changes = execSync(command, { encoding: 'utf-8' });
 
@@ -36,15 +34,15 @@ module.exports = function() {
       stream.write('\n');
 
       stream.write(
-        `## [v${library.version}](https://github.com/auth0/${repo}/tree/v${
-          library.version
-        }) (${moment().format('YYYY-MM-DD')})`
+        `## [v${newVersion}](https://github.com/auth0/${repo}/tree/v${newVersion}) (${moment().format(
+          'YYYY-MM-DD'
+        )})`
       );
 
       stream.write('\n');
 
       stream.write(
-        `[Full Changelog](https://github.com/auth0/${repo}/compare/v${currentVersion}...v${library.version})`
+        `[Full Changelog](https://github.com/auth0/${repo}/compare/v${currentVersion}...v${newVersion})`
       );
 
       stream.write('\n');

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -10,22 +10,26 @@ const path = require('path');
 const execSync = require('child_process').execSync;
 const moment = require('moment');
 
-const tmp = fs.readFileSync('.release', 'utf-8');
-const currentVersion = fs.readFileSync(
-  path.resolve(tmp, 'current-version'),
-  'utf-8'
-);
-
-const changelogPath = path.resolve(tmp, 'CHANGELOG.md');
-const stream = fs.createWriteStream(changelogPath);
-
-const webtask = `https://webtask.it.auth0.com/api/run/wt-hernan-auth0_com-0/oss-changelog.js?webtask_no_cache=1&repo=${repo}&milestone=v${library.version}`;
-const command = `curl -f -s -H "Accept: text/markdown" "${webtask}"`;
-const changes = execSync(command, { encoding: 'utf-8' });
-const previous = execSync('sed "s/# Change Log//" CHANGELOG.md | sed \'1,2d\'');
-
 module.exports = function() {
   return new Promise((resolve, reject) => {
+    const tmp = fs.readFileSync('.release', 'utf-8');
+
+    const currentVersion = fs.readFileSync(
+      path.resolve(tmp, 'current-version'),
+      'utf-8'
+    );
+
+    const changelogPath = path.resolve(tmp, 'CHANGELOG.md');
+    const stream = fs.createWriteStream(changelogPath);
+    library.version = '1.6.2';
+    const webtask = `https://webtask.it.auth0.com/api/run/wt-hernan-auth0_com-0/oss-changelog.js?webtask_no_cache=1&repo=${repo}&milestone=v${library.version}`;
+    const command = `curl -f -s -H "Accept: text/markdown" "${webtask}"`;
+    const changes = execSync(command, { encoding: 'utf-8' });
+
+    const previous = execSync(
+      'sed "s/# Change Log//" CHANGELOG.md | sed \'1,2d\''
+    );
+
     stream.once('open', function(fd) {
       stream.write('# Change Log');
       stream.write('\n');

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -1,0 +1,23 @@
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+
+if (fs.existsSync('dist')) {
+  execSync(`rm -r dist`, { stdio: 'inherit' });
+}
+
+if (fs.existsSync('coverage')) {
+  execSync(`rm -r coverage`, { stdio: 'inherit' });
+}
+
+if (!fs.existsSync('.release')) {
+  console.log('No in progress release found');
+  process.exit(0);
+}
+
+const tmp = fs.readFileSync('.release');
+
+if (fs.existsSync(tmp)) {
+  execSync(`rm -r ${tmp}`, { stdio: 'inherit' });
+}
+
+execSync(`rm -r .release`, { stdio: 'inherit' });

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,11 +2,23 @@ const fs = require('fs');
 const pkg = require('../package.json');
 const exec = require('./exec');
 const writeChangelog = require('./changelog');
+const path = require('path');
+const tmp = fs.mkdtempSync(`.release-tmp-`);
+
+if (!fs.existsSync('.release')) {
+  fs.writeFileSync('.release', tmp);
+} else {
+  console.error('Found a pending release. Please run `npm run release:clean`');
+  process.exit(1);
+}
 
 const newVersion = process.argv[2];
 if (!newVersion) {
   throw new Error('usage: `release new_version [branch]`');
 }
+
+var lastVersionFile = path.resolve(tmp, 'current-version');
+fs.writeFileSync(lastVersionFile, newVersion);
 
 const branch = process.argv[3];
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const pkg = require('../package.json');
 const exec = require('./exec');
+const writeChangelog = require('./changelog');
 
 const newVersion = process.argv[2];
 if (!newVersion) {
@@ -32,4 +33,6 @@ const branch = process.argv[3];
   fs.writeFileSync('./src/version.ts', `export default '${newVersion}';`);
 
   await exec('npm run docs');
+
+  await writeChangelog();
 })();

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -18,7 +18,7 @@ if (!newVersion) {
 }
 
 var lastVersionFile = path.resolve(tmp, 'current-version');
-fs.writeFileSync(lastVersionFile, newVersion);
+fs.writeFileSync(lastVersionFile, pkg.version);
 
 const branch = process.argv[3];
 
@@ -46,5 +46,5 @@ const branch = process.argv[3];
 
   await exec('npm run docs');
 
-  await writeChangelog();
+  await writeChangelog(newVersion);
 })();

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -4,11 +4,16 @@ const exec = require('./exec');
 
 const newVersion = process.argv[2];
 if (!newVersion) {
-  throw new Error('usage: `release new_version`');
+  throw new Error('usage: `release new_version [branch]`');
 }
 
+const branch = process.argv[3];
+
 (async () => {
-  await exec('git checkout master');
+  if (branch) {
+    await exec(`git checkout ${branch}`);
+  }
+
   await exec('git pull');
   await exec(`git checkout -b prepare/${newVersion}`);
 
@@ -23,6 +28,7 @@ if (!newVersion) {
     './package.json',
     JSON.stringify({ ...pkg, version: newVersion }, null, 2)
   );
+
   fs.writeFileSync('./src/version.ts', `export default '${newVersion}';`);
 
   await exec('npm run docs');


### PR DESCRIPTION
### Description

This PR adds the functionality to auto-generate the changelog based on the milestone and PR labels attached to PRs being released and aligns it with other SDKs. This is build-time code only and does not affect the runtime library.

Much of it has been borrowed from other libraries (such as `idtoken-verifier`) and tailored to suit.

One further change is that `npm run release [version]` now acts on the current branch by default instead of checking out master, and also accepts an optional `branch` argument to perform the release from.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
