### PR TITLE
Fix error in library type definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,7 @@ import 'promise-polyfill/src/polyfill';
 import 'fast-text-encoding';
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 
-// @ts-ignore
-import Auth0Client from './Auth0Client';
+import Auth0Client_ from './Auth0Client';
 import * as ClientStorage from './storage';
 import { Auth0ClientOptions } from './global';
 import { CACHE_LOCATION_MEMORY } from './constants';
@@ -26,7 +25,7 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
     options.scope = getUniqueScopes(options.scope, 'offline_access');
   }
 
-  const auth0 = new Auth0Client(options);
+  const auth0 = new Auth0Client_(options);
 
   if (
     auth0.cacheLocation === CACHE_LOCATION_MEMORY &&
@@ -44,4 +43,4 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
   return auth0;
 }
 
-export type Auth0Client = Auth0Client;
+export type Auth0Client = Auth0Client_;


### PR DESCRIPTION
### Description

`// @ts-ignore` comment is not preserved in the generated type definition, which means that library ships broken type definitions and consumers will get an error when they attempt to use it.

Reproduction:

```
$ npm i @auth0/auth0-spa-js@1.7.0-beta.3 typescript
$ cat index.ts
import c from '@auth0/auth0-spa-js';
$ ./node_modules/.bin/tsc --noEmit index.ts
node_modules/@auth0/auth0-spa-js/dist/typings/index.d.ts:9:8 - error TS2440: Import declaration conflicts with local declaration of 'Auth0Client'.

9 import Auth0Client from './Auth0Client';
         ~~~~~~~~~~~

Found 1 error.
```

### Testing

Reproduction above does not produce an error with this update. 

I guess a reasonable test to prevent such problems in the future would be to type check the type definition files before publishing.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`