### PR TITLE
include polyfill for Set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import 'core-js/es/array/from';
 import 'core-js/es/typed-array/slice';
 import 'core-js/es/array/includes';
 import 'core-js/es/string/includes';
+import 'core-js/es/set';
 import 'promise-polyfill/src/polyfill';
 import 'fast-text-encoding';
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';


### PR DESCRIPTION
### Description

`Set` polyfill for clients which do not have capability to instantiate `Set`.

### Testing

Use library version >= 1.6.0 without `Set` capability:
https://caniuse.com/#search=new%20Set()

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
