### PR TITLE
Updated readme to include information about the RT fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,17 @@ await createAuth0Client({
 });
 ```
 
-Using this setting will cause the SDK to automatically send the `offline_access` scope to the authorization server. Refresh tokens will then be used to exchange for new access tokens instead of using a hidden iframe, and calls the `/oauth/token` endpoint directly. This means that the SDK does not rely on third-party cookies when using refresh tokens.
+Using this setting will cause the SDK to automatically send the `offline_access` scope to the authorization server. Refresh tokens will then be used to exchange for new access tokens instead of using a hidden iframe, and calls the `/oauth/token` endpoint directly. This means that in most cases the SDK does not rely on third-party cookies when using refresh tokens.
 
 **Note** This configuration option requires Rotating Refresh Tokens to be [enabled for your Auth0 Tenant](https://auth0.com/docs/tokens/guides/configure-refresh-token-rotation).
+
+#### Refresh Token fallback
+
+In all cases where a refresh token is not available, the SDK falls back to the legacy technique of using a hidden iframe with `prompt=none` to try and get a new access token and refresh token. This scenario would occur for example if you are using the in-memory cache and you have refreshed the page. In this case, any refresh token that was stored previously would be lost.
+
+If the fallback mechanism fails, a `login_required` error will be thrown and could be handled in order to put the user back through the authentication process.
+
+**Note**: This fallback mechanism does still require access to the Auth0 session cookie, so if third-party cookies are being blocked then this fallback will not work and the user must re-authenticate in order to get a new refresh token.
 
 ## Contributing
 


### PR DESCRIPTION
### Description

Updated readme to include information about the RT fallback

### References

Raised internally and on the [Auth0 Community](https://community.auth0.com/t/trying-the-new-refresh-token-rotation-in-a-react-spa-are-3rd-party-cookies-supposed-to-be-required/41151)

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
