### PR TITLE
Updated stalebot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,9 +7,16 @@ daysUntilStale: 90
 daysUntilClose: 7
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+onlyLabels:
+  - "waiting for customer"
+  
+# Ignore issues in projects
+exemptProjects: true
 
-# Set to true to ignore issues with an assignee (defaults to false)
+# Ignore issues and PRs in milestones
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee
 exemptAssignees: true
 
 # Label to use when marking as stale

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,15 +1,15 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 90
+daysUntilStale: 30
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 daysUntilClose: 7
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 onlyLabels:
-  - "waiting for customer"
-  
+  - 'waiting for customer'
+
 # Ignore issues in projects
 exemptProjects: true
 


### PR DESCRIPTION
- Stalebot should only now act on those that are "waiting for customer"
- Stalebot should ignore issues on a project board
- Stalebot should ignore PRs in a milestone
- Reduced time to stale to 30 days

