### PR TITLE
[SDK-1125] createAuth0Client now throws errors that are not login_required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,9 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
       ignoreCache: true
     });
   } catch (error) {
-    // ignore
+    if (error.error !== 'login_required') {
+      throw error;
+    }
   }
   return auth0;
 }


### PR DESCRIPTION
### Description

Errors on start up thrown by `getTokenSilently` should be exposed if they are anything other than `login_required`. This may help diagnose configuration issues that might be difficult to debug if the developer has to wait 60 seconds to see them (thanks to the auth timeout when using an iframe and `response_mode: web_message`.

### References

Fixes #208 

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
