### PR TITLE
Customize defaultScope used by auth0Client

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -183,6 +183,24 @@ describe('Auth0', () => {
         expect(e.error).toEqual('some_other_error');
       }
     });
+
+    it('should respect advanced defaultScope option when provided', async () => {
+      const { auth0, utils, cache } = await setup({
+        advancedOptions: { defaultScope: 'openid jaffa' }
+      });
+      await auth0.getIdTokenClaims({
+        audience: 'the-audience',
+        scope: 'the-scope'
+      });
+      expect(cache.get).toHaveBeenCalledWith({
+        audience: 'the-audience',
+        scope: TEST_SCOPES
+      });
+      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
+        'openid jaffa',
+        'the-scope'
+      );
+    });
   });
 
   describe('loginWithPopup()', () => {
@@ -315,7 +333,9 @@ describe('Auth0', () => {
     it('opens popup with correct popup, url and custom config', async () => {
       const { auth0, utils } = await setup();
       await auth0.loginWithPopup({}, { timeoutInSeconds: 1 });
-      expect(utils.runPopup).toHaveBeenCalledWith(
+      expect(
+        utils.runPopup
+      ).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         { timeoutInSeconds: 1 }
       );
@@ -324,7 +344,9 @@ describe('Auth0', () => {
     it('opens popup with correct popup, url and timeout from client options', async () => {
       const { auth0, utils } = await setup({ authorizeTimeoutInSeconds: 1 });
       await auth0.loginWithPopup({}, DEFAULT_POPUP_CONFIG_OPTIONS);
-      expect(utils.runPopup).toHaveBeenCalledWith(
+      expect(
+        utils.runPopup
+      ).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         { timeoutInSeconds: 1 }
       );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -18,7 +18,7 @@ import TransactionManager from './transaction-manager';
 import { verify as verifyIdToken } from './jwt';
 import { AuthenticationError } from './errors';
 import * as ClientStorage from './storage';
-import { DEFAULT_POPUP_CONFIG_OPTIONS } from './constants';
+import { DEFAULT_POPUP_CONFIG_OPTIONS, DEFAULT_SCOPE } from './constants';
 import version from './version';
 
 const lock = new Lock();
@@ -32,7 +32,7 @@ export default class Auth0Client {
   private transactionManager: TransactionManager;
   private domainUrl: string;
   private tokenIssuer: string;
-  private readonly DEFAULT_SCOPE = 'openid profile email';
+  private defaultScope: string;
 
   constructor(private options: Auth0ClientOptions) {
     this.cache = new Cache();
@@ -41,6 +41,10 @@ export default class Auth0Client {
     this.tokenIssuer = this.options.issuer
       ? `https://${this.options.issuer}/`
       : `${this.domainUrl}/`;
+    this.defaultScope =
+      this.options.advancedOptions && this.options.advancedOptions.defaultScope
+        ? this.options.advancedOptions.defaultScope
+        : DEFAULT_SCOPE;
   }
   private _url(path) {
     const telemetry = encodeURIComponent(
@@ -65,7 +69,7 @@ export default class Auth0Client {
       ...withoutDomain,
       ...authorizeOptions,
       scope: getUniqueScopes(
-        this.DEFAULT_SCOPE,
+        this.defaultScope,
         this.options.scope,
         authorizeOptions.scope
       ),
@@ -216,10 +220,10 @@ export default class Auth0Client {
   public async getUser(
     options: GetUserOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.defaultScope
     }
   ) {
-    options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
+    options.scope = getUniqueScopes(this.defaultScope, options.scope);
     const cache = this.cache.get(options);
     return cache && cache.decodedToken.user;
   }
@@ -236,10 +240,10 @@ export default class Auth0Client {
   public async getIdTokenClaims(
     options: getIdTokenClaimsOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.defaultScope
     }
   ) {
-    options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
+    options.scope = getUniqueScopes(this.defaultScope, options.scope);
     const cache = this.cache.get(options);
     return cache && cache.decodedToken.claims;
   }
@@ -345,11 +349,11 @@ export default class Auth0Client {
   public async getTokenSilently(
     options: GetTokenSilentlyOptions = {
       audience: this.options.audience,
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.defaultScope,
       ignoreCache: false
     }
   ) {
-    options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
+    options.scope = getUniqueScopes(this.defaultScope, options.scope);
 
     try {
       const {
@@ -455,12 +459,12 @@ export default class Auth0Client {
   public async getTokenWithPopup(
     options: GetTokenWithPopupOptions = {
       audience: this.options.audience,
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.defaultScope
     },
     config: PopupConfigOptions = DEFAULT_POPUP_CONFIG_OPTIONS
   ) {
     options.scope = getUniqueScopes(
-      this.DEFAULT_SCOPE,
+      this.defaultScope,
       this.options.scope,
       options.scope
     );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,8 @@ export const CLEANUP_IFRAME_TIMEOUT_IN_SECONDS = 2;
  * @ignore
  */
 export const DEFAULT_POPUP_CONFIG_OPTIONS: PopupConfigOptions = {};
+
+/**
+ * @ignore
+ */
+export const DEFAULT_SCOPE = 'openid profile email';

--- a/src/global.ts
+++ b/src/global.ts
@@ -40,7 +40,8 @@ interface BaseLoginOptions {
   acr_values?: string;
   /**
    * The default scope to be used on authentication requests.
-   * `openid profile email` is always added to all requests.
+   * The defaultScope defined in the Auth0Client is included
+   * along with this scope
    */
   scope?: string;
   /**
@@ -59,6 +60,14 @@ interface BaseLoginOptions {
    * make sure to use the original parameter name.
    */
   [key: string]: any;
+}
+
+interface AdvancedOptions {
+  /**
+   * The default scope to be included with all request.
+   * If not provided, 'openid profile email' is used.
+   */
+  defaultScope?: string;
 }
 
 interface Auth0ClientOptions extends BaseLoginOptions {
@@ -95,6 +104,11 @@ interface Auth0ClientOptions extends BaseLoginOptions {
    * Defaults to 60s.
    */
   authorizeTimeoutInSeconds?: number;
+
+  /**
+   * Changes to recommeded defaults, like defaultScope
+   */
+  advancedOptions?: AdvancedOptions;
 }
 
 /**


### PR DESCRIPTION
### Description

The library includes `'openid profile email'` as defaultScope and there is no way for devs to exclude these scopes. Some of our users have lot of unnecessary information in `profile` and their JWT tokens too big to fit in the `Authorization` header. We would like to have the flexibility to exclude some scopes, as we have with the auth0-lock.js.

The maintainers suggested that a `advancedScope.defaultScope` can be used to control defaultScope for cases like us but, keep the default behaviour for other devs. This is an acceptable solution to us and this PR implements the suggestion.
```
const auth0 = await createAuth0Client({
  client_id: 'cid',
  domain: 'domain.auth0.com',
  advancedOptions: {
    defaultScope: 'openid'
  }
})
```
The Docs should be changed to add this info.

### References
- https://github.com/auth0/auth0-spa-js/issues/228#issuecomment-595116426
- https://github.com/auth0/auth0-spa-js/issues/228#issuecomment-595123093

### Testing
A simple test is added, please see if thats enough https://github.com/srihari93/auth0-spa-js/blob/a2fc948757362de2bdb3d05f661cd6304fbaacc5/__tests__/index.test.ts#L187-L203

### Checklist
- [x] I have added documentation for new/changed functionality in this PR description
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
