### PR TITLE
[SDK-1308] Return appState value on error from handleRedirectCallback

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -669,6 +669,7 @@ describe('Auth0', () => {
           queryResult.error_description
         );
       });
+
       it('throws AuthenticationError with state, error, error_description', async () => {
         const { auth0, utils } = await localSetup();
         const queryResult = {
@@ -691,6 +692,35 @@ describe('Auth0', () => {
           queryResult.error_description
         );
       });
+
+      it('throws AuthenticationError and includes the transation state', async () => {
+        const { auth0, utils, transactionManager } = await localSetup();
+
+        const appState = {
+          key: 'property'
+        };
+
+        transactionManager.get.mockReturnValue({ appState });
+
+        const queryResult = {
+          error: 'unauthorized',
+          error_description: 'Unauthorized user',
+          state: 'abcxyz'
+        };
+
+        utils.parseQueryResult.mockReturnValue(queryResult);
+
+        let errorThrown: AuthenticationError;
+
+        try {
+          await auth0.handleRedirectCallback();
+        } catch (error) {
+          errorThrown = error;
+        }
+
+        expect(errorThrown.appState).toEqual(appState);
+      });
+
       it('throws error when there is no transaction', async () => {
         const { auth0, transactionManager } = await localSetup();
         transactionManager.get.mockReturnValue(undefined);

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -693,7 +693,7 @@ describe('Auth0', () => {
         );
       });
 
-      it('throws AuthenticationError and includes the transation state', async () => {
+      it('throws AuthenticationError and includes the transaction state', async () => {
         const { auth0, utils, transactionManager } = await localSetup();
 
         const appState = {

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -28,7 +28,7 @@ describe('getTokenSilently', function() {
         );
         return win.auth0.getTokenSilently().then(() => {
           const parsedUrl = new URL(iframe.src);
-          shouldBe(parsedUrl.host, 'auth.brucke.club');
+          shouldBe(parsedUrl.host, 'brucke.auth0.com');
           const pageParams = decode(parsedUrl.search.substr(1));
           shouldBeUndefined(pageParams.code_verifier);
           shouldNotBeUndefined(pageParams.code_challenge);

--- a/cypress/integration/loginWithRedirect.js
+++ b/cypress/integration/loginWithRedirect.js
@@ -18,7 +18,7 @@ describe('loginWithRedirect', function() {
     cy.wait(2000);
     cy.url().then(url => {
       const parsedUrl = new URL(url);
-      shouldBe(parsedUrl.host, 'auth.brucke.club');
+      shouldBe(parsedUrl.host, 'brucke.auth0.com');
       const pageParams = decode(parsedUrl.search.substr(1));
       shouldBeUndefined(pageParams.code_verifier);
       shouldNotBeUndefined(pageParams.code_challenge);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -276,15 +276,20 @@ export default class Auth0Client {
     );
 
     const transaction = this.transactionManager.get(state);
-    const appState = transaction ? transaction.appState : null;
-
-    if (error) {
-      this.transactionManager.remove(state);
-      throw new AuthenticationError(error, error_description, state, appState);
-    }
 
     if (!transaction) {
       throw new Error('Invalid state');
+    }
+
+    if (error) {
+      this.transactionManager.remove(state);
+
+      throw new AuthenticationError(
+        error,
+        error_description,
+        state,
+        transaction.appState
+      );
     }
 
     this.transactionManager.remove(state);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -275,15 +275,18 @@ export default class Auth0Client {
       queryStringFragments.join('')
     );
 
+    const transaction = this.transactionManager.get(state);
+    const appState = transaction ? transaction.appState : null;
+
     if (error) {
       this.transactionManager.remove(state);
-      throw new AuthenticationError(error, error_description, state);
+      throw new AuthenticationError(error, error_description, state, appState);
     }
 
-    const transaction = this.transactionManager.get(state);
     if (!transaction) {
       throw new Error('Invalid state');
     }
+
     this.transactionManager.remove(state);
 
     const authResult = await oauthToken({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,8 @@ export class AuthenticationError extends Error {
   constructor(
     public error: string,
     public error_description: string,
-    public state: string
+    public state: string,
+    public appState: any = null
   ) {
     super(error_description);
     //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work

--- a/static/index.html
+++ b/static/index.html
@@ -25,7 +25,7 @@
     <script type="text/javascript">
       $(function() {
         createAuth0Client({
-          domain: 'auth.brucke.club',
+          domain: 'brucke.auth0.com',
           client_id: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp'
         })
           .then(function(auth0) {


### PR DESCRIPTION
### Description

This PR modifies the behaviour of `handleRedirectCallback` so that it returns any user-defined `appState` value in the error when an exception is thrown. This is so that, in the event that an error occurs thanks to a custom rule or similar, the application state can still be retrieved.

### References

This has been requested by a customer through an internal service desk ticket.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
