### PR TITLE
Fix leaking windows message event listener

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -854,9 +854,7 @@ describe('utils', () => {
       (<any>global).crypto = {};
 
       expect(validateCrypto).toThrowError(`
-      auth0-spa-js must run on a secure origin.
-      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin 
-      for more information.
+      auth0-spa-js must run on a secure origin. See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin for more information.
     `);
     });
   });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -793,6 +793,7 @@ describe('utils', () => {
       jest.runAllTimers();
       expect(message.source.close).toHaveBeenCalled();
       expect(window.document.body.removeChild).toHaveBeenCalledWith(iframe);
+      expect(window.removeEventListener).toBeCalled();
     });
     it('times out after timeoutInSeconds', async () => {
       const { iframe, url, origin } = setup('');
@@ -802,6 +803,15 @@ describe('utils', () => {
       jest.runTimersToTime(seconds * 1000);
       await expect(promise).rejects.toMatchObject(TIMEOUT_ERROR);
       expect(window.document.body.removeChild).toHaveBeenCalledWith(iframe);
+    });
+    it('removes the message event listener in the event of a timeout', async () => {
+      const { url, origin } = setup('');
+      const seconds = 10;
+      jest.useFakeTimers();
+      const promise = runIframe(url, origin, seconds);
+      jest.runTimersToTime(seconds * 1000);
+      await expect(promise).rejects.toMatchObject(TIMEOUT_ERROR);
+      expect(window.removeEventListener).toBeCalled();
     });
   });
   describe('getCrypto', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,15 +51,15 @@ export const runIframe = (
     const removeIframe = () => {
       if (window.document.body.contains(iframe)) {
         window.document.body.removeChild(iframe);
+        window.removeEventListener('message', iframeEventHandler, false);
       }
     };
 
-    let iframeEventHandler;
+    let iframeEventHandler: (e: MessageEvent) => void;
 
     const timeoutSetTimeoutId = setTimeout(() => {
       rej(new TimeoutError());
       removeIframe();
-      window.removeEventListener('message', iframeEventHandler, false);
     }, timeoutInSeconds * 1000);
 
     iframeEventHandler = function (e: MessageEvent) {
@@ -77,12 +77,12 @@ export const runIframe = (
         : res(e.data.response);
 
       clearTimeout(timeoutSetTimeoutId);
-      window.removeEventListener('message', iframeEventHandler, false);
 
       // Delay the removal of the iframe to prevent hanging loading status
       // in Chrome: https://github.com/auth0/auth0-spa-js/issues/240
       setTimeout(removeIframe, CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000);
     };
+
     window.addEventListener('message', iframeEventHandler, false);
     window.document.body.appendChild(iframe);
     iframe.setAttribute('src', authorizeUrl);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export const runIframe = (
   timeoutInSeconds: number = DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
 ) => {
   return new Promise<AuthenticationResult>((res, rej) => {
-    let iframe = window.document.createElement('iframe');
+    const iframe = window.document.createElement('iframe');
 
     iframe.setAttribute('width', '0');
     iframe.setAttribute('height', '0');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,7 +139,7 @@ export const runPopup = (authorizeUrl: string, config: PopupConfigOptions) => {
       resolve(e.data.response);
     };
 
-    window.addEventListener('message', e => popupEventListener);
+    window.addEventListener('message', e => popupEventListener(e));
   });
 };
 
@@ -386,9 +386,7 @@ export const validateCrypto = () => {
   }
   if (typeof getCryptoSubtle() === 'undefined') {
     throw new Error(`
-      auth0-spa-js must run on a secure origin.
-      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin
-      for more information.
+      auth0-spa-js must run on a secure origin. See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin for more information.
     `);
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,8 @@ export const runIframe = (
   timeoutInSeconds: number = DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
 ) => {
   return new Promise<AuthenticationResult>((res, rej) => {
-    const iframe = window.document.createElement('iframe');
+    let iframe = window.document.createElement('iframe');
+
     iframe.setAttribute('width', '0');
     iframe.setAttribute('height', '0');
     iframe.style.display = 'none';
@@ -53,23 +54,31 @@ export const runIframe = (
       }
     };
 
+    let iframeEventHandler;
+
     const timeoutSetTimeoutId = setTimeout(() => {
       rej(new TimeoutError());
       removeIframe();
+      window.removeEventListener('message', iframeEventHandler, false);
     }, timeoutInSeconds * 1000);
 
-    const iframeEventHandler = function (e: MessageEvent) {
+    iframeEventHandler = function (e: MessageEvent) {
       if (e.origin != eventOrigin) return;
       if (!e.data || e.data.type !== 'authorization_response') return;
+
       const eventSource = e.source;
+
       if (eventSource) {
         (eventSource as any).close();
       }
+
       e.data.response.error
         ? rej(GenericError.fromPayload(e.data.response))
         : res(e.data.response);
+
       clearTimeout(timeoutSetTimeoutId);
       window.removeEventListener('message', iframeEventHandler, false);
+
       // Delay the removal of the iframe to prevent hanging loading status
       // in Chrome: https://github.com/auth0/auth0-spa-js/issues/240
       setTimeout(removeIframe, CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000);
@@ -107,20 +116,30 @@ export const runPopup = (authorizeUrl: string, config: PopupConfigOptions) => {
   }
 
   return new Promise<AuthenticationResult>((resolve, reject) => {
+    let popupEventListener;
+
     const timeoutId = setTimeout(() => {
       reject(new PopupTimeoutError(popup));
+      window.removeEventListener('message', popupEventListener, false);
     }, (config.timeoutInSeconds || DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS) * 1000);
-    window.addEventListener('message', e => {
+
+    popupEventListener = function (e: MessageEvent) {
       if (!e.data || e.data.type !== 'authorization_response') {
         return;
       }
+
       clearTimeout(timeoutId);
+      window.removeEventListener('message', popupEventListener, false);
       popup.close();
+
       if (e.data.response.error) {
         return reject(GenericError.fromPayload(e.data.response));
       }
+
       resolve(e.data.response);
-    });
+    };
+
+    window.addEventListener('message', e => popupEventListener);
   });
 };
 
@@ -368,7 +387,7 @@ export const validateCrypto = () => {
   if (typeof getCryptoSubtle() === 'undefined') {
     throw new Error(`
       auth0-spa-js must run on a secure origin.
-      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin 
+      See https://github.com/auth0/auth0-spa-js/blob/master/FAQ.md#why-do-i-get-auth0-spa-js-must-run-on-a-secure-origin
       for more information.
     `);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,7 @@ export const runIframe = (
         : res(e.data.response);
 
       clearTimeout(timeoutSetTimeoutId);
+      window.removeEventListener('message', iframeEventHandler, false);
 
       // Delay the removal of the iframe to prevent hanging loading status
       // in Chrome: https://github.com/auth0/auth0-spa-js/issues/240


### PR DESCRIPTION
In both "loginWithPopup" and "loginWithRedirect", window.addEventListener('message',...  is called.

There are issues with the cleanup of this to properly remove it from the window. In the case of timeouts, it is not being removed properly.  For loginWithPopup, it wasn't being removed at all causing leaking resources the more times its called.