### PR TITLE
Fix Jest warning on describe returning a Promise

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -315,7 +315,9 @@ describe('Auth0', () => {
     it('opens popup with correct popup, url and custom config', async () => {
       const { auth0, utils } = await setup();
       await auth0.loginWithPopup({}, { timeoutInSeconds: 1 });
-      expect(utils.runPopup).toHaveBeenCalledWith(
+      expect(
+        utils.runPopup
+      ).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         { timeoutInSeconds: 1 }
       );
@@ -324,7 +326,9 @@ describe('Auth0', () => {
     it('opens popup with correct popup, url and timeout from client options', async () => {
       const { auth0, utils } = await setup({ authorizeTimeoutInSeconds: 1 });
       await auth0.loginWithPopup({}, DEFAULT_POPUP_CONFIG_OPTIONS);
-      expect(utils.runPopup).toHaveBeenCalledWith(
+      expect(
+        utils.runPopup
+      ).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         { timeoutInSeconds: 1 }
       );
@@ -705,7 +709,7 @@ describe('Auth0', () => {
         'There are no query params available for parsing.'
       );
     });
-    describe('when there is a valid query string in the url', async () => {
+    describe('when there is a valid query string in the url', () => {
       const localSetup = async () => {
         window.history.pushState(
           {},
@@ -934,7 +938,7 @@ describe('Auth0', () => {
         });
       });
     });
-    describe('when there is a valid query string in a hash', async () => {
+    describe('when there is a valid query string in a hash', () => {
       const localSetup = async () => {
         window.history.pushState({}, 'Test', `/`);
         window.history.pushState(
@@ -1233,7 +1237,7 @@ describe('Auth0', () => {
     });
   });
   describe('getTokenSilently()', () => {
-    describe('when `options.ignoreCache` is false', async () => {
+    describe('when `options.ignoreCache` is false', () => {
       it('calls `cache.get` with the correct options', async () => {
         const { auth0, cache, utils } = await setup();
         cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
@@ -1532,7 +1536,7 @@ describe('Auth0', () => {
       });
     });
   });
-  describe('getTokenWithPopup()', async () => {
+  describe('getTokenWithPopup()', () => {
     const localSetup = async () => {
       const result = await setup();
       result.auth0.loginWithPopup = jest.fn();

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -58,7 +58,7 @@ const verifier = new IDTokenVerifier({
 });
 verifier.getRsaVerifier = (_, __, cb) => cb(null, { verify: () => true });
 
-describe('jwt', async () => {
+describe('jwt', () => {
   it('decodes correctly', () => {
     const id_token =
       'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp0cnVlLCJpYXQiOjE1NTEzNjIzOTAsImV4cCI6MTU1MTM2NTk5MCwiYXVkIjoiazV1M28yZmlBQThYd2VYRUVYNjA0S0N3Q2p6anRNVTYiLCJpc3MiOiJodHRwczovL2JydWNrZS5hdXRoMC5jb20vIn0.MeU2xC4qwr6JvYeDjCRbzT78mvugpVcSlkoGqRsA-ig-JUHuKMsBO1mNgsilRaxulf_zEl-XktKpq9IisamKSRe1UeboESXsZ02nbZqP5i0X4pdYnTI9Z51Iuet2GAJqPDTMpyj-BA0yiROd1X3Ot91_Fh1ZU7EyZmYdoyJrx_Cue1ituMMIWBk1JOs6rMKy1xVCFoDk20upQzf5Xuy2oGtaRhrQzz5sdRR9Y5yxEN5kzcHrGVaZ_fLMYkUDF_aKv4PTFU-I-0HpP_-4PtcjTUJpeXDK_7BzpA6fAdnqaRTl6iYgNKl7R19_8QfQpoTkeJBmZ7HxW_13s03G5jNLSg';


### PR DESCRIPTION
### Description

Hi guys!
Last time I contributed to this library I noticed a few warnings while running the test suite with Jest, and I promised myself to open a PR to fix the issue, so...here it is 😃 
In detail, I removed all async keyword from `describe ` functions 'cause returning a Promise from "describe" is not supported.

### References

- [Stack overflow issue](https://stackoverflow.com/questions/56640062/returning-a-promise-from-describe-is-not-supported-tests-must-be-defined-sync)
- [Jest Jasmin2 reference](https://github.com/facebook/jest/blob/master/packages/jest-jasmine2/src/jasmine/Env.ts#L433)

### Checklist

- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
