### PR TITLE
center popup over owner window

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -246,7 +246,7 @@ describe('utils', () => {
       expect(window.open).toHaveBeenCalledWith(
         '',
         'auth0:authorize:popup',
-        'left=100,top=100,width=400,height=600,resizable,scrollbars=yes,status=1'
+        'left=312,top=84,width=400,height=600,resizable,scrollbars=yes,status=1'
       );
     });
     it('throws error when the popup is blocked', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.5.0",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,10 +63,15 @@ export const runIframe = (
 };
 
 export const openPopup = () => {
+  const width = 400;
+  const height = 600;
+  const left = window.screenX + (window.innerWidth - width) / 2;
+  const top = window.screenY + (window.innerHeight - height) / 2;
+
   const popup = window.open(
     '',
     'auth0:authorize:popup',
-    'left=100,top=100,width=400,height=600,resizable,scrollbars=yes,status=1'
+    `left=${left},top=${top},width=${width},height=${height},resizable,scrollbars=yes,status=1`
   );
   if (!popup) {
     throw new Error('Could not open popup');


### PR DESCRIPTION
Center the popup used in `loginWithPopup` over the owning window.  Tested on Chrome, Firefox and Safari on OSX  Also tested on IOS Safari, the popup opened, but the login redirect after login failed - that said, this is failing on 1.7.0-beta.2 as well so I'm pretty sure that it's unrelated.

This mostly addresses https://github.com/auth0/auth0-spa-js/issues/307
