### PR TITLE
Add logoutSilently

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -41,7 +41,7 @@ describe('InMemoryCache', () => {
       cache.get({
         client_id: 'test-client',
         audience: 'a',
-        scope: 's'
+        scope: 's',
       })
     ).toBeUndefined();
   });
@@ -58,10 +58,10 @@ describe('InMemoryCache', () => {
         claims: {
           __raw: 'idtoken',
           exp: nowSeconds() + dayInSeconds,
-          name: 'Test'
+          name: 'Test',
         },
-        user: { name: 'Test' }
-      }
+        user: { name: 'Test' },
+      },
     };
 
     cache.save(data);
@@ -70,7 +70,7 @@ describe('InMemoryCache', () => {
       cache.get({
         client_id: 'test-client',
         audience: 'the_audience',
-        scope: 'the_scope'
+        scope: 'the_scope',
       })
     ).toStrictEqual(data);
   });
@@ -92,10 +92,10 @@ describe('InMemoryCache', () => {
           claims: {
             __raw: 'idtoken',
             name: 'Test',
-            exp: nowSeconds() + dayInSeconds * 2
+            exp: nowSeconds() + dayInSeconds * 2,
           },
-          user: { name: 'Test' }
-        }
+          user: { name: 'Test' },
+        },
       };
 
       cache.save(data);
@@ -103,7 +103,7 @@ describe('InMemoryCache', () => {
       const cacheEntry = {
         client_id: 'test-client',
         audience: 'the_audience',
-        scope: 'the_scope'
+        scope: 'the_scope',
       };
 
       // Test that the cache state is normal up until just before the expiry time..
@@ -114,7 +114,7 @@ describe('InMemoryCache', () => {
       global.Date.now = dateNowStub;
 
       expect(cache.get(cacheEntry)).toStrictEqual({
-        refresh_token: 'refreshtoken'
+        refresh_token: 'refreshtoken',
       });
 
       global.Date.now = realDateNow;
@@ -136,10 +136,10 @@ describe('InMemoryCache', () => {
         claims: {
           __raw: 'idtoken',
           name: 'Test',
-          exp: nowSeconds() + dayInSeconds * 2
+          exp: nowSeconds() + dayInSeconds * 2,
         },
-        user: { name: 'Test' }
-      }
+        user: { name: 'Test' },
+      },
     };
 
     cache.save(data);
@@ -147,7 +147,7 @@ describe('InMemoryCache', () => {
     const cacheEntry = {
       client_id: 'test-client',
       audience: 'the_audience',
-      scope: 'the_scope'
+      scope: 'the_scope',
     };
 
     // Test that the cache state is normal before we expire the data
@@ -178,10 +178,10 @@ describe('InMemoryCache', () => {
         claims: {
           __raw: 'idtoken',
           name: 'Test',
-          exp: nowSeconds() + dayInSeconds
+          exp: nowSeconds() + dayInSeconds,
         },
-        user: { name: 'Test' }
-      }
+        user: { name: 'Test' },
+      },
     };
 
     cache.save(data);
@@ -189,7 +189,7 @@ describe('InMemoryCache', () => {
     const cacheEntry = {
       client_id: 'test-client',
       audience: 'the_audience',
-      scope: 'the_scope'
+      scope: 'the_scope',
     };
 
     // Test that the cache state is normal before we expire the data
@@ -236,10 +236,10 @@ describe('LocalStorageCache', () => {
         claims: {
           __raw: 'idtoken',
           exp: nowSeconds() + dayInSeconds + 100,
-          name: 'Test'
+          name: 'Test',
         },
-        user: { name: 'Test' }
-      }
+        user: { name: 'Test' },
+      },
     };
   });
 
@@ -255,7 +255,7 @@ describe('LocalStorageCache', () => {
         '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
         JSON.stringify({
           body: defaultEntry,
-          expiresAt: nowSeconds() + dayInSeconds
+          expiresAt: nowSeconds() + dayInSeconds,
         })
       );
 
@@ -263,7 +263,7 @@ describe('LocalStorageCache', () => {
         cache.get({
           client_id: '__TEST_CLIENT_ID__',
           audience: '__TEST_AUDIENCE__',
-          scope: '__TEST_SCOPE__'
+          scope: '__TEST_SCOPE__',
         })
       ).toStrictEqual(defaultEntry);
     });
@@ -288,12 +288,12 @@ describe('LocalStorageCache', () => {
               claims: {
                 __raw: 'idtoken',
                 exp: nowSeconds() + 15,
-                name: 'Test'
+                name: 'Test',
               },
-              user: { name: 'Test' }
-            }
+              user: { name: 'Test' },
+            },
           },
-          expiresAt: nowSeconds() + 10
+          expiresAt: nowSeconds() + 10,
         })
       );
 
@@ -304,10 +304,10 @@ describe('LocalStorageCache', () => {
         cache.get({
           client_id: '__TEST_CLIENT_ID__',
           audience: '__TEST_AUDIENCE__',
-          scope: '__TEST_SCOPE__'
+          scope: '__TEST_SCOPE__',
         })
       ).toStrictEqual({
-        refresh_token: '__REFRESH_TOKEN__'
+        refresh_token: '__REFRESH_TOKEN__',
       });
     });
   });
@@ -327,12 +327,12 @@ describe('LocalStorageCache', () => {
             claims: {
               __raw: 'idtoken',
               exp: nowSeconds() + 15,
-              name: 'Test'
+              name: 'Test',
             },
-            user: { name: 'Test' }
-          }
+            user: { name: 'Test' },
+          },
         },
-        expiresAt: nowSeconds() + 10
+        expiresAt: nowSeconds() + 10,
       })
     );
 
@@ -343,7 +343,7 @@ describe('LocalStorageCache', () => {
       cache.get({
         client_id: '__TEST_CLIENT_ID__',
         audience: '__TEST_AUDIENCE__',
-        scope: '__TEST_SCOPE__'
+        scope: '__TEST_SCOPE__',
       })
     ).toBeUndefined();
 
@@ -360,7 +360,7 @@ describe('LocalStorageCache', () => {
         '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
         JSON.stringify({
           body: defaultEntry,
-          expiresAt: nowSeconds() + dayInSeconds - 60
+          expiresAt: nowSeconds() + dayInSeconds - 60,
         })
       );
     });
@@ -370,9 +370,9 @@ describe('LocalStorageCache', () => {
         expires_in: dayInSeconds + 100,
         decodedToken: {
           claims: {
-            exp: nowSeconds() + 100
-          }
-        }
+            exp: nowSeconds() + 100,
+          },
+        },
       });
 
       cache.save(entry);
@@ -381,7 +381,7 @@ describe('LocalStorageCache', () => {
         '@@auth0spajs@@::__TEST_CLIENT_ID__::__TEST_AUDIENCE__::__TEST_SCOPE__',
         JSON.stringify({
           body: entry,
-          expiresAt: nowSeconds() + 40
+          expiresAt: nowSeconds() + 40,
         })
       );
     });
