### PR TITLE
[SDK-1291] Wrapped InMemoryCache implementation in a closure

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -27,7 +27,7 @@ const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
 
 const cacheFactory = location => {
   const builders = {
-    memory: () => new InMemoryCache(),
+    memory: () => new InMemoryCache().enclosedCache,
     localstorage: () => new LocalStorageCache()
   };
 


### PR DESCRIPTION
### Description

This PR wraps the in-memory cache implementation in a closure, to help mitigate a possible XSS attack by preventing direct access to the `cache` object inside the cache class.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
