### PR TITLE
Add the Auth0Client type to the package interface

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -5,8 +5,7 @@ jest.mock('../src/cache');
 jest.mock('../src/transaction-manager');
 jest.mock('../src/utils');
 
-import Auth0Client from '../src/Auth0Client';
-import createAuth0Client from '../src/index';
+import createAuth0Client, { Auth0Client } from '../src/index';
 import { AuthenticationError } from '../src/errors';
 import version from '../src/version';
 const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
@@ -315,7 +314,9 @@ describe('Auth0', () => {
     it('opens popup with correct popup, url and custom config', async () => {
       const { auth0, utils } = await setup();
       await auth0.loginWithPopup({}, { timeoutInSeconds: 1 });
-      expect(utils.runPopup).toHaveBeenCalledWith(
+      expect(
+        utils.runPopup
+      ).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         { timeoutInSeconds: 1 }
       );
@@ -324,7 +325,9 @@ describe('Auth0', () => {
     it('opens popup with correct popup, url and timeout from client options', async () => {
       const { auth0, utils } = await setup({ authorizeTimeoutInSeconds: 1 });
       await auth0.loginWithPopup({}, DEFAULT_POPUP_CONFIG_OPTIONS);
-      expect(utils.runPopup).toHaveBeenCalledWith(
+      expect(
+        utils.runPopup
+      ).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         { timeoutInSeconds: 1 }
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ import * as ClientStorage from './storage';
 import './global';
 import { validateCrypto } from './utils';
 
+// export the return type of the createAuth0Client factory
+export { Auth0Client };
+
 export default async function createAuth0Client(options: Auth0ClientOptions) {
   validateCrypto();
 


### PR DESCRIPTION
### Description

This PR add the Auth0Client type to the package interface.

### References

https://github.com/auth0/auth0-spa-js/issues/416

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