@@ -392,7 +392,7 @@ describe('LocalStorageCache', () => {
       'some-key',
       '@@auth0spajs@@::key-1',
       'some-key-2',
-      '@@auth0spajs@@::key-2'
+      '@@auth0spajs@@::key-2',
     ];
 
     for (const key of keys) {
@@ -408,28 +408,5 @@ describe('LocalStorageCache', () => {
     expect(localStorage.removeItem).toHaveBeenCalledWith(
       '@@auth0spajs@@::key-2'
     );
-  });
-  it('deletes key correctly', () => {
-    cache.save({
-      audience: 'the_audiene',
-      scope: 'the_scope',
-      id_token: 'idtoken',
-      access_token: 'accesstoken',
-      expires_in: 2,
-      decodedToken: {
-        claims: {
-          __raw: 'idtoken',
-          name: 'Test',
-          exp: new Date().getTime() / 1000 + 1
-        },
-        user: { name: 'Test' }
-      }
-    });
-    expect(Object.keys(cache.cache).length).toBe(1);
-    cache.delete({
-      audience: 'the_audiene',
-      scope: 'the_scope'
-    });
-    expect(Object.keys(cache.cache).length).toBe(0);
   });
 });

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -409,4 +409,27 @@ describe('LocalStorageCache', () => {
       '@@auth0spajs@@::key-2'
     );
   });
+  it('deletes key correctly', () => {
+    cache.save({
+      audience: 'the_audiene',
+      scope: 'the_scope',
+      id_token: 'idtoken',
+      access_token: 'accesstoken',
+      expires_in: 2,
+      decodedToken: {
+        claims: {
+          __raw: 'idtoken',
+          name: 'Test',
+          exp: new Date().getTime() / 1000 + 1
+        },
+        user: { name: 'Test' }
+      }
+    });
+    expect(Object.keys(cache.cache).length).toBe(1);
+    cache.delete({
+      audience: 'the_audiene',
+      scope: 'the_scope'
+    });
+    expect(Object.keys(cache.cache).length).toBe(0);
+  });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -13,12 +13,12 @@ import {
   urlDecodeB64,
   getCrypto,
   getCryptoSubtle,
-  validateCrypto
+  validateCrypto,
 } from '../src/utils';
 
 import {
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
-  DEFAULT_SILENT_TOKEN_RETRY_COUNT
+  DEFAULT_SILENT_TOKEN_RETRY_COUNT,
 } from '../src/constants';
 
 (<any>global).TextEncoder = TextEncoder;
@@ -45,7 +45,7 @@ describe('utils', () => {
         parseQueryResult('value=test&otherValue=another-test')
       ).toMatchObject({
         value: 'test',
-        otherValue: 'another-test'
+        otherValue: 'another-test',
       });
     });
     it('strips off hash values', () => {
@@ -53,13 +53,13 @@ describe('utils', () => {
         parseQueryResult('code=some-code&state=some-state#__')
       ).toMatchObject({
         code: 'some-code',
-        state: 'some-state'
+        state: 'some-state',
       });
     });
     it('converts `expires_in` to int', () => {
       expect(parseQueryResult('value=test&expires_in=10')).toMatchObject({
         value: 'test',
-        expires_in: 10
+        expires_in: 10,
       });
     });
   });
@@ -70,7 +70,7 @@ describe('utils', () => {
           id: 1,
           value: 'test',
           url: 'http://example.com',
-          nope: undefined
+          nope: undefined,
         })
       ).toBe('id=1&value=test&url=http%3A%2F%2Fexample.com');
     });
