### PR TITLE
check for window.navigator for web-worker check

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -117,6 +117,7 @@ export default class Auth0Client {
 
     // Don't use web workers unless using refresh tokens in memory and not IE11
     if (
+      window.navigator &&
       window.Worker &&
       this.options.useRefreshTokens &&
       this.cacheLocation === CACHE_LOCATION_MEMORY &&


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This can solve issue - https://github.com/zeit/next.js/issues/11967#issuecomment-616383108

For websites that use Next.JS or Gatsby to do limited SSR, this library breaks with the following error message:

```
  WebpackError: ReferenceError: Blob is not defined
  
  - auth0-spa-js.production.esm.js:15 
    node_modules/@auth0/auth0-spa-js/dist/auth0-spa-js.production.esm.js:15:44578
  
  - auth0-spa-js.production.esm.js:15 Module.<anonymous>
    node_modules/@auth0/auth0-spa-js/dist/auth0-spa-js.production.esm.js:15:44698
  
  - authenticationContext.tsx:1 Module../src/utils/authenticationContext.tsx
    src/utils/authenticationContext.tsx:1:1
  
  - base.tsx:1 Module../src/components/sideNavigation/base.tsx
    src/components/sideNavigation/base.tsx:1:1
  
  - admin.tsx:1 Module../src/components/sideNavigation/admin.tsx
    src/components/sideNavigation/admin.tsx:1:1
  
  - admin.tsx:1 Module../src/components/navigationBars/admin.tsx
    src/components/navigationBars/admin.tsx:1:1
  
  - admin.tsx:1 Module../src/layouts/admin.tsx
    src/layouts/admin.tsx:1:1
  
  - renderLayout.tsx:1 Module../src/utils/renderLayout.tsx
    src/utils/renderLayout.tsx:1:1
  ```


### Testing

You can test this change by importing this changed version in a Gatsby project and running `gatsby build`

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
