### PR TITLE
Fixed issue with cache not retaining refresh token

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,5 +1,4 @@
 import { InMemoryCache, LocalStorageCache } from '../src/cache';
-import { _ } from 'core-js';
 
 const nowSeconds = () => Math.floor(Date.now() / 1000);
 

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -56,10 +56,14 @@ describe('InMemoryCache', () => {
       }
     });
 
+    // Test that the cache state is normal up until just before the expiry time..
     jest.advanceTimersByTime(799);
     expect(Object.keys(cache.cache).length).toBe(1);
 
+    // Advance the time to match the expiry time..
     jest.advanceTimersByTime(1);
+
+    // and test that the cache has been emptied.
     expect(Object.keys(cache.cache).length).toBe(0);
   });
 
@@ -82,10 +86,14 @@ describe('InMemoryCache', () => {
       }
     });
 
+    // Test that the cache state is normal up until just before the expiry time..
     jest.advanceTimersByTime(799);
     expect(Object.keys(cache.cache).length).toBe(1);
 
+    // Advance the time to just past the expiry..
     jest.advanceTimersByTime(1);
+
+    // And test that the cache has been emptied, except for the refresh token
     expect(cache.cache).toStrictEqual({
       '@@auth0spajs@@::test-client::the_audience::the_scope': {
         refresh_token: 'refreshtoken'
@@ -110,9 +118,15 @@ describe('InMemoryCache', () => {
         user: { name: 'Test' }
       }
     });
+
+    // Test that the cache state is normal up until just before the expiry time..
     jest.advanceTimersByTime(799);
     expect(Object.keys(cache.cache).length).toBe(1);
+
+    // Advance the time to just past the expiry..
     jest.advanceTimersByTime(1);
+
+    // And test that the cache has been emptied
     expect(Object.keys(cache.cache).length).toBe(0);
   });
 });

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -194,19 +194,22 @@ describe('LocalStorageCache', () => {
             id_token: '__ID_TOKEN__',
             access_token: '__ACCESS_TOKEN__',
             refresh_token: '__REFRESH_TOKEN__',
-            expires_in: -10,
+            expires_in: 10,
             decodedToken: {
               claims: {
                 __raw: 'idtoken',
-                exp: nowSeconds() - 5,
+                exp: nowSeconds() + 15,
                 name: 'Test'
               },
               user: { name: 'Test' }
             }
           },
-          expiresAt: nowSeconds() - 10
+          expiresAt: nowSeconds() + 10
         })
       );