@@ -79,7 +79,7 @@ describe('utils', () => {
     let oldATOB;
     beforeEach(() => {
       oldATOB = (<any>global).atob;
-      (<any>global).atob = jest.fn(s => s);
+      (<any>global).atob = jest.fn((s) => s);
     });
     afterEach(() => {
       (<any>global).atob = oldATOB;
@@ -96,7 +96,7 @@ describe('utils', () => {
       // then we convert the percent encodings into raw bytes which
       // can be fed into btoa.
       // https://stackoverflow.com/questions/30106476/
-      const b64EncodeUnicode = str =>
+      const b64EncodeUnicode = (str) =>
         btoa(
           encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, p1) =>
             String.fromCharCode(<any>('0x' + p1))
@@ -112,7 +112,7 @@ describe('utils', () => {
     let oldBTOA;
     beforeEach(() => {
       oldBTOA = (<any>global).btoa;
-      (<any>global).btoa = jest.fn(s => s);
+      (<any>global).btoa = jest.fn((s) => s);
     });
     afterEach(() => {
       (<any>global).btoa = oldBTOA;
@@ -128,13 +128,13 @@ describe('utils', () => {
   describe('createRandomString', () => {
     it('creates random string based on crypto.getRandomValues', () => {
       (<any>global).crypto = {
-        getRandomValues: () => [1, 5, 10, 15, 100]
+        getRandomValues: () => [1, 5, 10, 15, 100],
       };
       expect(createRandomString()).toBe('15AFY');
     });
     it('creates random string with a length between 43 and 128', () => {
       (<any>global).crypto = {
-        getRandomValues: (a: Uint8Array) => Array(a.length).fill(0)
+        getRandomValues: (a: Uint8Array) => Array(a.length).fill(0),
       };
       const result = createRandomString();
       expect(result.length).toBeGreaterThanOrEqual(43);
@@ -158,9 +158,9 @@ describe('utils', () => {
           digest: jest.fn((alg, encoded) => {
             expect(alg).toMatchObject({ name: 'SHA-256' });
             expect(Array.from(encoded)).toMatchObject([116, 101, 115, 116]);
-            return new Promise(res => res(true));
-          })
-        }
+            return new Promise((res) => res(true));
+          }),
+        },
       };
       const result = await sha256('test');
       expect(result).toBe(true);
@@ -169,18 +169,18 @@ describe('utils', () => {
       (<any>global).msCrypto = {};
 
       const digestResult = {
-        oncomplete: null
+        oncomplete: null,
       };
 
       (<any>global).crypto = {
         subtle: {
           digest: jest.fn(() => {
             return digestResult;
-          })
-        }
+          }),
+        },
       };
 
-      const sha = sha256('test').then(r => {
+      const sha = sha256('test').then((r) => {
         expect(r).toBe(true);
       });
 
@@ -192,18 +192,18 @@ describe('utils', () => {
       (<any>global).msCrypto = {};
 
       const digestResult = {
-        onerror: null
+        onerror: null,
       };
 
       (<any>global).crypto = {
         subtle: {
           digest: jest.fn(() => {
             return digestResult;
-          })
-        }
+          }),
+        },
       };
 
-      const sha = sha256('test').catch(e => {
+      const sha = sha256('test').catch((e) => {
         expect(e).toBe('An error occurred');
       });
 
@@ -216,18 +216,18 @@ describe('utils', () => {
       (<any>global).msCrypto = {};
 
       const digestResult = {
-        onabort: null
+        onabort: null,
       };
 
       (<any>global).crypto = {
         subtle: {
           digest: jest.fn(() => {
             return digestResult;
-          })
-        }
+          }),
+        },
       };
 
-      const sha = sha256('test').catch(e => {
+      const sha = sha256('test').catch((e) => {
         expect(e).toBe('The digest operation was aborted');
       });
 
@@ -264,8 +264,8 @@ describe('utils', () => {
 
     it('calls oauth/token with the correct url', async () => {
       mockUnfetch.mockReturnValue(
-        new Promise(res =>
-          res({ ok: true, json: () => new Promise(ress => ress(true)) })
+        new Promise((res) =>
+          res({ ok: true, json: () => new Promise((ress) => ress(true)) })
         )
       );
 
@@ -274,7 +274,7 @@ describe('utils', () => {
         baseUrl: 'https://test.com',
         client_id: 'client_idIn',
         code: 'codeIn',
-        code_verifier: 'code_verifierIn'
+        code_verifier: 'code_verifierIn',
       });
 
       expect(mockUnfetch).toBeCalledWith('https://test.com/oauth/token', {
@@ -282,7 +282,7 @@ describe('utils', () => {
           '{"redirect_uri":"http://localhost","grant_type":"authorization_code","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
         headers: { 'Content-type': 'application/json' },
         method: 'POST',
-        signal: abortController.signal
+        signal: abortController.signal,
       });
 
       expect(mockUnfetch.mock.calls[0][1].signal).not.toBeUndefined();
@@ -291,14 +291,14 @@ describe('utils', () => {
     it('handles error with error response', async () => {
       const theError = {
         error: 'the-error',
-        error_description: 'the-error-description'
+        error_description: 'the-error-description',
       };
 
       mockUnfetch.mockReturnValue(
-        new Promise(res =>
+        new Promise((res) =>
           res({
             ok: false,
-            json: () => new Promise(ress => ress(theError))
+            json: () => new Promise((ress) => ress(theError)),
           })
         )
       );
@@ -308,7 +308,7 @@ describe('utils', () => {
           baseUrl: 'https://test.com',
           client_id: 'client_idIn',
           code: 'codeIn',
-          code_verifier: 'code_verifierIn'
+          code_verifier: 'code_verifierIn',
         });
       } catch (error) {
         expect(error.message).toBe(theError.error_description);
@@ -319,10 +319,10 @@ describe('utils', () => {
 
     it('handles error without error response', async () => {
       mockUnfetch.mockReturnValue(
-        new Promise(res =>
+        new Promise((res) =>
           res({
             ok: false,
-            json: () => new Promise(ress => ress(false))
+            json: () => new Promise((ress) => ress(false)),
           })
         )
       );
@@ -332,7 +332,7 @@ describe('utils', () => {
           baseUrl: 'https://test.com',
           client_id: 'client_idIn',
           code: 'codeIn',
-          code_verifier: 'code_verifierIn'
+          code_verifier: 'code_verifierIn',
         });
       } catch (error) {
         expect(error.message).toBe(
@@ -357,7 +357,7 @@ describe('utils', () => {
           baseUrl: 'https://test.com',
           client_id: 'client_idIn',
           code: 'codeIn',
-          code_verifier: 'code_verifierIn'
+          code_verifier: 'code_verifierIn',
         });
       } catch (error) {
         expect(error.message).toBe('Network failure');
@@ -379,7 +379,7 @@ describe('utils', () => {
         .mockReturnValue(
           Promise.resolve({
             ok: true,
-            json: () => Promise.resolve({ access_token: 'access-token' })
+            json: () => Promise.resolve({ access_token: 'access-token' }),
           })
         );
 
@@ -387,7 +387,7 @@ describe('utils', () => {
         baseUrl: 'https://test.com',
         client_id: 'client_idIn',
         code: 'codeIn',
-        code_verifier: 'code_verifierIn'
+        code_verifier: 'code_verifierIn',
       });
 
       expect(result.access_token).toBe('access-token');
@@ -402,7 +402,7 @@ describe('utils', () => {
             () =>
               resolve({
                 ok: true,
-                json: () => Promise.resolve({ access_token: 'access-token' })
+                json: () => Promise.resolve({ access_token: 'access-token' }),
               }),
             500
           );
@@ -416,7 +416,7 @@ describe('utils', () => {
           client_id: 'client_idIn',
           code: 'codeIn',
           code_verifier: 'code_verifierIn',
-          timeout: 100
+          timeout: 100,
         });
       } catch (e) {
         expect(e.message).toBe("Timeout when executing 'fetch'");
@@ -428,7 +428,7 @@ describe('utils', () => {
     it('retries the request in the event of a timeout', async () => {
       const fetchResult = {
         ok: true,
-        json: () => Promise.resolve({ access_token: 'access-token' })
+        json: () => Promise.resolve({ access_token: 'access-token' }),
       };
 
       mockUnfetch.mockReturnValueOnce(
@@ -444,7 +444,7 @@ describe('utils', () => {
         client_id: 'client_idIn',
         code: 'codeIn',
         code_verifier: 'code_verifierIn',
-        timeout: 500
+        timeout: 500,
       });
 
       expect(result.access_token).toBe('access-token');
@@ -458,10 +458,10 @@ describe('utils', () => {
 
     const url = 'https://authorize.com';
 
-    const setup = customMessage => {
+    const setup = (customMessage) => {
       const popup = {
         location: { href: url },
-        close: jest.fn()
+        close: jest.fn(),
       };
 
       window.addEventListener = <any>jest.fn((message, callback) => {
@@ -474,7 +474,7 @@ describe('utils', () => {
 
     describe('with invalid messages', () => {
       ['', {}, { data: 'test' }, { data: { type: 'other-type' } }].forEach(
-        m => {
+        (m) => {
           it(`ignores invalid messages: ${JSON.stringify(m)}`, async () => {
             const { popup, url } = setup(m);
             /**
@@ -500,8 +500,8 @@ describe('utils', () => {
       const message = {
         data: {
           type: 'authorization_response',
-          response: { id_token: 'id_token' }
-        }
+          response: { id_token: 'id_token' },
+        },
       };
 
       const { popup, url } = setup(message);
@@ -518,8 +518,8 @@ describe('utils', () => {
       const message = {
         data: {
           type: 'authorization_response',
-          response: { error: 'error' }
-        }
+          response: { error: 'error' },
+        },
       };
 
       const { popup, url } = setup(message);
@@ -551,7 +551,7 @@ describe('utils', () => {
       await expect(
         runPopup(url, {
           timeoutInSeconds: seconds,
-          popup
+          popup,
         })
       ).rejects.toMatchObject({ ...TIMEOUT_ERROR, popup });
 
@@ -583,8 +583,8 @@ describe('utils', () => {
       const message = {
         data: {
           type: 'authorization_response',
-          response: { id_token: 'id_token' }
-        }
+          response: { id_token: 'id_token' },
+        },
       };
 
       const { popup, url } = setup(message);
@@ -604,10 +604,10 @@ describe('utils', () => {
   });
   describe('runIframe', () => {
     const TIMEOUT_ERROR = { error: 'timeout', error_description: 'Timeout' };
-    const setup = customMessage => {
+    const setup = (customMessage) => {
       const iframe = {
         setAttribute: jest.fn(),
-        style: { display: '' }
+        style: { display: '' },
       };
       const url = 'https://authorize.com';
       const origin =
@@ -617,7 +617,7 @@ describe('utils', () => {
         callback(customMessage);
       });
       window.removeEventListener = jest.fn();
-      window.document.createElement = <any>jest.fn(type => {
+      window.document.createElement = <any>jest.fn((type) => {
         expect(type).toBe('iframe');
         return iframe;
       });
@@ -633,8 +633,8 @@ describe('utils', () => {
         source: { close: jest.fn() },
         data: {
           type: 'authorization_response',
-          response: { id_token: 'id_token' }
-        }
+          response: { id_token: 'id_token' },
+        },
       };
       const { iframe, url } = setup(message);
       jest.useFakeTimers();
@@ -646,7 +646,7 @@ describe('utils', () => {
       expect(iframe.setAttribute.mock.calls).toMatchObject([
         ['width', '0'],
         ['height', '0'],
-        ['src', url]
+        ['src', url],
       ]);
       expect(iframe.style.display).toBe('none');
     });
@@ -656,8 +656,8 @@ describe('utils', () => {
         {},
         { origin: 'other-origin' },
         { data: 'test' },
-        { data: { type: 'other-type' } }
-      ].forEach(m => {
+        { data: { type: 'other-type' } },
+      ].forEach((m) => {
         it(`ignores invalid messages: ${JSON.stringify(m)}`, async () => {
           const { iframe, url, origin } = setup(m);
           jest.useFakeTimers();
@@ -675,8 +675,8 @@ describe('utils', () => {
         source: { close: jest.fn() },
         data: {
           type: 'authorization_response',
-          response: { id_token: 'id_token' }
-        }
+          response: { id_token: 'id_token' },
+        },
       };
       const { iframe, url } = setup(message);
       jest.useFakeTimers();
@@ -694,8 +694,8 @@ describe('utils', () => {
         source: { close: jest.fn() },
         data: {
           type: 'authorization_response',
-          response: { error: 'error' }
-        }
+          response: { error: 'error' },
+        },
       };
       const { iframe, url } = setup(message);
       jest.useFakeTimers();
@@ -767,8 +767,7 @@ describe('utils', () => {
 
       expect(validateCrypto).toThrowError(`
       auth0-spa-js must run on a secure origin.
-      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin 
-      for more information.
+      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin for more information.
     `);
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.7.0-beta.5",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -11,7 +11,7 @@ import {
   sha256,
   bufferToBase64UrlEncoded,
   oauthToken,
-  validateCrypto,
+  validateCrypto
 } from './utils';
 
 import { InMemoryCache, ICache, LocalStorageCache } from './cache';
@@ -23,7 +23,7 @@ import {
   CACHE_LOCATION_MEMORY,
   DEFAULT_POPUP_CONFIG_OPTIONS,
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
-  MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
+  MISSING_REFRESH_TOKEN_ERROR_MESSAGE
 } from './constants';
 import version from './version';
 import {
@@ -39,9 +39,10 @@ import {
   GetTokenSilentlyOptions,
   GetTokenWithPopupOptions,
   LogoutOptions,
+  LogoutSilentlyOptions,
   RefreshTokenOptions,
   OAuthTokenOptions,
-  CacheLocation,
+  CacheLocation
 } from './global';
 
 // @ts-ignore
@@ -62,7 +63,7 @@ const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
  */
 const cacheLocationBuilders = {
   memory: () => new InMemoryCache().enclosedCache,
-  localstorage: () => new LocalStorageCache(),
+  localstorage: () => new LocalStorageCache()
 };
 
 /**
@@ -131,7 +132,7 @@ export default class Auth0Client {
       btoa(
         JSON.stringify({
           name: 'auth0-spa-js',
-          version: version,
+          version: version
         })
       )
     );
@@ -167,7 +168,7 @@ export default class Auth0Client {
       nonce,
       redirect_uri: redirect_uri || this.options.redirect_uri,
       code_challenge,
-      code_challenge_method: 'S256',
+      code_challenge_method: 'S256'
     };
   }
   private _authorizeUrl(authorizeOptions: AuthorizeOptions) {
@@ -180,7 +181,7 @@ export default class Auth0Client {
       id_token,
       nonce,
       leeway: this.options.leeway,
-      max_age: this._parseNumber(this.options.max_age),
+      max_age: this._parseNumber(this.options.max_age)
     });
   }
   private _parseNumber(value: any): number {
@@ -230,7 +231,7 @@ export default class Auth0Client {
       appState,
       scope: params.scope,
       audience: params.audience || 'default',
-      redirect_uri: params.redirect_uri,
+      redirect_uri: params.redirect_uri
     });
 
     return url + fragment;
@@ -273,7 +274,7 @@ export default class Auth0Client {
 
     const url = this._authorizeUrl({
       ...params,
-      response_mode: 'web_message',
+      response_mode: 'web_message'
     });
 
     const codeResult = await runPopup(url, {
@@ -281,7 +282,7 @@ export default class Auth0Client {
       timeoutInSeconds:
         config.timeoutInSeconds ||
         this.options.authorizeTimeoutInSeconds ||
-        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
+        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
     });
 
     if (stateIn !== codeResult.state) {
@@ -295,7 +296,7 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri,
+        redirect_uri: params.redirect_uri
       } as OAuthTokenOptions,
       this.worker
     );
@@ -307,12 +308,14 @@ export default class Auth0Client {
       decodedToken,
       scope: params.scope,
       audience: params.audience || 'default',
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     };
 
     this.cache.save(cacheEntry);
 
-    ClientStorage.save('auth0.is.authenticated', true, { daysUntilExpire: 1 });
+    ClientStorage.save('auth0.is.authenticated', true, {
+      daysUntilExpire: 1
+    });
   }
 
   /**
@@ -328,14 +331,14 @@ export default class Auth0Client {
   public async getUser(
     options: GetUserOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.DEFAULT_SCOPE
     }
   ) {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
-      ...options,
+      ...options
     });
 
     return cache && cache.decodedToken && cache.decodedToken.user;
@@ -353,7 +356,7 @@ export default class Auth0Client {
   public async getIdTokenClaims(
     options: GetIdTokenClaimsOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.DEFAULT_SCOPE
     }
   ) {
     options.scope = getUniqueScopes(
@@ -364,7 +367,7 @@ export default class Auth0Client {
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
-      ...options,
+      ...options
     });
 
     return cache && cache.decodedToken && cache.decodedToken.claims;
@@ -427,7 +430,7 @@ export default class Auth0Client {
       client_id: this.options.client_id,
       code_verifier: transaction.code_verifier,
       grant_type: 'authorization_code',
-      code,
+      code
     } as OAuthTokenOptions;
 
     // some old versions of the SDK might not have added redirect_uri to the
@@ -448,15 +451,17 @@ export default class Auth0Client {
       decodedToken,
       audience: transaction.audience,
       scope: transaction.scope,
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     };
 
     this.cache.save(cacheEntry);
 
-    ClientStorage.save('auth0.is.authenticated', true, { daysUntilExpire: 1 });
+    ClientStorage.save('auth0.is.authenticated', true, {
+      daysUntilExpire: 1
+    });
 
     return {
-      appState: transaction.appState,
+      appState: transaction.appState
     };
   }
 
@@ -495,7 +500,7 @@ export default class Auth0Client {
         options.scope
       ),
       ignoreCache: false,
-      ...options,
+      ...options
     };
 
     try {
@@ -503,7 +508,7 @@ export default class Auth0Client {
         const cache = this.cache.get({
           scope: getTokenOptions.scope,
           audience: getTokenOptions.audience || 'default',
-          client_id: this.options.client_id,
+          client_id: this.options.client_id
         });
 
         if (cache && cache.access_token) {
@@ -521,10 +526,13 @@ export default class Auth0Client {
           ? await this._getTokenUsingRefreshToken(getTokenOptions)
           : await this._getTokenFromIFrame(getTokenOptions);
 
-      this.cache.save({ client_id: this.options.client_id, ...authResult });
+      this.cache.save({
+        client_id: this.options.client_id,
+        ...authResult
+      });
 
       ClientStorage.save('auth0.is.authenticated', true, {
-        daysUntilExpire: 1,
+        daysUntilExpire: 1
       });
 
       return authResult.access_token;
@@ -549,7 +557,7 @@ export default class Auth0Client {
   public async getTokenWithPopup(
     options: GetTokenWithPopupOptions = {
       audience: this.options.audience,
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.DEFAULT_SCOPE
     },
     config: PopupConfigOptions = DEFAULT_POPUP_CONFIG_OPTIONS
   ) {
@@ -564,7 +572,7 @@ export default class Auth0Client {
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     });
 
     return cache.access_token;
@@ -649,7 +657,7 @@ export default class Auth0Client {
     const url = this._authorizeUrl({
       ...params,
       prompt: 'none',
-      response_mode: 'web_message',
+      response_mode: 'web_message'
     });
 
     const timeout =
@@ -667,7 +675,7 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri,
+        redirect_uri: params.redirect_uri
       } as OAuthTokenOptions,
       this.worker
     );
@@ -678,8 +686,57 @@ export default class Auth0Client {
       ...tokenResult,
       decodedToken,
       scope: params.scope,
-      audience: params.audience || 'default',
+      audience: params.audience || 'default'
     };
+  }
+
+  /**
+   * ```js
+   * auth0.logout();
+   * ```
+   *
+   * Clears the application session and performs a redirect to `/v2/logout`, using
+   * the parameters provided as arguments, to clear the Auth0 session.
+   * If the `federated` option is specified it also clears the Identity Provider session.
+   * If the `localOnly` option is specified, it only clears the application session.
+   * It is invalid to set both the `federated` and `localOnly` options to `true`,
+   * and an error will be thrown if you do.
+   * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
+   *
+   * @param options
+   */
+  public async logoutSilently(options: LogoutSilentlyOptions) {
+    const {
+      federated,
+      localOnly,
+      timeoutInSeconds,
+      audience,
+      scope,
+      ...logoutOptions
+    } = options;
+
+    if (localOnly && federated) {
+      throw new Error(
+        'It is invalid to set both the `federated` and `localOnly` options to `true`'
+      );
+    }
+
+    ClientStorage.remove('auth0.is.authenticated');
+
+    if (localOnly) {
+      return;
+    }
+
+    const federatedQuery = federated ? `&federated` : '';
+    const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
+
+    await runIframe(
+      `${url}${federatedQuery}`,
+      this.domainUrl,
+      timeoutInSeconds || this.options.logoutTimeoutInSeconds
+    );
+
+    this.cache.clear();
   }
 
   private async _getTokenUsingRefreshToken(
@@ -694,7 +751,7 @@ export default class Auth0Client {
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     });
 
     // If you don't have a refresh token in memory
@@ -717,7 +774,7 @@ export default class Auth0Client {
           client_id: this.options.client_id,
           grant_type: 'refresh_token',
           refresh_token: cache && cache.refresh_token,
-          redirect_uri,
+          redirect_uri
         } as RefreshTokenOptions,
         this.worker
       );
@@ -735,7 +792,7 @@ export default class Auth0Client {
       ...tokenResult,
       decodedToken,
       scope: options.scope,
-      audience: options.audience || 'default',
+      audience: options.audience || 'default'
     };
   }
 }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -11,7 +11,7 @@ import {
   sha256,
   bufferToBase64UrlEncoded,
   oauthToken,
-  validateCrypto
+  validateCrypto,
 } from './utils';
 
 import { InMemoryCache, ICache, LocalStorageCache } from './cache';
@@ -23,7 +23,7 @@ import {
   CACHE_LOCATION_MEMORY,
   DEFAULT_POPUP_CONFIG_OPTIONS,
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
-  MISSING_REFRESH_TOKEN_ERROR_MESSAGE
+  MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
 } from './constants';
 import version from './version';
 import {
@@ -42,7 +42,7 @@ import {
   LogoutSilentlyOptions,
   RefreshTokenOptions,
   OAuthTokenOptions,
-  CacheLocation
+  CacheLocation,
 } from './global';
 
 // @ts-ignore
@@ -63,7 +63,7 @@ const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
  */
 const cacheLocationBuilders = {
   memory: () => new InMemoryCache().enclosedCache,
-  localstorage: () => new LocalStorageCache()
+  localstorage: () => new LocalStorageCache(),
 };
 
 /**
@@ -132,7 +132,7 @@ export default class Auth0Client {
       btoa(
         JSON.stringify({
           name: 'auth0-spa-js',
-          version: version
+          version: version,
         })
       )
     );
@@ -168,7 +168,7 @@ export default class Auth0Client {
       nonce,
       redirect_uri: redirect_uri || this.options.redirect_uri,
       code_challenge,
-      code_challenge_method: 'S256'
+      code_challenge_method: 'S256',
     };
   }
   private _authorizeUrl(authorizeOptions: AuthorizeOptions) {
@@ -181,7 +181,7 @@ export default class Auth0Client {
       id_token,
       nonce,
       leeway: this.options.leeway,
-      max_age: this._parseNumber(this.options.max_age)
+      max_age: this._parseNumber(this.options.max_age),
     });
   }
   private _parseNumber(value: any): number {
@@ -231,7 +231,7 @@ export default class Auth0Client {
       appState,
       scope: params.scope,
       audience: params.audience || 'default',
-      redirect_uri: params.redirect_uri
+      redirect_uri: params.redirect_uri,
     });
 
     return url + fragment;
@@ -274,7 +274,7 @@ export default class Auth0Client {
 
     const url = this._authorizeUrl({
       ...params,
-      response_mode: 'web_message'
+      response_mode: 'web_message',
     });
 
     const codeResult = await runPopup(url, {
@@ -282,7 +282,7 @@ export default class Auth0Client {
       timeoutInSeconds:
         config.timeoutInSeconds ||
         this.options.authorizeTimeoutInSeconds ||
-        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
+        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
     });
 
     if (stateIn !== codeResult.state) {
@@ -296,7 +296,7 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri
+        redirect_uri: params.redirect_uri,
       } as OAuthTokenOptions,
       this.worker
     );
@@ -308,13 +308,13 @@ export default class Auth0Client {
       decodedToken,
       scope: params.scope,
       audience: params.audience || 'default',
-      client_id: this.options.client_id
+      client_id: this.options.client_id,
     };
 
     this.cache.save(cacheEntry);
 
     ClientStorage.save('auth0.is.authenticated', true, {
-      daysUntilExpire: 1
+      daysUntilExpire: 1,
     });
   }
 
@@ -331,14 +331,14 @@ export default class Auth0Client {
   public async getUser(
     options: GetUserOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.DEFAULT_SCOPE,
     }
   ) {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
-      ...options
+      ...options,
     });
 
     return cache && cache.decodedToken && cache.decodedToken.user;
@@ -356,7 +356,7 @@ export default class Auth0Client {
   public async getIdTokenClaims(
     options: GetIdTokenClaimsOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.DEFAULT_SCOPE,
     }
   ) {
     options.scope = getUniqueScopes(
@@ -367,7 +367,7 @@ export default class Auth0Client {
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
-      ...options
+      ...options,
     });
 
     return cache && cache.decodedToken && cache.decodedToken.claims;
@@ -430,7 +430,7 @@ export default class Auth0Client {
       client_id: this.options.client_id,
       code_verifier: transaction.code_verifier,
       grant_type: 'authorization_code',
-      code
+      code,
     } as OAuthTokenOptions;
 
     // some old versions of the SDK might not have added redirect_uri to the
@@ -451,17 +451,17 @@ export default class Auth0Client {
       decodedToken,
       audience: transaction.audience,
       scope: transaction.scope,
-      client_id: this.options.client_id
+      client_id: this.options.client_id,
     };
 
     this.cache.save(cacheEntry);
 
     ClientStorage.save('auth0.is.authenticated', true, {
-      daysUntilExpire: 1
+      daysUntilExpire: 1,
     });
 
     return {
-      appState: transaction.appState
+      appState: transaction.appState,
     };
   }
 
@@ -500,7 +500,7 @@ export default class Auth0Client {
         options.scope
       ),
       ignoreCache: false,
-      ...options
+      ...options,
     };
 
     try {
@@ -508,7 +508,7 @@ export default class Auth0Client {
         const cache = this.cache.get({
           scope: getTokenOptions.scope,
           audience: getTokenOptions.audience || 'default',
-          client_id: this.options.client_id
+          client_id: this.options.client_id,
         });
 
         if (cache && cache.access_token) {
@@ -528,11 +528,11 @@ export default class Auth0Client {
 
       this.cache.save({
         client_id: this.options.client_id,
-        ...authResult
+        ...authResult,
       });
 
       ClientStorage.save('auth0.is.authenticated', true, {
-        daysUntilExpire: 1
+        daysUntilExpire: 1,
       });
 
       return authResult.access_token;
@@ -557,7 +557,7 @@ export default class Auth0Client {
   public async getTokenWithPopup(
     options: GetTokenWithPopupOptions = {
       audience: this.options.audience,
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.DEFAULT_SCOPE,
     },
     config: PopupConfigOptions = DEFAULT_POPUP_CONFIG_OPTIONS
   ) {
@@ -572,7 +572,7 @@ export default class Auth0Client {
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',
-      client_id: this.options.client_id
+      client_id: this.options.client_id,
     });
 
     return cache.access_token;
@@ -635,6 +635,35 @@ export default class Auth0Client {
     window.location.assign(`${url}${federatedQuery}`);
   }
 
+  /**
+   * ```js
+   * auth0.logoutSilently();
+   * ```
+   *
+   * Clears the application session by opening an iframe to /v2/logout without redirecting, using
+   * the parameters provided as arguments, to clear the Auth0 session.
+   * If the `federated` option is specified it also clears the Identity Provider session.
+   * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
+   *
+   * @param options
+   */
+  public async logoutSilently(options: LogoutSilentlyOptions = {}) {
+    const { federated, timeoutInSeconds, ...logoutOptions } = options;
+
+    ClientStorage.remove('auth0.is.authenticated');
+
+    const federatedQuery = federated ? `&federated` : '';
+    const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
+
+    await runIframe(
+      `${url}${federatedQuery}`,
+      this.domainUrl,
+      timeoutInSeconds || this.options.logoutTimeoutInSeconds
+    );
+
+    this.cache.clear();
+  }
+
   private async _getTokenFromIFrame(
     options: GetTokenSilentlyOptions
   ): Promise<any> {
@@ -657,7 +686,7 @@ export default class Auth0Client {
     const url = this._authorizeUrl({
       ...params,
       prompt: 'none',
-      response_mode: 'web_message'
+      response_mode: 'web_message',
     });
 
     const timeout =
@@ -675,7 +704,7 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri
+        redirect_uri: params.redirect_uri,
       } as OAuthTokenOptions,
       this.worker
     );
@@ -686,57 +715,8 @@ export default class Auth0Client {
       ...tokenResult,
       decodedToken,
       scope: params.scope,
-      audience: params.audience || 'default'
+      audience: params.audience || 'default',
     };
-  }
-
-  /**
-   * ```js
-   * auth0.logout();
-   * ```
-   *
-   * Clears the application session and performs a redirect to `/v2/logout`, using
-   * the parameters provided as arguments, to clear the Auth0 session.
-   * If the `federated` option is specified it also clears the Identity Provider session.
-   * If the `localOnly` option is specified, it only clears the application session.
-   * It is invalid to set both the `federated` and `localOnly` options to `true`,
-   * and an error will be thrown if you do.
-   * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
-   *
-   * @param options
-   */
-  public async logoutSilently(options: LogoutSilentlyOptions) {
-    const {
-      federated,
-      localOnly,
-      timeoutInSeconds,
-      audience,
-      scope,
-      ...logoutOptions
-    } = options;
-
-    if (localOnly && federated) {
-      throw new Error(
-        'It is invalid to set both the `federated` and `localOnly` options to `true`'
-      );
-    }
-
-    ClientStorage.remove('auth0.is.authenticated');
-
-    if (localOnly) {
-      return;
-    }
-
-    const federatedQuery = federated ? `&federated` : '';
-    const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
-
-    await runIframe(
-      `${url}${federatedQuery}`,
-      this.domainUrl,
-      timeoutInSeconds || this.options.logoutTimeoutInSeconds
-    );
-
-    this.cache.clear();
   }
 
   private async _getTokenUsingRefreshToken(
@@ -751,7 +731,7 @@ export default class Auth0Client {
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',
-      client_id: this.options.client_id
+      client_id: this.options.client_id,
     });
 
     // If you don't have a refresh token in memory
@@ -774,7 +754,7 @@ export default class Auth0Client {
           client_id: this.options.client_id,
           grant_type: 'refresh_token',
           refresh_token: cache && cache.refresh_token,
-          redirect_uri
+          redirect_uri,
         } as RefreshTokenOptions,
         this.worker
       );
@@ -792,7 +772,7 @@ export default class Auth0Client {
       ...tokenResult,
       decodedToken,
       scope: options.scope,
-      audience: options.audience || 'default'
+      audience: options.audience || 'default',
     };
   }
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -110,6 +110,12 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * Defaults to 60s.
    */
   authorizeTimeoutInSeconds?: number;
+
+  /**
+   * A maximum number of seconds to wait before declaring background calls to /logout as failed for timeout
+   * Defaults to 60s.
+   */
+  logoutTimeoutInSeconds?: number;
 }
 
 /**
@@ -241,24 +247,7 @@ export interface GetTokenSilentlyOptions {
 
 export interface GetTokenWithPopupOptions extends PopupLoginOptions {}
 
-export interface LogoutOptions {
-  /**
-   * The URL where Auth0 will redirect your browser to after the logout.
-   *
-   * > Note that if the `client_id` parameter is included, the
-   * `returnTo` URL that is provided must be listed in the
-   * Application's "Allowed Logout URLs" in the Auth0 dashboard.
-   * However, if the `client_id` parameter is not included, the
-   * `returnTo` URL must be listed in the "Allowed Logout URLs" at
-   * the account level in the Auth0 dashboard.
-   */
-  returnTo?: string;
-
-  /**
-   * The `client_id` of your application.
-   */
-  client_id?: string;
-
+export interface CommonLogoutOptions {
   /**
    * When supported by the upstream identity provider,
    * forces the user to logout of their identity provider
@@ -276,7 +265,39 @@ export interface LogoutOptions {
    */
   localOnly?: boolean;
 }
+export interface LogoutOptions extends CommonLogoutOptions {
+  /**
+   * The URL where Auth0 will redirect your browser to after the logout.
+   *
+   * > Note that if the `client_id` parameter is included, the
+   * `returnTo` URL that is provided must be listed in the
+   * Application's "Allowed Logout URLs" in the Auth0 dashboard.
+   * However, if the `client_id` parameter is not included, the
+   * `returnTo` URL must be listed in the "Allowed Logout URLs" at
+   * the account level in the Auth0 dashboard.
+   */
+  returnTo?: string;
 
+  /**
+   * The `client_id` of your application.
+   */
+  client_id?: string;
+}
+export interface LogoutSilentlyOptions extends CommonLogoutOptions {
+  /**
+   * A maximum number of seconds to wait before declaring the background /authorize call as failed for timeout
+   * Defaults to 60s.
+   */
+  timeoutInSeconds?: number;
+  /**
+   * The scope to clear from the local cache
+   */
+  scope?: string;
+  /**
+   * The audience to clear from the local cache
+   */
+  audience?: string;
+}
 /**
  * @ignore
  */

--- a/src/global.ts
+++ b/src/global.ts
@@ -256,7 +256,9 @@ export interface CommonLogoutOptions {
    * [Read more about how federated logout works at Auth0](https://auth0.com/docs/logout/guides/logout-idps)
    */
   federated?: boolean;
+}
 
+export interface LogoutOptions extends CommonLogoutOptions {
   /**
    * When `true`, this skips the request to the logout endpoint on the authorization server,
    * effectively performing a "local" logout of the application. No redirect should take place,
@@ -264,8 +266,7 @@ export interface CommonLogoutOptions {
    * This option cannot be specified along with the `federated` option.
    */
   localOnly?: boolean;
-}
-export interface LogoutOptions extends CommonLogoutOptions {
+
   /**
    * The URL where Auth0 will redirect your browser to after the logout.
    *
@@ -283,21 +284,15 @@ export interface LogoutOptions extends CommonLogoutOptions {
    */
   client_id?: string;
 }
+
 export interface LogoutSilentlyOptions extends CommonLogoutOptions {
   /**
    * A maximum number of seconds to wait before declaring the background /authorize call as failed for timeout
    * Defaults to 60s.
    */
   timeoutInSeconds?: number;
-  /**
-   * The scope to clear from the local cache
-   */
-  scope?: string;
-  /**
-   * The audience to clear from the local cache
-   */
-  audience?: string;
 }
+
 /**
  * @ignore
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,17 +3,17 @@ import fetch from 'unfetch';
 import {
   AuthenticationResult,
   PopupConfigOptions,
-  TokenEndpointOptions
+  TokenEndpointOptions,
 } from './global';
 
 import {
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
   DEFAULT_SILENT_TOKEN_RETRY_COUNT,
   DEFAULT_FETCH_TIMEOUT_MS,
-  CLEANUP_IFRAME_TIMEOUT_IN_SECONDS
+  CLEANUP_IFRAME_TIMEOUT_IN_SECONDS,
 } from './constants';
 
-const dedupe = arr => arr.filter((x, i) => arr.indexOf(x) === i);
+const dedupe = (arr) => arr.filter((x, i) => arr.indexOf(x) === i);
 
 const TIMEOUT_ERROR = { error: 'timeout', error_description: 'Timeout' };
 
@@ -21,9 +21,7 @@ export const createAbortController = () => new AbortController();
 
 export const getUniqueScopes = (...scopes: string[]) => {
   const scopeString = scopes.filter(Boolean).join();
-  return dedupe(scopeString.replace(/\s/g, ',').split(','))
-    .join(' ')
-    .trim();
+  return dedupe(scopeString.replace(/\s/g, ',').split(',')).join(' ').trim();
 };
 
 export const parseQueryResult = (queryString: string) => {
@@ -34,14 +32,14 @@ export const parseQueryResult = (queryString: string) => {
   let queryParams = queryString.split('&');
 
   let parsedQuery: any = {};
-  queryParams.forEach(qp => {
+  queryParams.forEach((qp) => {
     let [key, val] = qp.split('=');
     parsedQuery[key] = decodeURIComponent(val);
   });
 
   return <AuthenticationResult>{
     ...parsedQuery,
-    expires_in: parseInt(parsedQuery.expires_in)
+    expires_in: parseInt(parsedQuery.expires_in),
   };
 };
 
@@ -55,7 +53,7 @@ export const runIframe = (
     iframe.setAttribute('width', '0');
     iframe.setAttribute('height', '0');
     iframe.style.display = 'none';
-    
+
     const removeIframe = () => {
       if (window.document.body.contains(iframe)) {
         window.document.body.removeChild(iframe);
@@ -67,22 +65,19 @@ export const runIframe = (
       removeIframe();
     }, timeoutInSeconds * 1000);
 
-    const iframeEventHandler = function(e: MessageEvent) {
+    const iframeEventHandler = function (e: MessageEvent) {
       if (e.origin != eventOrigin) return;
       if (!e.data || e.data.type !== 'authorization_response') return;
       const eventSource = e.source;
       if (eventSource) {
-          (<any>eventSource).close();
+        (<any>eventSource).close();
       }
       e.data.response.error ? rej(e.data.response) : res(e.data.response);
       clearTimeout(timeoutSetTimeoutId);
       window.removeEventListener('message', iframeEventHandler, false);
       // Delay the removal of the iframe to prevent hanging loading status
       // in Chrome: https://github.com/auth0/auth0-spa-js/issues/240
-      setTimeout(
-        removeIframe,
-        CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000
-      );
+      setTimeout(removeIframe, CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000);
     };
     window.addEventListener('message', iframeEventHandler, false);
     window.document.body.appendChild(iframe);
@@ -90,7 +85,7 @@ export const runIframe = (
   });
 };
 
-const openPopup = url => {
+const openPopup = (url) => {
   const width = 400;
   const height = 600;
   const left = window.screenX + (window.innerWidth - width) / 2;
@@ -120,7 +115,7 @@ export const runPopup = (authorizeUrl: string, config: PopupConfigOptions) => {
     const timeoutId = setTimeout(() => {
       reject({ ...TIMEOUT_ERROR, popup });
     }, (config.timeoutInSeconds || DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS) * 1000);
-    window.addEventListener('message', e => {
+    window.addEventListener('message', (e) => {
       if (!e.data || e.data.type !== 'authorization_response') {
         return;
       }
@@ -141,7 +136,7 @@ export const createRandomString = () => {
   const randomValues = Array.from(
     getCrypto().getRandomValues(new Uint8Array(43))
   );
-  randomValues.forEach(v => (random += charset[v % charset.length]));
+  randomValues.forEach((v) => (random += charset[v % charset.length]));
   return random;
 };
 
@@ -150,8 +145,8 @@ export const decode = (value: string) => atob(value);
 
 export const createQueryParams = (params: any) => {
   return Object.keys(params)
-    .filter(k => typeof params[k] !== 'undefined')
-    .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
+    .filter((k) => typeof params[k] !== 'undefined')
+    .map((k) => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
     .join('&');
 };
 
@@ -170,7 +165,7 @@ export const sha256 = async (s: string) => {
   // or reject depending on their intention.
   if ((<any>window).msCrypto) {
     return new Promise((res, rej) => {
-      digestOp.oncomplete = e => {
+      digestOp.oncomplete = (e) => {
         res(e.target.result);
       };
 
@@ -193,11 +188,11 @@ const urlEncodeB64 = (input: string) => {
 };
 
 // https://stackoverflow.com/questions/30106476/
-const decodeB64 = input =>
+const decodeB64 = (input) =>
   decodeURIComponent(
     atob(input)
       .split('')
-      .map(c => {
+      .map((c) => {
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
       })
       .join('')
@@ -206,7 +201,7 @@ const decodeB64 = input =>
 export const urlDecodeB64 = (input: string) =>
   decodeB64(input.replace(/_/g, '/').replace(/-/g, '+'));
 
-export const bufferToBase64UrlEncoded = input => {
+export const bufferToBase64UrlEncoded = (input) => {
   const ie11SafeInput = new Uint8Array(input);
   return urlEncodeB64(
     window.btoa(String.fromCharCode(...Array.from(ie11SafeInput)))
@@ -214,9 +209,9 @@ export const bufferToBase64UrlEncoded = input => {
 };
 
 const sendMessage = (message, to) =>
-  new Promise(function(resolve, reject) {
+  new Promise(function (resolve, reject) {
     const messageChannel = new MessageChannel();
-    messageChannel.port1.onmessage = function(event) {
+    messageChannel.port1.onmessage = function (event) {
       // Only for fetch errors, as these get retried
       if (event.data.error) {
         reject(new Error(event.data.error));
@@ -236,7 +231,7 @@ const switchFetch = async (url, opts, timeout, worker) => {
     const response = await fetch(url, opts);
     return {
       ok: response.ok,
-      json: await response.json()
+      json: await response.json(),
     };
   }
 };
@@ -252,7 +247,7 @@ const fetchWithTimeout = (
 
   const fetchOptions = {
     ...options,
-    signal
+    signal,
   };
 
   // The promise will resolve with one of these two promises (the fetch or the timeout), whichever completes first.
@@ -263,7 +258,7 @@ const fetchWithTimeout = (
         controller.abort();
         reject(new Error("Timeout when executing 'fetch'"));
       }, timeout);
-    })
+    }),
   ]);
 };
 
@@ -290,7 +285,7 @@ const getJSON = async (url, timeout, options, worker) => {
 
   const {
     json: { error, error_description, ...success },
-    ok
+    ok,
   } = response;
 
   if (!ok) {
@@ -318,11 +313,11 @@ export const oauthToken = async (
       method: 'POST',
       body: JSON.stringify({
         redirect_uri: window.location.origin,
-        ...options
+        ...options,
       }),
       headers: {
-        'Content-type': 'application/json'
-      }
+        'Content-type': 'application/json',
+      },
     },
     worker
   );
@@ -347,8 +342,7 @@ export const validateCrypto = () => {
   if (typeof getCryptoSubtle() === 'undefined') {
     throw new Error(`
       auth0-spa-js must run on a secure origin.
-      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin
-      for more information.
+      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin for more information.
     `);
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -347,7 +347,7 @@ export const validateCrypto = () => {
   if (typeof getCryptoSubtle() === 'undefined') {
     throw new Error(`
       auth0-spa-js must run on a secure origin.
-      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin 
+      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin
       for more information.
     `);
   }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds logoutSilently(), which behaves the same as logout(), but uses runIframe instead of setting window.location to log out.

It also adds cache.delete() to remove a token from the local cache.

I modeled tests on a combination of getTokenSilently and logout.

Feel free to edit this directly if you need to.

### References

Fixes: #308 

### Testing

Call logoutSilently, instead of logout, and confirm that cookies, local storage and cache are cleared as expected.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
