### PR TITLE
Configure CI build to store screenshots from integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,5 +12,11 @@ jobs:
       - run: npm run test:integration
       - run: npm run test:es-check
       - run: npm run print-bundle-size
+      - run:
+          name: Copy screenshots
+          command: |
+            ls ~/repo/cypress/screenshots
+            mkdir /tmp/screenshots
+            cp -R ~/repo/cypress/screenshots/*/*.png /tmp/screenshots
       - store_artifacts:
-          path: ~/repo/cypress/screenshots
+          path: /tmp/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,13 @@ jobs:
           name: Copy screenshots
           command: |
             mkdir /tmp/screenshots
-            cp -R ~/repo/cypress/screenshots/*/*.png ~/tmp/screenshots 2>/dev/null || :
+            cp -R ~/repo/cypress/screenshots/*/*.png /tmp/screenshots 2>/dev/null || :
       - run:
           name: Copy videos
           command: |
             mkdir /tmp/videos
-            cp -R ~/repo/cypress/videos/*.mp4 ~/tmp/videos 2>/dev/null || :
+            cp -R ~/repo/cypress/videos/*.mp4 /tmp/videos 2>/dev/null || :
       - store_artifacts:
-          path: /tmp
+          path: /tmp/screenshots
+      - store_artifacts:
+          path: /tmp/videos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,12 @@ jobs:
       - run:
           name: Copy screenshots
           command: |
-            ls ~/repo/cypress/screenshots
             mkdir /tmp/screenshots
-            cp -R ~/repo/cypress/screenshots/*/*.png /tmp/screenshots
+            cp -R ~/repo/cypress/screenshots/*/*.png ~/tmp/screenshots 2>/dev/null || :
+      - run:
+          name: Copy videos
+          command: |
+            mkdir /tmp/videos
+            cp -R ~/repo/cypress/videos/*.mp4 ~/tmp/videos 2>/dev/null || :
       - store_artifacts:
-          path: /tmp/screenshots
+          path: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,3 +12,5 @@ jobs:
       - run: npm run test:integration
       - run: npm run test:es-check
       - run: npm run print-bundle-size
+      - store_artifacts:
+        path: ~/repo/cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,4 @@ jobs:
       - run: npm run test:es-check
       - run: npm run print-bundle-size
       - store_artifacts:
-        path: ~/repo/cypress/screenshots
+          path: ~/repo/cypress/screenshots


### PR DESCRIPTION
### Description

This PR configures Circle to store screenshot output from integration tests to better debug integration problems when tests fail.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
