### PR TITLE
[SDK-1127] Delay removal of iframe to prevent Chrome hanging status bug #240

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -2,6 +2,24 @@ import Cache from '../src/cache';
 
 describe('cache', () => {
   let cache: Cache;
+  let OriginalDate: Date;
+
+  beforeEach(() => {
+    OriginalDate = (<any>global).Date;
+    (<any>global).Date = class {
+      time: number;
+      constructor(time: number) {
+        this.time = time;
+      }
+      getTime() {
+        return this.time || 0;
+      }
+    };
+  });
+  afterEach(() => {
+    (<any>global).Date = OriginalDate;
+  });
+
   beforeEach(() => {
     cache = new Cache();
     jest.useFakeTimers();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,4 +6,9 @@ export const DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS = 60;
 /**
  * @ignore
  */
+export const CLEANUP_IFRAME_TIMEOUT_IN_SECONDS = 2;
+
+/**
+ * @ignore
+ */
 export const DEFAULT_POPUP_CONFIG_OPTIONS: PopupConfigOptions = {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,9 @@
 import fetch from 'unfetch';
 
-import { DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS } from './constants';
+import {
+  DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
+  CLEANUP_IFRAME_TIMEOUT_IN_SECONDS
+} from './constants';
 
 const dedupe = arr => arr.filter((x, i) => arr.indexOf(x) === i);
 
@@ -54,7 +57,12 @@ export const runIframe = (
       e.data.response.error ? rej(e.data.response) : res(e.data.response);
       clearTimeout(timeoutSetTimeoutId);
       window.removeEventListener('message', iframeEventHandler, false);
-      window.document.body.removeChild(iframe);
+      // Delay the removal of the iframe to prevent hanging loading status
+      // in Chrome: https://github.com/auth0/auth0-spa-js/issues/240
+      setTimeout(
+        () => window.document.body.removeChild(iframe),
+        CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000
+      );
     };
     window.addEventListener('message', iframeEventHandler, false);
     window.document.body.appendChild(iframe);


### PR DESCRIPTION
### Description

Workaround for a Chrome browser bug where the loading status intermittently hangs when the `/authorize` iframe is removed in `getTokenSilently`

### References

- #240
- Also https://github.com/auth0/auth0.js/issues/1044

![Screenshot 2020-03-16 at 11 19 49](https://user-images.githubusercontent.com/1299658/76753617-ce1d8900-6778-11ea-8112-47b1b8244662.png)


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- ~[ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs~
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`

