### PR TITLE
Throw a proper exception on status 429

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -226,7 +226,6 @@ const switchFetch = async (url, opts, timeout, worker) => {
     if (response.status == 429) {
       return {
         ok: false,
-        status: response.status,
         json: {
           error: 'too_many_requests',
           error_description: 'Global rate limit exceeded'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,7 +224,8 @@ const switchFetch = async (url, opts, timeout, worker) => {
     const response = await fetch(url, opts);
     return {
       ok: response.ok,
-      json: await response.json()
+      json: await response.json(),
+      status: response.status
     };
   }
 };
@@ -280,8 +281,9 @@ const getJSON = async (url, timeout, options, worker) => {
   }
 
   const {
-    json: { error, error_description, status, ...success },
-    ok
+    json: { error, error_description, ...success },
+    ok,
+    status
   } = response;
 
   if (!ok) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,11 +280,17 @@ const getJSON = async (url, timeout, options, worker) => {
   }
 
   const {
-    json: { error, error_description, ...success },
+    json: { error, error_description, status, ...success },
     ok
   } = response;
 
   if (!ok) {
+    if (status === 429) {
+      const e = <any>new Error('too_many_requests');
+      e.error_description = 'Too Many Requests';
+      throw e;
+    }
+
     const errorMessage =
       error_description || `HTTP error. Unable to fetch ${url}`;
     const e = <any>new Error(errorMessage);


### PR DESCRIPTION
### Description

This adds throwing a specific exception when the rate limit is hit making it easier to implement backoff logic for calls to `getToken()`.

This is a quick/MVP1 solution, it would probably be best to check the content-type from the response and then do the JSON parsing, or just wrap it in try-catch. Please add your thoughts.

Something similar should be added to the request being triggered from the iframe as well, but I still need to look into that one. Any context or comments around that one would be appreciated.

### References

[Issue](https://github.com/auth0/auth0-spa-js/issues/396)

### Testing

Still need to add tests.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