+
+      const now = nowSeconds();
+      global.Date.now = jest.fn(() => (now + 30) * 1000);
 
       expect(
         cache.get({
@@ -230,19 +233,22 @@ describe('LocalStorageCache', () => {
           scope: '__TEST_SCOPE__',
           id_token: '__ID_TOKEN__',
           access_token: '__ACCESS_TOKEN__',
-          expires_in: -10,
+          expires_in: 10,
           decodedToken: {
             claims: {
               __raw: 'idtoken',
-              exp: nowSeconds() - 5,
+              exp: nowSeconds() + 15,
               name: 'Test'
             },
             user: { name: 'Test' }
           }
         },
-        expiresAt: nowSeconds() - 10
+        expiresAt: nowSeconds() + 10
       })
     );
+
+    const now = nowSeconds();
+    global.Date.now = jest.fn(() => (now + 30) * 1000);
 
     expect(
       cache.get({

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,6 +1,7 @@
 import { InMemoryCache, LocalStorageCache } from '../src/cache';
 
 const nowSeconds = () => Math.floor(Date.now() / 1000);
+const dayInSeconds = 86400;
 
 describe('InMemoryCache', () => {
   let cache: InMemoryCache;
@@ -141,11 +142,11 @@ describe('LocalStorageCache', () => {
       scope: '__TEST_SCOPE__',
       id_token: '__ID_TOKEN__',
       access_token: '__ACCESS_TOKEN__',
-      expires_in: 86400,
+      expires_in: dayInSeconds,
       decodedToken: {
         claims: {
           __raw: 'idtoken',
-          exp: nowSeconds() + 86500,
+          exp: nowSeconds() + dayInSeconds + 100,
           name: 'Test'
         },
         user: { name: 'Test' }
@@ -165,7 +166,7 @@ describe('LocalStorageCache', () => {
         '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
         JSON.stringify({
           body: defaultEntry,
-          expiresAt: nowSeconds() + 86400
+          expiresAt: nowSeconds() + dayInSeconds
         })
       );
 
@@ -264,14 +265,14 @@ describe('LocalStorageCache', () => {
         '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
         JSON.stringify({
           body: defaultEntry,
-          expiresAt: nowSeconds() + 86400 - 60
+          expiresAt: nowSeconds() + dayInSeconds - 60
         })
       );
     });
 
     it('can set a value into the cache when exp < expires_in', () => {
       const entry = Object.assign({}, defaultEntry, {
-        expires_in: 86500,
+        expires_in: dayInSeconds + 100,
         decodedToken: {
           claims: {
             exp: nowSeconds() + 100

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,4 +1,5 @@
 import { InMemoryCache, LocalStorageCache } from '../src/cache';
+import { _ } from 'core-js';
 
 const nowSeconds = () => Math.floor(Date.now() / 1000);
 
@@ -54,6 +55,7 @@ describe('InMemoryCache', () => {
         user: { name: 'Test' }
       }
     });
+
     jest.advanceTimersByTime(799);
     expect(Object.keys(cache.cache).length).toBe(1);
 
@@ -61,10 +63,40 @@ describe('InMemoryCache', () => {
     expect(Object.keys(cache.cache).length).toBe(0);
   });
 
+  it('strips everything except the refresh token when expiry has been reached', () => {
+    cache.save({
+      client_id: 'test-client',
+      audience: 'the_audience',
+      scope: 'the_scope',
+      id_token: 'idtoken',
+      access_token: 'accesstoken',
+      refresh_token: 'refreshtoken',
+      expires_in: 1,
+      decodedToken: {
+        claims: {
+          __raw: 'idtoken',
+          name: 'Test',
+          exp: new Date().getTime() / 1000 + 2
+        },
+        user: { name: 'Test' }
+      }
+    });
+
+    jest.advanceTimersByTime(799);
+    expect(Object.keys(cache.cache).length).toBe(1);
+
+    jest.advanceTimersByTime(1);
+    expect(cache.cache).toStrictEqual({
+      '@@auth0spajs@@::test-client::the_audience::the_scope': {
+        refresh_token: 'refreshtoken'
+      }
+    });
+  });
+
   it('expires after `user.exp` when `user.exp` < `expires_in`', () => {
     cache.save({
       client_id: 'test-client',
-      audience: 'the_audiene',
+      audience: 'the_audience',
       scope: 'the_scope',
       id_token: 'idtoken',
       access_token: 'accesstoken',
@@ -93,6 +125,7 @@ describe('LocalStorageCache', () => {
   beforeEach(() => {
     cache = new LocalStorageCache();
 
+    jest.clearAllMocks();
     jest.useFakeTimers();
     localStorage.clear();
     (<any>localStorage.removeItem).mockClear();
@@ -127,59 +160,64 @@ describe('LocalStorageCache', () => {
     global.Date.now = realDateNow;
   });
 
-  it('can set a value into the cache when expires_in < exp', () => {
-    cache.save(defaultEntry);
+  describe('cache.get', () => {
+    it('can retrieve an item from the cache', () => {
+      localStorage.setItem(
+        '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
+        JSON.stringify({
+          body: defaultEntry,
+          expiresAt: nowSeconds() + 86400
+        })
+      );
 
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
-      JSON.stringify({
-        body: defaultEntry,
-        expiresAt: nowSeconds() + 86400 - 60
-      })
-    );
-  });
-
-  it('can set a value into the cache when exp < expires_in', () => {
-    const entry = Object.assign({}, defaultEntry, {
-      expires_in: 86500,
-      decodedToken: {
-        claims: {
-          exp: nowSeconds() + 100
-        }
-      }
+      expect(
+        cache.get({
+          client_id: '__TEST_CLIENT_ID__',
+          audience: '__TEST_AUDIENCE__',
+          scope: '__TEST_SCOPE__'
+        })
+      ).toStrictEqual(defaultEntry);
     });
 
-    cache.save(entry);
+    it('returns undefined when there is no data', () => {
+      expect(cache.get({ scope: '', audience: '' })).toBeUndefined();
+    });
 
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
-      JSON.stringify({
-        body: entry,
-        expiresAt: nowSeconds() + 40
-      })
-    );
-  });
+    it('strips the data, leaving the refresh token, when the expiry has been reached', () => {
+      localStorage.setItem(
+        '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
+        JSON.stringify({
+          body: {
+            client_id: '__TEST_CLIENT_ID__',
+            audience: '__TEST_AUDIENCE__',
+            scope: '__TEST_SCOPE__',
+            id_token: '__ID_TOKEN__',
+            access_token: '__ACCESS_TOKEN__',
+            refresh_token: '__REFRESH_TOKEN__',
+            expires_in: -10,
+            decodedToken: {
+              claims: {
+                __raw: 'idtoken',
+                exp: nowSeconds() - 5,
+                name: 'Test'
+              },
+              user: { name: 'Test' }
+            }
+          },
+          expiresAt: nowSeconds() - 10
+        })
+      );
 
-  it('can retrieve an item from the cache', () => {
-    localStorage.setItem(
-      '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
-      JSON.stringify({
-        body: defaultEntry,
-        expiresAt: nowSeconds() + 86400
-      })
-    );
-
-    expect(
-      cache.get({
-        client_id: '__TEST_CLIENT_ID__',
-        audience: '__TEST_AUDIENCE__',
-        scope: '__TEST_SCOPE__'
-      })
-    ).toStrictEqual(defaultEntry);
-  });
-
-  it('returns undefined when there is no data', () => {
-    expect(cache.get({ scope: '', audience: '' })).toBeUndefined();
+      expect(
+        cache.get({
+          client_id: '__TEST_CLIENT_ID__',
+          audience: '__TEST_AUDIENCE__',
+          scope: '__TEST_SCOPE__'
+        })
+      ).toStrictEqual({
+        refresh_token: '__REFRESH_TOKEN__'
+      });
+    });
   });
 
   it('expires after cache `expiresAt` when expiresAt < current time', () => {
@@ -219,22 +257,85 @@ describe('LocalStorageCache', () => {
     );
   });
 
-  it('deletes the cache item once the timeout has been reached', () => {
-    const entry = Object.assign({}, defaultEntry, {
-      expires_in: 120,
-      decodedToken: {
-        claims: {
-          exp: nowSeconds() + 240
-        }
-      }
+  describe('cache.save', () => {
+    it('can set a value into the cache when expires_in < exp', () => {
+      cache.save(defaultEntry);
+
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
+        JSON.stringify({
+          body: defaultEntry,
+          expiresAt: nowSeconds() + 86400 - 60
+        })
+      );
     });
 
-    cache.save(entry);
+    it('can set a value into the cache when exp < expires_in', () => {
+      const entry = Object.assign({}, defaultEntry, {
+        expires_in: 86500,
+        decodedToken: {
+          claims: {
+            exp: nowSeconds() + 100
+          }
+        }
+      });
 
-    // 96000, because the timeout time will be calculated at expires_in * 1000 * 0.8
-    jest.advanceTimersByTime(96000);
+      cache.save(entry);
 
-    expect(localStorage.removeItem).toHaveBeenCalled();
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
+        JSON.stringify({
+          body: entry,
+          expiresAt: nowSeconds() + 40
+        })
+      );
+    });
+
+    it('deletes the cache item once the timeout has been reached', () => {
+      const entry = Object.assign({}, defaultEntry, {
+        expires_in: 120,
+        decodedToken: {
+          claims: {
+            exp: nowSeconds() + 240
+          }
+        }
+      });
+
+      cache.save(entry);
+
+      // 96000, because the timeout time will be calculated at expires_in * 1000 * 0.8
+      jest.advanceTimersByTime(96000);
+
+      expect(localStorage.removeItem).toHaveBeenCalled();
+    });
+
+    it('strips the cache data, leaving the refresh token, once the timeout has been reached', () => {
+      const exp = nowSeconds() + 240;
+      const expiresIn = nowSeconds() + 120;
+
+      const entry = Object.assign({}, defaultEntry, {
+        expires_in: 120,
+        refresh_token: 'refresh-token',
+        decodedToken: {
+          claims: {
+            exp
+          }
+        }
+      });
+
+      cache.save(entry);
+
+      // 96000, because the timeout time will be calculated at expires_in * 1000 * 0.8
+      jest.advanceTimersByTime(96000);
+
+      const payload = JSON.parse(
+        localStorage.getItem(
+          '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__'
+        )
+      );
+
+      expect(payload.body).toStrictEqual({ refresh_token: 'refresh-token' });
+    });
   });
 
   it('removes the correct items when the cache is cleared', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1267,7 +1267,7 @@ describe('Auth0', () => {
 
           await auth0.getTokenSilently();
 
-          //we only evaluate that the code didn't bail out because of the cache
+          // we only evaluate that the code didn't bail out because of the cache
           expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
         });
 
@@ -1278,6 +1278,8 @@ describe('Auth0', () => {
 
           await auth0.getTokenSilently();
 
+          // we only evaluate that the code didn't bail out because the cache didn't return
+          // an access token
           expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
         });
       });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1270,6 +1270,16 @@ describe('Auth0', () => {
           //we only evaluate that the code didn't bail out because of the cache
           expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
         });
+
+        it('continues method execution when there is a value from the cache but no access token', async () => {
+          const { auth0, utils, cache } = await setup();
+
+          cache.get.mockReturnValue({});
+
+          await auth0.getTokenSilently();
+
+          expect(utils.encode).toHaveBeenCalledWith(TEST_RANDOM_STRING);
+        });
       });
 
       describe('when refresh tokens are used', () => {

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -55,7 +55,7 @@ describe('getTokenSilently', function() {
           cy.toggleSwitch('local-storage');
 
           cy.login().then(() => {
-            cy.reload();
+            cy.reload().wait(5000);
 
             cy.get('[data-cy=get-token]')
               .click()
@@ -82,7 +82,8 @@ describe('getTokenSilently', function() {
             cy.toggleSwitch('use-cache');
 
             cy.login().then(() => {
-              cy.toggleSwitch('refresh-tokens').wait(250);
+              cy.toggleSwitch('refresh-tokens').wait(1000);
+              win.localStorage.clear();
 
               cy.get('[data-cy=get-token]')
                 .click()

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -268,7 +268,7 @@ export default class Auth0Client {
       ...options
     });
 
-    return cache && cache.decodedToken.user;
+    return cache && cache.decodedToken && cache.decodedToken.user;
   }
 
   /**
@@ -297,7 +297,7 @@ export default class Auth0Client {
       ...options
     });
 
-    return cache && cache.decodedToken.claims;
+    return cache && cache.decodedToken && cache.decodedToken.claims;
   }
 
   /**
@@ -409,7 +409,7 @@ export default class Auth0Client {
           client_id: this.options.client_id
         });
 
-        if (cache) {
+        if (cache && cache.access_token) {
           await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
           return cache.access_token;
         }
@@ -562,6 +562,12 @@ export default class Auth0Client {
   private async _getTokenUsingRefreshToken(
     options: GetTokenSilentlyOptions
   ): Promise<any> {
+    options.scope = getUniqueScopes(
+      this.DEFAULT_SCOPE,
+      this.options.scope,
+      options.scope
+    );
+
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -66,7 +66,9 @@ export class LocalStorageCache implements ICache {
     setTimeout(() => {
       const payload = this.getPayload(cacheKey);
 
-      if (!payload || !payload.body) return;
+      if (!payload || !payload.body) {
+        return;
+      }
 
       if (payload.body.refresh_token) {
         const newPayload = this.stripPayload(payload);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -121,11 +121,15 @@ export class LocalStorageCache implements ICache {
     const json = window.localStorage.getItem(cacheKey);
     let payload;
 
-    if (!json) return;
+    if (!json) {
+      return;
+    }
 
     payload = JSON.parse(json);
 
-    if (!payload) return;
+    if (!payload) {
+      return;
+    }
 
     return payload;
   }

--- a/static/index.html
+++ b/static/index.html
@@ -19,6 +19,8 @@
 
       <h1 class="mb-5">Auth0 SPA JS Playground</h1>
 
+      <p><strong>Is authenticated:</strong>&nbsp;{{ isAuthenticated }}</p>
+
       <div v-if="!loading">
         <div class="btn-group mb-3">
           <button class="btn btn-primary" @click="loginPopup">
@@ -136,6 +138,16 @@
           />
         </div>
 
+        <div class="form-group">
+          <label for="audience">Audience</label>
+          <input
+            type="text"
+            class="form-control"
+            id="audience"
+            v-model="audience"
+          />
+        </div>
+
         <div class="custom-control custom-switch mb-5">
           <input
             type="checkbox"
@@ -200,6 +212,7 @@
     <script type="text/javascript">
       var defaultDomain = 'brucke.auth0.com';
       var defaultClientId = 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp';
+      var defaultAudience = '';
 
       var app = new Vue({
         el: '#app',
@@ -220,6 +233,7 @@
             isAuthenticated: false,
             domain: data.domain || defaultDomain,
             clientId: data.clientId || defaultClientId,
+            audience: data.audience || defaultAudience,
             error: null
           };
         },
@@ -247,7 +261,8 @@
               domain: _self.domain,
               client_id: _self.clientId,
               cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory',
-              useRefreshTokens: _self.useRefreshTokens
+              useRefreshTokens: _self.useRefreshTokens,
+              audience: _self.audience
             }).then(function(auth0) {
               _self.auth0 = auth0;
               window.auth0 = auth0; // Cypress integration tests support
@@ -266,7 +281,8 @@
                 clientId: this.clientId,
                 useLocalStorage: this.useLocalStorage,
                 useRefreshTokens: this.useRefreshTokens,
-                useCache: this.useCache
+                useCache: this.useCache,
+                audience: this.audience
               })
             );
           },
@@ -276,6 +292,7 @@
             this.useLocalStorage = false;
             this.useRefreshTokens = false;
             this.useCache = true;
+            this.audience = defaultAudience;
             this.saveForm();
           },
           showAuth0Info: function() {
@@ -302,7 +319,10 @@
                 redirect_uri: 'http://localhost:3000/callback.html'
               })
               .then(function() {
-                _self.showAuth0Info();
+                auth0.isAuthenticated().then(function(isAuthenticated) {
+                  _self.isAuthenticated = isAuthenticated;
+                  _self.showAuth0Info();
+                });
               });
           },
           loginRedirect: function() {
@@ -332,8 +352,12 @@
             _self.auth0
               .getTokenSilently({ ignoreCache: !_self.useCache })
               .then(function(token) {
-                _self.access_tokens.push(token);
+                _self.access_tokens = [token];
                 _self.error = null;
+
+                auth0.isAuthenticated().then(function(isAuthenticated) {
+                  _self.isAuthenticated = isAuthenticated;
+                });
               })
               .catch(function(e) {
                 console.error(e);

--- a/static/index.html
+++ b/static/index.html
@@ -352,7 +352,7 @@
             _self.auth0
               .getTokenSilently({ ignoreCache: !_self.useCache })
               .then(function(token) {
-                _self.access_tokens = [token];
+                _self.access_tokens.push(token);
                 _self.error = null;
 
                 auth0.isAuthenticated().then(function(isAuthenticated) {


### PR DESCRIPTION
### Description

This PR corrects a design problem with the new local storage cache (and the original in-memory cache) where the refresh token was not being retained.

Currently, when the `expiresIn` value is reached and the access token should be dropped/renewed, the cache is cleared. Unfortunately, this also clears the refresh token.

This PR corrects that by retaining the refresh token when the access token expires, by stripping everything from the cache data except the refresh token, which can then be used to fetch a new access token.

### Testing

Manual testing in the playground, as well a new unit tests to cover this scenario.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
