### PR TITLE
Fix case for 'consent_required' auth failure in createAuth0Client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export default async function createAuth0Client(options: Auth0ClientOptions) {
       ignoreCache: true
     });
   } catch (error) {
-    if (error.error !== 'login_required') {
+    if (error.error !== 'login_required' && error.error !== 'consent_required') {
       throw error;
     }
   }


### PR DESCRIPTION
### Description

createAuth0Client doesn't handle the 'consent_required' auth failure case and throws without returning a client instance. In general I think the whole code flow should be rethought as this function is doing two seemingly unrelated things: creating the client AND trying to authenticate silently. There's no clear way to indicate failure in one or either of those things failing.
A PR is attached with a proposed solution.

### Reproduction

If you are working locally on localhost on two different projects that use auth0 with different client_id on the same domain and one of them sets the auth0.is.authenticated flag to true when it authenticates, the other project may try to silent auth in createAuth0Client but it doesn't have consent yet, so it throws without returning a client.

### Environment

Library version 1.6.5
