### PR TITLE
Clean up temp files after running release process

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -47,4 +47,6 @@ const branch = process.argv[3];
   await exec('npm run docs');
 
   await writeChangelog(newVersion);
+
+  await exec('npm run release:clean');
 })();


### PR DESCRIPTION
This PR runs `release:clean` after running the﻿release script so that any temporary files are cleaned up. Currently, the developer would have to do this manually.

This is an oversight from when the automatic changelog script was taken from [`idtoken-verifier`](https://github.com/auth0/idtoken-verifier).
