### PR TITLE
No longer acquires a browser lock if there was a hit on the cache

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1073,18 +1073,13 @@ describe('Auth0', () => {
 
         expect(token).toBe(TEST_ACCESS_TOKEN);
       });
-      it('acquires and releases lock when there is a cache', async () => {
+      it('does not acquire a lock when the cache is available', async () => {
         const { auth0, cache, lock } = await setup();
         cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
 
         await auth0.getTokenSilently();
-        expect(lock.acquireLockMock).toHaveBeenCalledWith(
-          GET_TOKEN_SILENTLY_LOCK_KEY,
-          5000
-        );
-        expect(lock.releaseLockMock).toHaveBeenCalledWith(
-          GET_TOKEN_SILENTLY_LOCK_KEY
-        );
+
+        expect(lock.acquireLockMock).not.toHaveBeenCalled();
       });
       it('continues method execution when there is no cache available', async () => {
         const { auth0, utils } = await setup();

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -332,8 +332,6 @@ export default class Auth0Client {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
 
     try {
-      await lock.acquireLock(GET_TOKEN_SILENTLY_LOCK_KEY, 5000);
-
       if (!options.ignoreCache) {
         const cache = this.cache.get({
           scope: options.scope,
@@ -341,10 +339,11 @@ export default class Auth0Client {
         });
 
         if (cache) {
-          await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
           return cache.access_token;
         }
       }
+
+      await lock.acquireLock(GET_TOKEN_SILENTLY_LOCK_KEY, 5000);
 
       const stateIn = encodeState(createRandomString());
       const nonceIn = createRandomString();


### PR DESCRIPTION
### Description

This fixes the behaviour reported in #338 where getting an access token is still slow even though there's a cached value, because of the browser lock.

The primary purpose of the browser lock is to serialize calls to the authorization and token endpoints. If those calls aren't being made (i.e. because it can use a cached value) then we don't need to acquire a lock.

### References

Fixes #338 

### Testing

Fixed an existing test to ensure lock was not being acquired.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
