### PR TITLE
[SDK-1099] Add `localOnly` logout option

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1563,6 +1563,12 @@ describe('Auth0', () => {
       auth0.logout({ localOnly: false });
       expect(window.location.assign).toHaveBeenCalled();
     });
+    it('throws when both `options.localOnly` and `options.federated` are true', async () => {
+      const { auth0 } = await setup();
+
+      const fn = () => auth0.logout({ localOnly: true, federated: true });
+      expect(fn).toThrow();
+    });
   });
 });
 describe('default creation function', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1545,6 +1545,24 @@ describe('Auth0', () => {
         `https://test.auth0.com/v2/logout?query=params${TEST_TELEMETRY_QUERY_STRING}&federated`
       );
     });
+    it('removes `auth0.is.authenticated` key from storage when `options.localOnly` is true', async () => {
+      const { auth0, storage } = await setup();
+
+      auth0.logout({ localOnly: true });
+      expect(storage.remove).toHaveBeenCalledWith('auth0.is.authenticated');
+    });
+    it('skips `window.location.assign` when `options.localOnly` is true', async () => {
+      const { auth0 } = await setup();
+
+      auth0.logout({ localOnly: true });
+      expect(window.location.assign).not.toHaveBeenCalledWith();
+    });
+    it('calls `window.location.assign` when `options.localOnly` is false', async () => {
+      const { auth0 } = await setup();
+
+      auth0.logout({ localOnly: false });
+      expect(window.location.assign).toHaveBeenCalled();
+    });
   });
 });
 describe('default creation function', () => {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -490,6 +490,8 @@ export default class Auth0Client {
    * the parameters provided as arguments, to clear the Auth0 session.
    * If the `federated` option is specified it also clears the Identity Provider session.
    * If the `localOnly` option is specified, it only clears the application session.
+   * It is invalid to set both the `federated` and `localOnly` options to `true`,
+   * and an error will be thrown if you do.
    * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
    *
    * @param options
@@ -505,7 +507,7 @@ export default class Auth0Client {
 
     if (localOnly && federated) {
       throw new Error(
-        `Logging out of identity providers using the 'federated' option will not work when specifying a local logout using 'localOnly'`
+        'It is invalid to set both the `federated` and `localOnly` options to `true`'
       );
     }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -489,7 +489,7 @@ export default class Auth0Client {
    * Clears the application session and performs a redirect to `/v2/logout`, using
    * the parameters provided as arguments, to clear the Auth0 session.
    * If the `federated` option is specified it also clears the Identity Provider session.
-   * If the `localOnly` option is specified, only clears the application session.
+   * If the `localOnly` option is specified, it only clears the application session.
    * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
    *
    * @param options

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -498,7 +498,10 @@ export default class Auth0Client {
       delete options.client_id;
     }
     ClientStorage.remove('auth0.is.authenticated');
-    const { federated, ...logoutOptions } = options;
+    const { federated, localOnly, ...logoutOptions } = options;
+    if (localOnly) {
+      return;
+    }
     const federatedQuery = federated ? `&federated` : '';
     const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
     window.location.assign(`${url}${federatedQuery}`);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -486,8 +486,11 @@ export default class Auth0Client {
    * auth0.logout();
    * ```
    *
-   * Performs a redirect to `/v2/logout` using the parameters provided
-   * as arguments. [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
+   * Clears the application session and performs a redirect to `/v2/logout`, using
+   * the parameters provided as arguments, to clear the Auth0 session.
+   * If the `federated` option is specified it also clears the Identity Provider session.
+   * If the `localOnly` option is specified, only clears the application session.
+   * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
    *
    * @param options
    */
@@ -497,13 +500,24 @@ export default class Auth0Client {
     } else {
       delete options.client_id;
     }
-    ClientStorage.remove('auth0.is.authenticated');
+
     const { federated, localOnly, ...logoutOptions } = options;
+
+    if (localOnly && federated) {
+      throw new Error(
+        `Logging out of identity providers using the 'federated' option will not work when specifying a local logout using 'localOnly'`
+      );
+    }
+
+    ClientStorage.remove('auth0.is.authenticated');
+
     if (localOnly) {
       return;
     }
+
     const federatedQuery = federated ? `&federated` : '';
     const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
+
     window.location.assign(`${url}${federatedQuery}`);
   }
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -224,6 +224,12 @@ interface LogoutOptions {
    * [Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)
    */
   federated?: boolean;
+
+  /**
+   * When `true`, this skips the request to the logout endpoint on the authorization server,
+   * effectively performing a "local" logout of the application.
+   */
+  localOnly?: boolean;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -221,13 +221,16 @@ interface LogoutOptions {
    * When supported by the upstream identity provider,
    * forces the user to logout of their identity provider
    * and from Auth0.
+   * This option cannot be specified along with the `localOnly` option.
    * [Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)
    */
   federated?: boolean;
 
   /**
    * When `true`, this skips the request to the logout endpoint on the authorization server,
-   * effectively performing a "local" logout of the application.
+   * effectively performing a "local" logout of the application. No redirect should take place,
+   * you should update local logged in state.
+   * This option cannot be specified along with the `federated` option.
    */
   localOnly?: boolean;
 }


### PR DESCRIPTION
### Description

Add an option to the LogoutOptions object that would allow the developer to only perform a "local" logout of the application, suppressing the call to the logout endpoint on the authz server.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

~- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs~
- [x] All active GitHub checks for tests, formatting, and security are passing
