### PR TITLE
Reset prettier config to pre-2.0 defaults, reformatted some files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "printWidth": 80
+  "printWidth": 80,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
 }

--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -31,7 +31,7 @@ const assertPost = (url, body, callNum = 0) => {
 const fetchResponse = (ok, json) =>
   Promise.resolve({
     ok,
-    json: () => Promise.resolve(json),
+    json: () => Promise.resolve(json)
   });
 
 const setup: any = (config?, claims?) => {
@@ -40,7 +40,7 @@ const setup: any = (config?, claims?) => {
       {
         domain: 'auth0_domain',
         client_id: 'auth0_client_id',
-        redirect_uri: 'my_callback_url',
+        redirect_uri: 'my_callback_url'
       },
       config
     )
@@ -48,10 +48,10 @@ const setup: any = (config?, claims?) => {
   mockVerify.mockReturnValue({
     claims: Object.assign(
       {
-        exp: Date.now() / 1000 + 86400,
+        exp: Date.now() / 1000 + 86400
       },
       claims
-    ),
+    )
   });
   return auth0;
 };
@@ -74,7 +74,7 @@ const login: any = async (
           id_token: 'my_id_token',
           refresh_token: 'my_refresh_token',
           access_token: 'my_access_token',
-          expires_in: 86400,
+          expires_in: 86400
         },
         tokenResponse
       )
@@ -88,11 +88,11 @@ describe('Auth0Client', () => {
     mockWindow.location.assign = jest.fn();
     mockWindow.crypto = {
       subtle: {
-        digest: () => 'foo',
+        digest: () => 'foo'
       },
       getRandomValues() {
         return '123';
-      },
+      }
     };
     mockWindow.MessageChannel = MessageChannel;
     mockWindow.Worker = {};
@@ -106,7 +106,7 @@ describe('Auth0Client', () => {
   it('automatically adds the offline_access scope during construction', async () => {
     setup({
       useRefreshTokens: true,
-      scope: 'test-scope',
+      scope: 'test-scope'
     });
 
     expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -128,20 +128,20 @@ describe('Auth0Client', () => {
       state: 'MTIz',
       nonce: 'MTIz',
       code_challenge: '',
-      code_challenge_method: 'S256',
+      code_challenge_method: 'S256'
     });
     assertPost('https://auth0_domain/oauth/token', {
       redirect_uri: 'my_callback_url',
       client_id: 'auth0_client_id',
       code_verifier: '123',
       grant_type: 'authorization_code',
-      code: 'my_code',
+      code: 'my_code'
     });
   });
 
   it('refreshes the token from a web worker', async () => {
     const auth0 = setup({
-      useRefreshTokens: true,
+      useRefreshTokens: true
     });
     expect(auth0.worker).toBeDefined();
     await login(auth0);
@@ -150,7 +150,7 @@ describe('Auth0Client', () => {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
-        expires_in: 86400,
+        expires_in: 86400
       })
     );
     const access_token = await auth0.getTokenSilently({ ignoreCache: true });
@@ -160,7 +160,7 @@ describe('Auth0Client', () => {
         client_id: 'auth0_client_id',
         grant_type: 'refresh_token',
         redirect_uri: 'my_callback_url',
-        refresh_token: 'my_refresh_token',
+        refresh_token: 'my_refresh_token'
       },
       1
     );
@@ -170,7 +170,7 @@ describe('Auth0Client', () => {
   it('refreshes the token without the worker', async () => {
     const auth0 = setup({
       useRefreshTokens: true,
-      cacheLocation: 'localstorage',
+      cacheLocation: 'localstorage'
     });
     expect(auth0.worker).toBeUndefined();
     await login(auth0);
@@ -179,14 +179,14 @@ describe('Auth0Client', () => {
       client_id: 'auth0_client_id',
       code_verifier: '123',
       grant_type: 'authorization_code',
-      code: 'my_code',
+      code: 'my_code'
     });
     mockFetch.mockResolvedValueOnce(
       fetchResponse(true, {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
-        expires_in: 86400,
+        expires_in: 86400
       })
     );
     const access_token = await auth0.getTokenSilently({ ignoreCache: true });
@@ -196,7 +196,7 @@ describe('Auth0Client', () => {
         client_id: 'auth0_client_id',
         grant_type: 'refresh_token',
         redirect_uri: 'my_callback_url',
-        refresh_token: 'my_refresh_token',
+        refresh_token: 'my_refresh_token'
       },
       1
     );
@@ -208,7 +208,7 @@ describe('Auth0Client', () => {
 
     const auth0 = setup({
       useRefreshTokens: true,
-      cacheLocation: 'memory',
+      cacheLocation: 'memory'
     });
 
     expect(auth0.worker).toBeUndefined();
@@ -220,7 +220,7 @@ describe('Auth0Client', () => {
       client_id: 'auth0_client_id',
       code_verifier: '123',
       grant_type: 'authorization_code',
-      code: 'my_code',
+      code: 'my_code'
     });
 
     mockFetch.mockResolvedValueOnce(
@@ -228,7 +228,7 @@ describe('Auth0Client', () => {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
-        expires_in: 86400,
+        expires_in: 86400
       })
     );
 
@@ -240,7 +240,7 @@ describe('Auth0Client', () => {
         client_id: 'auth0_client_id',
         grant_type: 'refresh_token',
         redirect_uri: 'my_callback_url',
-        refresh_token: 'my_refresh_token',
+        refresh_token: 'my_refresh_token'
       },
       1
     );
@@ -250,7 +250,7 @@ describe('Auth0Client', () => {
 
   it('handles fetch errors from the worker', async () => {
     const auth0 = setup({
-      useRefreshTokens: true,
+      useRefreshTokens: true
     });
     expect(auth0.worker).toBeDefined();
     await login(auth0);
@@ -264,7 +264,7 @@ describe('Auth0Client', () => {
 
   it('handles api errors from the worker', async () => {
     const auth0 = setup({
-      useRefreshTokens: true,
+      useRefreshTokens: true
     });
     expect(auth0.worker).toBeDefined();
     await login(auth0);
@@ -272,7 +272,7 @@ describe('Auth0Client', () => {
     mockFetch.mockResolvedValue(
       fetchResponse(false, {
         error: 'my_api_error',
-        error_description: 'my_error_description',
+        error_description: 'my_error_description'
       })
     );
     await expect(auth0.getTokenSilently({ ignoreCache: true })).rejects.toThrow(
@@ -285,22 +285,22 @@ describe('Auth0Client', () => {
     const constants = require('../src/constants');
     const originalDefaultFetchTimeoutMs = constants.DEFAULT_FETCH_TIMEOUT_MS;
     Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
-      get: () => 100,
+      get: () => 100
     });
     const auth0 = setup({
-      useRefreshTokens: true,
+      useRefreshTokens: true
     });
     expect(auth0.worker).toBeDefined();
     await login(auth0);
     mockFetch.mockReset();
     mockFetch.mockImplementation(
       () =>
-        new Promise((resolve) =>
+        new Promise(resolve =>
           setTimeout(
             () =>
               resolve({
                 ok: true,
-                json: () => Promise.resolve({ access_token: 'access-token' }),
+                json: () => Promise.resolve({ access_token: 'access-token' })
               }),
             500
           )
@@ -316,26 +316,26 @@ describe('Auth0Client', () => {
     expect(AbortController.prototype.abort).toBeCalledTimes(7);
     expect(mockFetch).toBeCalledTimes(3);
     Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
-      get: () => originalDefaultFetchTimeoutMs,
+      get: () => originalDefaultFetchTimeoutMs
     });
   });
 
   it('falls back to iframe when missing refresh token errors from the worker', async () => {
     const auth0 = setup({
-      useRefreshTokens: true,
+      useRefreshTokens: true
     });
     expect(auth0.worker).toBeDefined();
     await login(auth0, true, { refresh_token: '' });
     jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
       access_token: 'my_access_token',
-      state: 'MTIz',
+      state: 'MTIz'
     });
     mockFetch.mockResolvedValueOnce(
       fetchResponse(true, {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
-        expires_in: 86400,
+        expires_in: 86400
       })
     );
     const access_token = await auth0.getTokenSilently({ ignoreCache: true });
@@ -346,7 +346,7 @@ describe('Auth0Client', () => {
   it('handles fetch errors without the worker', async () => {
     const auth0 = setup({
       useRefreshTokens: true,
-      cacheLocation: 'localstorage',
+      cacheLocation: 'localstorage'
     });
     expect(auth0.worker).toBeUndefined();
     await login(auth0);
@@ -361,7 +361,7 @@ describe('Auth0Client', () => {
   it('handles api errors without the worker', async () => {
     const auth0 = setup({
       useRefreshTokens: true,
-      cacheLocation: 'localstorage',
+      cacheLocation: 'localstorage'
     });
     expect(auth0.worker).toBeUndefined();
     await login(auth0);
@@ -369,7 +369,7 @@ describe('Auth0Client', () => {
     mockFetch.mockResolvedValue(
       fetchResponse(false, {
         error: 'my_api_error',
-        error_description: 'my_error_description',
+        error_description: 'my_error_description'
       })
     );
     await expect(auth0.getTokenSilently({ ignoreCache: true })).rejects.toThrow(
@@ -382,23 +382,23 @@ describe('Auth0Client', () => {
     const constants = require('../src/constants');
     const originalDefaultFetchTimeoutMs = constants.DEFAULT_FETCH_TIMEOUT_MS;
     Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
-      get: () => 100,
+      get: () => 100
     });
     const auth0 = setup({
       useRefreshTokens: true,
-      cacheLocation: 'localstorage',
+      cacheLocation: 'localstorage'
     });
     expect(auth0.worker).toBeUndefined();
     await login(auth0);
     mockFetch.mockReset();
     mockFetch.mockImplementation(
       () =>
-        new Promise((resolve) =>
+        new Promise(resolve =>
           setTimeout(
             () =>
               resolve({
                 ok: true,
-                json: () => Promise.resolve({ access_token: 'access-token' }),
+                json: () => Promise.resolve({ access_token: 'access-token' })
               }),
             500
           )
@@ -413,27 +413,27 @@ describe('Auth0Client', () => {
     expect(AbortController.prototype.abort).toBeCalledTimes(4);
     expect(mockFetch).toBeCalledTimes(3);
     Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
-      get: () => originalDefaultFetchTimeoutMs,
+      get: () => originalDefaultFetchTimeoutMs
     });
   });
 
   it('falls back to iframe when missing refresh token without the worker', async () => {
     const auth0 = setup({
       useRefreshTokens: true,
-      cacheLocation: 'localstorage',
+      cacheLocation: 'localstorage'
     });
     expect(auth0.worker).toBeUndefined();
     await login(auth0, true, { refresh_token: '' });
     jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
       access_token: 'my_access_token',
-      state: 'MTIz',
+      state: 'MTIz'
     });
     mockFetch.mockResolvedValueOnce(
       fetchResponse(true, {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
-        expires_in: 86400,
+        expires_in: 86400
       })
     );
     const access_token = await auth0.getTokenSilently({ ignoreCache: true });
@@ -446,30 +446,30 @@ describe('Auth0Client', () => {
     Object.defineProperty(window.navigator, 'userAgent', {
       value:
         'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko',
-      configurable: true,
+      configurable: true
     });
     const auth0 = setup({
-      useRefreshTokens: true,
+      useRefreshTokens: true
     });
     expect(auth0.worker).toBeUndefined();
     await login(auth0, true, { refresh_token: '' });
     jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
       access_token: 'my_access_token',
-      state: 'MTIz',
+      state: 'MTIz'
     });
     mockFetch.mockResolvedValueOnce(
       fetchResponse(true, {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
-        expires_in: 86400,
+        expires_in: 86400
       })
     );
     const access_token = await auth0.getTokenSilently({ ignoreCache: true });
     expect(access_token).toEqual('my_access_token');
     expect(utils.runIframe).toHaveBeenCalled();
     Object.defineProperty(window.navigator, 'userAgent', {
-      value: originalUserAgent,
+      value: originalUserAgent
     });
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -8,7 +8,7 @@ import { CacheLocation } from '../src/global';
 
 import createAuth0Client, {
   Auth0Client,
-  GetTokenSilentlyOptions,
+  GetTokenSilentlyOptions
 } from '../src/index';
 
 import { AuthenticationError } from '../src/errors';
@@ -35,7 +35,7 @@ const TEST_TELEMETRY_QUERY_STRING = `&auth0Client=${encodeURIComponent(
   btoa(
     JSON.stringify({
       name: 'auth0-spa-js',
-      version: version,
+      version: version
     })
   )
 )}`;
@@ -45,35 +45,35 @@ import { DEFAULT_POPUP_CONFIG_OPTIONS } from '../src/constants';
 const mockEnclosedCache = {
   get: jest.fn(),
   save: jest.fn(),
-  clear: jest.fn(),
+  clear: jest.fn()
 };
 
 jest.mock('../src/cache', () => ({
   InMemoryCache: () => ({
-    enclosedCache: mockEnclosedCache,
+    enclosedCache: mockEnclosedCache
   }),
-  LocalStorageCache: () => mockEnclosedCache,
+  LocalStorageCache: () => mockEnclosedCache
 }));
 
 jest.mock('../src/token.worker');
 
 const webWorkerMatcher = expect.objectContaining({
-  postMessage: expect.any(Function),
+  postMessage: expect.any(Function)
 });
 
 const setup = async (options = {}) => {
   const auth0 = await createAuth0Client({
     domain: TEST_DOMAIN,
     client_id: TEST_CLIENT_ID,
-    ...options,
+    ...options
   });
 
-  const getDefaultInstance = (m) => require(m).default.mock.instances[0];
+  const getDefaultInstance = m => require(m).default.mock.instances[0];
 
   const storage = {
     get: require('../src/storage').get,
     save: require('../src/storage').save,
-    remove: require('../src/storage').remove,
+    remove: require('../src/storage').remove
   };
 
   const lock = require('browser-tabs-lock');
@@ -92,7 +92,7 @@ const setup = async (options = {}) => {
 
   utils.parseQueryResult.mockReturnValue({
     state: TEST_ENCODED_STATE,
-    code: TEST_CODE,
+    code: TEST_CODE
   });
 
   utils.runPopup.mockReturnValue(
@@ -106,23 +106,23 @@ const setup = async (options = {}) => {
   utils.oauthToken.mockReturnValue(
     Promise.resolve({
       id_token: TEST_ID_TOKEN,
-      access_token: TEST_ACCESS_TOKEN,
+      access_token: TEST_ACCESS_TOKEN
     })
   );
 
   tokenVerifier.mockReturnValue({
     user: {
-      sub: TEST_USER_ID,
+      sub: TEST_USER_ID
     },
     claims: {
       sub: TEST_USER_ID,
-      aud: TEST_CLIENT_ID,
-    },
+      aud: TEST_CLIENT_ID
+    }
   });
 
   const popup = {
     location: { href: '' },
-    close: jest.fn(),
+    close: jest.fn()
   };
 
   return {
@@ -133,7 +133,7 @@ const setup = async (options = {}) => {
     transactionManager,
     utils,
     lock,
-    popup,
+    popup
   };
 };
 
@@ -146,8 +146,8 @@ describe('Auth0', () => {
 
     (<any>global).crypto = {
       subtle: {
-        digest: () => '',
-      },
+        digest: () => ''
+      }
     };
   });
 
@@ -155,7 +155,7 @@ describe('Auth0', () => {
     it('should create an Auth0 client', async () => {
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
-        client_id: TEST_CLIENT_ID,
+        client_id: TEST_CLIENT_ID
       });
 
       expect(auth0).toBeInstanceOf(Auth0Client);
@@ -172,7 +172,7 @@ describe('Auth0', () => {
         createAuth0Client({
           domain: TEST_DOMAIN,
           client_id: TEST_CLIENT_ID,
-          cacheLocation: 'dummy',
+          cacheLocation: 'dummy'
         } as any)
       ).rejects.toThrow(new Error('Invalid cache location "dummy"'));
     });
@@ -183,7 +183,7 @@ describe('Auth0', () => {
       utils.runIframe.mockImplementation(() => {
         throw {
           error: 'login_required',
-          error_message: 'Login required',
+          error_message: 'Login required'
         };
       });
 
@@ -191,7 +191,7 @@ describe('Auth0', () => {
 
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
-        client_id: TEST_CLIENT_ID,
+        client_id: TEST_CLIENT_ID
       });
 
       expect(auth0).toBeInstanceOf(Auth0Client);
@@ -204,7 +204,7 @@ describe('Auth0', () => {
       utils.runIframe.mockImplementation(() => {
         throw {
           error: 'some_other_error',
-          error_message: 'This is a different error to login_required',
+          error_message: 'This is a different error to login_required'
         };
       });
 
@@ -217,7 +217,7 @@ describe('Auth0', () => {
       try {
         await createAuth0Client({
           domain: TEST_DOMAIN,
-          client_id: TEST_CLIENT_ID,
+          client_id: TEST_CLIENT_ID
         });
       } catch (e) {
         expect(e.error).toEqual('some_other_error');
@@ -241,7 +241,7 @@ describe('Auth0', () => {
         `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
         {
           popup,
-          timeoutInSeconds: 60,
+          timeoutInSeconds: 60
         }
       );
     });
@@ -267,7 +267,7 @@ describe('Auth0', () => {
       const { auth0, utils } = await setup();
 
       await auth0.loginWithPopup({
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
@@ -279,7 +279,7 @@ describe('Auth0', () => {
         redirect_uri: 'http://localhost',
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
@@ -287,7 +287,7 @@ describe('Auth0', () => {
       const { auth0, utils } = await setup({ leeway: 10 });
 
       await auth0.loginWithPopup({
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
 
       expect(utils.createQueryParams).toHaveBeenCalledWith({
@@ -300,14 +300,14 @@ describe('Auth0', () => {
         redirect_uri: 'http://localhost',
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
     it('creates correct query params when providing a default redirect_uri', async () => {
       const redirect_uri = 'https://custom-redirect-uri/callback';
       const { auth0, utils } = await setup({
-        redirect_uri,
+        redirect_uri
       });
 
       await auth0.loginWithPopup({});
@@ -321,7 +321,7 @@ describe('Auth0', () => {
         nonce: TEST_ENCODED_STATE,
         redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
-        code_challenge_method: 'S256',
+        code_challenge_method: 'S256'
       });
     });
 
@@ -340,7 +340,7 @@ describe('Auth0', () => {
         nonce: TEST_ENCODED_STATE,
         redirect_uri: 'http://localhost',
         code_challenge: TEST_BASE64_ENCODED_STRING,
-        code_challenge_method: 'S256',
+        code_challenge_method: 'S256'
       });
     });
 
@@ -370,7 +370,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup(
         {},
         {
-          timeoutInSeconds: 25,
+          timeoutInSeconds: 25
         }
       );
 
@@ -387,7 +387,7 @@ describe('Auth0', () => {
 
       utils.runPopup.mockReturnValue(
         Promise.resolve({
-          state: 'other-state',
+          state: 'other-state'
         })
       );
       await expect(auth0.loginWithPopup({})).rejects.toThrowError(
@@ -406,7 +406,7 @@ describe('Auth0', () => {
           code: TEST_CODE,
           code_verifier: TEST_RANDOM_STRING,
           grant_type: 'authorization_code',
-          redirect_uri: 'http://localhost',
+          redirect_uri: 'http://localhost'
         },
         undefined
       );
@@ -416,7 +416,7 @@ describe('Auth0', () => {
       const redirect_uri = 'http://another.uri';
 
       const { auth0, utils } = await setup({
-        redirect_uri,
+        redirect_uri
       });
 
       await auth0.loginWithPopup();
@@ -430,7 +430,7 @@ describe('Auth0', () => {
         nonce: TEST_ENCODED_STATE,
         redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
-        code_challenge_method: 'S256',
+        code_challenge_method: 'S256'
       });
 
       expect(utils.oauthToken).toHaveBeenCalledWith(
@@ -441,7 +441,7 @@ describe('Auth0', () => {
           code: TEST_CODE,
           code_verifier: TEST_RANDOM_STRING,
           grant_type: 'authorization_code',
-          redirect_uri,
+          redirect_uri
         },
         undefined
       );
@@ -458,7 +458,7 @@ describe('Auth0', () => {
           code: TEST_CODE,
           code_verifier: TEST_RANDOM_STRING,
           grant_type: 'authorization_code',
-          redirect_uri: 'http://localhost',
+          redirect_uri: 'http://localhost'
         },
         undefined
       );
@@ -473,12 +473,12 @@ describe('Auth0', () => {
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
-        max_age: undefined,
+        max_age: undefined
       });
     });
     it('calls `tokenVerifier.verify` with the `issuer` from in the oauth/token response', async () => {
       const { auth0, tokenVerifier } = await setup({
-        issuer: 'test-123.auth0.com',
+        issuer: 'test-123.auth0.com'
       });
 
       await auth0.loginWithPopup({});
@@ -488,7 +488,7 @@ describe('Auth0', () => {
         nonce: TEST_ENCODED_STATE,
         iss: 'https://test-123.auth0.com/',
         leeway: undefined,
-        max_age: undefined,
+        max_age: undefined
       });
     });
     it('calls `tokenVerifier.verify` with the `leeway` from constructor', async () => {
@@ -501,7 +501,7 @@ describe('Auth0', () => {
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: 10,
-        max_age: undefined,
+        max_age: undefined
       });
     });
     it('calls `tokenVerifier.verify` with undefined `max_age` when value set in constructor is an empty string', async () => {
@@ -514,7 +514,7 @@ describe('Auth0', () => {
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
-        max_age: undefined,
+        max_age: undefined
       });
     });
     it('calls `tokenVerifier.verify` with the parsed `max_age` string from constructor', async () => {
@@ -527,7 +527,7 @@ describe('Auth0', () => {
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
-        max_age: 10,
+        max_age: 10
       });
     });
     it('calls `tokenVerifier.verify` with the parsed `max_age` number from constructor', async () => {
@@ -540,7 +540,7 @@ describe('Auth0', () => {
         aud: 'test-client-id',
         iss: 'https://test.auth0.com/',
         leeway: undefined,
-        max_age: 10,
+        max_age: 10
       });
     });
     it('saves cache', async () => {
@@ -555,8 +555,8 @@ describe('Auth0', () => {
         scope: TEST_SCOPES,
         decodedToken: {
           claims: { sub: TEST_USER_ID, aud: TEST_CLIENT_ID },
-          user: { sub: TEST_USER_ID },
-        },
+          user: { sub: TEST_USER_ID }
+        }
       });
     });
     it('saves `auth0.is.authenticated` key in storage', async () => {
@@ -580,7 +580,7 @@ describe('Auth0', () => {
     const REDIRECT_OPTIONS = {
       redirect_uri: 'https://redirect.uri',
       appState: TEST_APP_STATE,
-      connection: 'test-connection',
+      connection: 'test-connection'
     };
 
     it('encodes state with random string', async () => {
@@ -621,7 +621,7 @@ describe('Auth0', () => {
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
@@ -630,7 +630,7 @@ describe('Auth0', () => {
       utils.getUniqueScopes.mockReturnValue('offline_access');
 
       const { auth0 } = await setup({
-        useRefreshTokens: true,
+        useRefreshTokens: true
       });
 
       // utils.getUniqueScopes.mockReturnValue(`${TEST_SCOPES} offline_access`);
@@ -653,7 +653,7 @@ describe('Auth0', () => {
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
@@ -671,7 +671,7 @@ describe('Auth0', () => {
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
@@ -679,7 +679,7 @@ describe('Auth0', () => {
       const redirect_uri = 'https://custom-redirect-uri/callback';
       const { redirect_uri: _ignore, ...options } = REDIRECT_OPTIONS;
       const { auth0, utils } = await setup({
-        redirect_uri,
+        redirect_uri
       });
 
       await auth0.buildAuthorizeUrl(options);
@@ -694,14 +694,14 @@ describe('Auth0', () => {
         redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
     it('creates correct query params when overriding redirect_uri', async () => {
       const redirect_uri = 'https://custom-redirect-uri/callback';
       const { auth0, utils } = await setup({
-        redirect_uri,
+        redirect_uri
       });
 
       await auth0.buildAuthorizeUrl(REDIRECT_OPTIONS);
@@ -716,7 +716,7 @@ describe('Auth0', () => {
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
@@ -736,7 +736,7 @@ describe('Auth0', () => {
         redirect_uri: REDIRECT_OPTIONS.redirect_uri,
         code_challenge: TEST_BASE64_ENCODED_STRING,
         code_challenge_method: 'S256',
-        connection: 'test-connection',
+        connection: 'test-connection'
       });
     });
 
@@ -752,7 +752,7 @@ describe('Auth0', () => {
           code_verifier: TEST_RANDOM_STRING,
           nonce: TEST_ENCODED_STATE,
           scope: TEST_SCOPES,
-          redirect_uri: 'https://redirect.uri',
+          redirect_uri: 'https://redirect.uri'
         }
       );
     });
@@ -761,7 +761,7 @@ describe('Auth0', () => {
       const { auth0 } = await setup();
 
       const url = await auth0.buildAuthorizeUrl({
-        ...REDIRECT_OPTIONS,
+        ...REDIRECT_OPTIONS
       });
 
       expect(url).toBe(
@@ -784,7 +784,7 @@ describe('Auth0', () => {
     const REDIRECT_OPTIONS = {
       redirect_uri: 'https://redirect.uri',
       appState: TEST_APP_STATE,
-      connection: 'test-connection',
+      connection: 'test-connection'
     };
 
     it('calls `window.location.assign` with the correct url', async () => {
@@ -801,7 +801,7 @@ describe('Auth0', () => {
 
       await auth0.loginWithRedirect({
         ...REDIRECT_OPTIONS,
-        fragment: '/reset',
+        fragment: '/reset'
       });
       expect(window.location.assign).toHaveBeenCalledWith(
         `https://test.auth0.com/authorize?query=params${TEST_TELEMETRY_QUERY_STRING}#/reset`
@@ -840,7 +840,7 @@ describe('Auth0', () => {
           nonce: TEST_ENCODED_STATE,
           audience: 'default',
           scope: TEST_SCOPES,
-          appState: TEST_APP_STATE,
+          appState: TEST_APP_STATE
         });
         result.cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
         return result;
@@ -874,7 +874,7 @@ describe('Auth0', () => {
         const { auth0, utils } = await localSetup();
         const queryResult = {
           error: 'unauthorized',
-          error_description: 'Unauthorized user',
+          error_description: 'Unauthorized user'
         };
         utils.parseQueryResult.mockReturnValue(queryResult);
 
@@ -888,7 +888,7 @@ describe('Auth0', () => {
         const queryResult = {
           error: 'unauthorized',
           error_description: 'Unauthorized user',
-          state: 'abcxyz',
+          state: 'abcxyz'
         };
         utils.parseQueryResult.mockReturnValue(queryResult);
 
@@ -910,7 +910,7 @@ describe('Auth0', () => {
         const { auth0, utils, transactionManager } = await localSetup();
 
         const appState = {
-          key: 'property',
+          key: 'property'
         };
 
         transactionManager.get.mockReturnValue({ appState });
@@ -918,7 +918,7 @@ describe('Auth0', () => {
         const queryResult = {
           error: 'unauthorized',
           error_description: 'Unauthorized user',
-          state: 'abcxyz',
+          state: 'abcxyz'
         };
 
         utils.parseQueryResult.mockReturnValue(queryResult);
@@ -975,7 +975,7 @@ describe('Auth0', () => {
             client_id: TEST_CLIENT_ID,
             code: TEST_CODE,
             code_verifier: TEST_RANDOM_STRING,
-            grant_type: 'authorization_code',
+            grant_type: 'authorization_code'
           },
           undefined
         );
@@ -988,7 +988,7 @@ describe('Auth0', () => {
           audience: 'default',
           scope: TEST_SCOPES,
           appState: TEST_APP_STATE,
-          redirect_uri: 'http://localhost',
+          redirect_uri: 'http://localhost'
         });
         await auth0.handleRedirectCallback();
         const arg = utils.oauthToken.mock.calls[0][0];
@@ -1002,7 +1002,7 @@ describe('Auth0', () => {
           nonce: TEST_RANDOM_STRING,
           audience: 'default',
           scope: TEST_SCOPES,
-          appState: TEST_APP_STATE,
+          appState: TEST_APP_STATE
         });
         await auth0.handleRedirectCallback();
         const arg = utils.oauthToken.mock.calls[0][0];
@@ -1019,7 +1019,7 @@ describe('Auth0', () => {
           aud: 'test-client-id',
           iss: 'https://test.auth0.com/',
           leeway: undefined,
-          max_age: undefined,
+          max_age: undefined
         });
       });
       it('saves cache', async () => {
@@ -1035,8 +1035,8 @@ describe('Auth0', () => {
           scope: TEST_SCOPES,
           decodedToken: {
             claims: { sub: TEST_USER_ID, aud: TEST_CLIENT_ID },
-            user: { sub: TEST_USER_ID },
-          },
+            user: { sub: TEST_USER_ID }
+          }
         });
       });
       it('saves `auth0.is.authenticated` key in storage', async () => {
@@ -1056,7 +1056,7 @@ describe('Auth0', () => {
         const response = await auth0.handleRedirectCallback();
 
         expect(response).toEqual({
-          appState: TEST_APP_STATE,
+          appState: TEST_APP_STATE
         });
       });
     });
@@ -1074,7 +1074,7 @@ describe('Auth0', () => {
           nonce: TEST_ENCODED_STATE,
           audience: 'default',
           scope: TEST_SCOPES,
-          appState: TEST_APP_STATE,
+          appState: TEST_APP_STATE
         });
         result.cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
         return result;
@@ -1116,7 +1116,7 @@ describe('Auth0', () => {
         const { auth0, utils } = await localSetup();
         const queryResult = {
           error: 'unauthorized',
-          error_description: 'Unauthorized user',
+          error_description: 'Unauthorized user'
         };
         utils.parseQueryResult.mockReturnValue(queryResult);
 
@@ -1129,7 +1129,7 @@ describe('Auth0', () => {
         const queryResult = {
           error: 'unauthorized',
           error_description: 'Unauthorized user',
-          state: 'abcxyz',
+          state: 'abcxyz'
         };
         utils.parseQueryResult.mockReturnValue(queryResult);
 
@@ -1187,7 +1187,7 @@ describe('Auth0', () => {
             client_id: TEST_CLIENT_ID,
             code: TEST_CODE,
             code_verifier: TEST_RANDOM_STRING,
-            grant_type: 'authorization_code',
+            grant_type: 'authorization_code'
           },
           undefined
         );
@@ -1203,7 +1203,7 @@ describe('Auth0', () => {
           aud: 'test-client-id',
           iss: 'https://test.auth0.com/',
           leeway: undefined,
-          max_age: undefined,
+          max_age: undefined
         });
       });
       it('saves cache', async () => {
@@ -1219,8 +1219,8 @@ describe('Auth0', () => {
           scope: TEST_SCOPES,
           decodedToken: {
             claims: { sub: TEST_USER_ID, aud: TEST_CLIENT_ID },
-            user: { sub: TEST_USER_ID },
-          },
+            user: { sub: TEST_USER_ID }
+          }
         });
       });
       it('saves `auth0.is.authenticated` key in storage', async () => {
@@ -1240,7 +1240,7 @@ describe('Auth0', () => {
         const response = await auth0.handleRedirectCallback();
 
         expect(response).toEqual({
-          appState: TEST_APP_STATE,
+          appState: TEST_APP_STATE
         });
       });
     });
@@ -1260,10 +1260,10 @@ describe('Auth0', () => {
           claims: {
             sub: TEST_USER_ID,
             email: TEST_USER_EMAIL,
-            aud: TEST_CLIENT_ID,
+            aud: TEST_CLIENT_ID
           },
-          user: { sub: TEST_USER_ID, email: TEST_USER_EMAIL },
-        },
+          user: { sub: TEST_USER_ID, email: TEST_USER_EMAIL }
+        }
       };
       cache.get.mockReturnValue(userIn);
       const userOut = await auth0.getUser();
@@ -1277,7 +1277,7 @@ describe('Auth0', () => {
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'default',
         scope: TEST_SCOPES,
-        client_id: TEST_CLIENT_ID,
+        client_id: TEST_CLIENT_ID
       });
 
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1293,7 +1293,7 @@ describe('Auth0', () => {
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'the-audience',
         scope: TEST_SCOPES,
-        client_id: TEST_CLIENT_ID,
+        client_id: TEST_CLIENT_ID
       });
 
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1318,10 +1318,10 @@ describe('Auth0', () => {
           claims: {
             aud: TEST_CLIENT_ID,
             sub: TEST_USER_ID,
-            email: TEST_USER_EMAIL,
+            email: TEST_USER_EMAIL
           },
-          user: { sub: TEST_USER_ID, email: TEST_USER_EMAIL },
-        },
+          user: { sub: TEST_USER_ID, email: TEST_USER_EMAIL }
+        }
       };
       cache.get.mockReturnValue(userIn);
       const userOut = await auth0.getIdTokenClaims();
@@ -1334,7 +1334,7 @@ describe('Auth0', () => {
         utils.getUniqueScopes.mockReturnValue('offline_access');
 
         const { auth0, cache } = await setup({
-          useRefreshTokens: true,
+          useRefreshTokens: true
         });
 
         await auth0.getIdTokenClaims();
@@ -1342,7 +1342,7 @@ describe('Auth0', () => {
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'default',
           scope: TEST_SCOPES,
-          client_id: TEST_CLIENT_ID,
+          client_id: TEST_CLIENT_ID
         });
 
         expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1357,18 +1357,18 @@ describe('Auth0', () => {
         utils.getUniqueScopes.mockReturnValue('offline_access');
 
         const { auth0, cache } = await setup({
-          useRefreshTokens: true,
+          useRefreshTokens: true
         });
 
         await auth0.getIdTokenClaims({
           audience: 'the-audience',
-          scope: 'the-scope',
+          scope: 'the-scope'
         });
 
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'the-audience',
           scope: TEST_SCOPES,
-          client_id: TEST_CLIENT_ID,
+          client_id: TEST_CLIENT_ID
         });
 
         expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1388,7 +1388,7 @@ describe('Auth0', () => {
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'default',
           scope: TEST_SCOPES,
-          client_id: TEST_CLIENT_ID,
+          client_id: TEST_CLIENT_ID
         });
 
         expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1403,13 +1403,13 @@ describe('Auth0', () => {
 
         await auth0.getIdTokenClaims({
           audience: 'the-audience',
-          scope: 'the-scope',
+          scope: 'the-scope'
         });
 
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'the-audience',
           scope: TEST_SCOPES,
-          client_id: TEST_CLIENT_ID,
+          client_id: TEST_CLIENT_ID
         });
 
         expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1426,7 +1426,7 @@ describe('Auth0', () => {
       const { auth0 } = await setup();
       auth0.getUser = jest.fn(() =>
         Promise.resolve({
-          id: TEST_USER_ID,
+          id: TEST_USER_ID
         })
       );
       const result = await auth0.isAuthenticated();
@@ -1452,7 +1452,7 @@ describe('Auth0', () => {
           expect(cache.get).toHaveBeenCalledWith({
             audience: 'default',
             scope: TEST_SCOPES,
-            client_id: TEST_CLIENT_ID,
+            client_id: TEST_CLIENT_ID
           });
 
           expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1499,7 +1499,7 @@ describe('Auth0', () => {
           utils.getUniqueScopes.mockReturnValue('offline_access');
 
           const { auth0, cache } = await setup({
-            useRefreshTokens: true,
+            useRefreshTokens: true
           });
 
           utils.getUniqueScopes.mockReturnValue(
@@ -1513,7 +1513,7 @@ describe('Auth0', () => {
           expect(cache.get).toHaveBeenCalledWith({
             audience: 'default',
             scope: `${TEST_SCOPES} offline_access`,
-            client_id: TEST_CLIENT_ID,
+            client_id: TEST_CLIENT_ID
           });
 
           expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1525,7 +1525,7 @@ describe('Auth0', () => {
 
         it('calls the token endpoint with the correct params', async () => {
           const { auth0, cache, utils } = await setup({
-            useRefreshTokens: true,
+            useRefreshTokens: true
           });
 
           utils.getUniqueScopes.mockReturnValue(
@@ -1536,7 +1536,7 @@ describe('Auth0', () => {
             Promise.resolve({
               id_token: TEST_ID_TOKEN,
               access_token: TEST_ACCESS_TOKEN,
-              refresh_token: TEST_REFRESH_TOKEN,
+              refresh_token: TEST_REFRESH_TOKEN
             })
           );
 
@@ -1547,7 +1547,7 @@ describe('Auth0', () => {
           expect(cache.get).toHaveBeenCalledWith({
             audience: 'default',
             scope: `${TEST_SCOPES} offline_access`,
-            client_id: TEST_CLIENT_ID,
+            client_id: TEST_CLIENT_ID
           });
 
           expect(utils.oauthToken).toHaveBeenCalledWith(
@@ -1556,7 +1556,7 @@ describe('Auth0', () => {
               refresh_token: TEST_REFRESH_TOKEN,
               client_id: TEST_CLIENT_ID,
               grant_type: 'refresh_token',
-              redirect_uri: 'http://localhost',
+              redirect_uri: 'http://localhost'
             },
             webWorkerMatcher
           );
@@ -1570,8 +1570,8 @@ describe('Auth0', () => {
             audience: 'default',
             decodedToken: {
               claims: { sub: TEST_USER_ID, aud: TEST_CLIENT_ID },
-              user: { sub: TEST_USER_ID },
-            },
+              user: { sub: TEST_USER_ID }
+            }
           });
         });
 
@@ -1580,12 +1580,12 @@ describe('Auth0', () => {
           utils.getUniqueScopes.mockReturnValue('offline_access');
 
           const { auth0 } = await setup({
-            useRefreshTokens: true,
+            useRefreshTokens: true
           });
 
           await auth0.getTokenSilently({
             audience: 'other-audience',
-            ignoreCache: true,
+            ignoreCache: true
           });
 
           expect(utils.runIframe).toHaveBeenCalledWith(
@@ -1601,7 +1601,7 @@ describe('Auth0', () => {
       const defaultOptionsIgnoreCacheTrue: GetTokenSilentlyOptions = {
         audience: 'test:audience',
         scope: 'test:scope',
-        ignoreCache: true,
+        ignoreCache: true
       };
 
       it('releases the lock when there is an error', async () => {
@@ -1654,7 +1654,7 @@ describe('Auth0', () => {
           nonce: TEST_ENCODED_STATE,
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
-          code_challenge_method: 'S256',
+          code_challenge_method: 'S256'
         });
       });
 
@@ -1673,14 +1673,14 @@ describe('Auth0', () => {
           nonce: TEST_ENCODED_STATE,
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
-          code_challenge_method: 'S256',
+          code_challenge_method: 'S256'
         });
       });
 
       it('creates correct query params when providing a default redirect_uri', async () => {
         const redirect_uri = 'https://custom-redirect-uri/callback';
         const { auth0, utils } = await setup({
-          redirect_uri,
+          redirect_uri
         });
 
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
@@ -1695,7 +1695,7 @@ describe('Auth0', () => {
           nonce: TEST_ENCODED_STATE,
           redirect_uri,
           code_challenge: TEST_BASE64_ENCODED_STRING,
-          code_challenge_method: 'S256',
+          code_challenge_method: 'S256'
         });
       });
 
@@ -1715,7 +1715,7 @@ describe('Auth0', () => {
           nonce: TEST_ENCODED_STATE,
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
-          code_challenge_method: 'S256',
+          code_challenge_method: 'S256'
         });
 
         expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1730,7 +1730,7 @@ describe('Auth0', () => {
 
         const customQueryParameterOptions = {
           ...defaultOptionsIgnoreCacheTrue,
-          foo: 'bar',
+          foo: 'bar'
         };
         await auth0.getTokenSilently(customQueryParameterOptions);
         expect(utils.createQueryParams).toHaveBeenCalledWith({
@@ -1745,7 +1745,7 @@ describe('Auth0', () => {
           redirect_uri: 'http://localhost',
           code_challenge: TEST_BASE64_ENCODED_STRING,
           code_challenge_method: 'S256',
-          foo: 'bar',
+          foo: 'bar'
         });
       });
 
@@ -1773,7 +1773,7 @@ describe('Auth0', () => {
         const { auth0, utils } = await setup();
         await auth0.getTokenSilently({
           ...defaultOptionsIgnoreCacheTrue,
-          timeoutInSeconds: 1,
+          timeoutInSeconds: 1
         });
         expect(utils.runIframe).toHaveBeenCalledWith(
           `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_TELEMETRY_QUERY_STRING}`,
@@ -1787,7 +1787,7 @@ describe('Auth0', () => {
 
         utils.runIframe.mockReturnValue(
           Promise.resolve({
-            state: 'other-state',
+            state: 'other-state'
           })
         );
 
@@ -1812,7 +1812,7 @@ describe('Auth0', () => {
             code: TEST_CODE,
             code_verifier: TEST_RANDOM_STRING,
             grant_type: 'authorization_code',
-            redirect_uri: 'http://localhost',
+            redirect_uri: 'http://localhost'
           },
           undefined
         );
@@ -1828,7 +1828,7 @@ describe('Auth0', () => {
           aud: 'test-client-id',
           iss: 'https://test.auth0.com/',
           leeway: undefined,
-          max_age: undefined,
+          max_age: undefined
         });
       });
       it('saves cache', async () => {
@@ -1843,8 +1843,8 @@ describe('Auth0', () => {
           scope: TEST_SCOPES,
           decodedToken: {
             claims: { sub: TEST_USER_ID, aud: TEST_CLIENT_ID },
-            user: { sub: TEST_USER_ID },
-          },
+            user: { sub: TEST_USER_ID }
+          }
         });
       });
       it('saves `auth0.is.authenticated` key in storage', async () => {
@@ -1888,7 +1888,7 @@ describe('Auth0', () => {
       expect(auth0.loginWithPopup).toHaveBeenCalledWith(
         {
           audience: undefined,
-          scope: TEST_SCOPES,
+          scope: TEST_SCOPES
         },
         DEFAULT_POPUP_CONFIG_OPTIONS
       );
@@ -1904,7 +1904,7 @@ describe('Auth0', () => {
       const { auth0, utils } = await localSetup();
       const loginOptions = {
         audience: 'other-audience',
-        scope: 'other-scope',
+        scope: 'other-scope'
       };
       const configOptions = { timeoutInSeconds: 1 };
 
@@ -1928,7 +1928,7 @@ describe('Auth0', () => {
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'default',
         scope: TEST_SCOPES,
-        client_id: TEST_CLIENT_ID,
+        client_id: TEST_CLIENT_ID
       });
 
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -1958,7 +1958,7 @@ describe('Auth0', () => {
 
       auth0.logout();
       expect(utils.createQueryParams).toHaveBeenCalledWith({
-        client_id: TEST_CLIENT_ID,
+        client_id: TEST_CLIENT_ID
       });
     });
 
@@ -1974,7 +1974,7 @@ describe('Auth0', () => {
 
       auth0.logout({ client_id: 'another-client-id' });
       expect(utils.createQueryParams).toHaveBeenCalledWith({
-        client_id: 'another-client-id',
+        client_id: 'another-client-id'
       });
     });
 
@@ -1983,7 +1983,7 @@ describe('Auth0', () => {
 
       auth0.logout({ returnTo: 'https://return.to', client_id: null });
       expect(utils.createQueryParams).toHaveBeenCalledWith({
-        returnTo: 'https://return.to',
+        returnTo: 'https://return.to'
       });
     });
 
@@ -2056,7 +2056,7 @@ describe('default creation function', () => {
 
     const auth0 = await createAuth0Client({
       domain: TEST_DOMAIN,
-      client_id: TEST_CLIENT_ID,
+      client_id: TEST_CLIENT_ID
     });
 
     expect(require('../src/storage').get).toHaveBeenCalledWith(
@@ -2073,7 +2073,7 @@ describe('default creation function', () => {
 
     const auth0 = await createAuth0Client({
       domain: TEST_DOMAIN,
-      client_id: TEST_CLIENT_ID,
+      client_id: TEST_CLIENT_ID
     });
 
     expect(auth0.getTokenSilently).toHaveBeenCalledWith();
@@ -2085,7 +2085,7 @@ describe('default creation function', () => {
 
       const options = {
         audience: 'the-audience',
-        scope: 'the-scope',
+        scope: 'the-scope'
       };
 
       Auth0Client.prototype.getTokenSilently = jest.fn();
@@ -2096,7 +2096,7 @@ describe('default creation function', () => {
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
         client_id: TEST_CLIENT_ID,
-        ...options,
+        ...options
       });
 
       expect(auth0.getTokenSilently).toHaveBeenCalledWith();
@@ -2110,7 +2110,7 @@ describe('default creation function', () => {
       const options = {
         audience: 'the-audience',
         scope: 'the-scope',
-        useRefreshTokens: true,
+        useRefreshTokens: true
       };
 
       Auth0Client.prototype.getTokenSilently = jest.fn();
@@ -2121,7 +2121,7 @@ describe('default creation function', () => {
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
         client_id: TEST_CLIENT_ID,
-        ...options,
+        ...options
       });
 
       expect(utils.getUniqueScopes).toHaveBeenCalledWith(
@@ -2140,7 +2140,7 @@ describe('default creation function', () => {
       const options = {
         audience: 'the-audience',
         scope: 'the-scope',
-        cacheLocation,
+        cacheLocation
       };
 
       Auth0Client.prototype.getTokenSilently = jest.fn();
@@ -2150,7 +2150,7 @@ describe('default creation function', () => {
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
         client_id: TEST_CLIENT_ID,
-        ...options,
+        ...options
       });
 
       expect(auth0.getTokenSilently).toHaveBeenCalledWith();

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -17,11 +17,11 @@ const verifyOptions = {
 
 const createCertificate = (): Promise<Certificate> =>
   new Promise((res, rej) => {
-    pem.createCertificate({ days: 1, selfSigned: true }, function(err, keys) {
+    pem.createCertificate({ days: 1, selfSigned: true }, function (err, keys) {
       if (err) {
         return rej(err);
       }
-      pem.getPublicKey(keys.certificate, function(e, p) {
+      pem.getPublicKey(keys.certificate, function (e, p) {
         if (e) {
           return rej(e);
         }

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -9,7 +9,7 @@ const path = require('path');
 const execSync = require('child_process').execSync;
 const moment = require('moment');
 
-module.exports = function(newVersion) {
+module.exports = function (newVersion) {
   return new Promise((resolve, reject) => {
     const tmp = fs.readFileSync('.release', 'utf-8');
 
@@ -28,7 +28,7 @@ module.exports = function(newVersion) {
       'sed "s/# Change Log//" CHANGELOG.md | sed \'1,2d\''
     );
 
-    stream.once('open', function(fd) {
+    stream.once('open', function (fd) {
       stream.write('# Change Log');
       stream.write('\n');
       stream.write('\n');
@@ -52,7 +52,7 @@ module.exports = function(newVersion) {
       stream.end();
     });
 
-    stream.once('close', function(fd) {
+    stream.once('close', function (fd) {
       execSync(`mv ${changelogPath} CHANGELOG.md`, { stdio: 'inherit' });
       execSync('git add CHANGELOG.md', { stdio: 'inherit' });
       resolve();

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -11,7 +11,7 @@ import {
   sha256,
   bufferToBase64UrlEncoded,
   oauthToken,
-  validateCrypto,
+  validateCrypto
 } from './utils';
 
 import { InMemoryCache, ICache, LocalStorageCache } from './cache';
@@ -23,7 +23,7 @@ import {
   CACHE_LOCATION_MEMORY,
   DEFAULT_POPUP_CONFIG_OPTIONS,
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
-  MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
+  MISSING_REFRESH_TOKEN_ERROR_MESSAGE
 } from './constants';
 import version from './version';
 import {
@@ -41,7 +41,7 @@ import {
   LogoutOptions,
   RefreshTokenOptions,
   OAuthTokenOptions,
-  CacheLocation,
+  CacheLocation
 } from './global';
 
 // @ts-ignore
@@ -62,7 +62,7 @@ const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
  */
 const cacheLocationBuilders = {
   memory: () => new InMemoryCache().enclosedCache,
-  localstorage: () => new LocalStorageCache(),
+  localstorage: () => new LocalStorageCache()
 };
 
 /**
@@ -131,7 +131,7 @@ export default class Auth0Client {
       btoa(
         JSON.stringify({
           name: 'auth0-spa-js',
-          version: version,
+          version: version
         })
       )
     );
@@ -167,7 +167,7 @@ export default class Auth0Client {
       nonce,
       redirect_uri: redirect_uri || this.options.redirect_uri,
       code_challenge,
-      code_challenge_method: 'S256',
+      code_challenge_method: 'S256'
     };
   }
   private _authorizeUrl(authorizeOptions: AuthorizeOptions) {
@@ -180,7 +180,7 @@ export default class Auth0Client {
       id_token,
       nonce,
       leeway: this.options.leeway,
-      max_age: this._parseNumber(this.options.max_age),
+      max_age: this._parseNumber(this.options.max_age)
     });
   }
   private _parseNumber(value: any): number {
@@ -230,7 +230,7 @@ export default class Auth0Client {
       appState,
       scope: params.scope,
       audience: params.audience || 'default',
-      redirect_uri: params.redirect_uri,
+      redirect_uri: params.redirect_uri
     });
 
     return url + fragment;
@@ -273,7 +273,7 @@ export default class Auth0Client {
 
     const url = this._authorizeUrl({
       ...params,
-      response_mode: 'web_message',
+      response_mode: 'web_message'
     });
 
     const codeResult = await runPopup(url, {
@@ -281,7 +281,7 @@ export default class Auth0Client {
       timeoutInSeconds:
         config.timeoutInSeconds ||
         this.options.authorizeTimeoutInSeconds ||
-        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
+        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
     });
 
     if (stateIn !== codeResult.state) {
@@ -295,7 +295,7 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri,
+        redirect_uri: params.redirect_uri
       } as OAuthTokenOptions,
       this.worker
     );
@@ -307,7 +307,7 @@ export default class Auth0Client {
       decodedToken,
       scope: params.scope,
       audience: params.audience || 'default',
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     };
 
     this.cache.save(cacheEntry);
@@ -328,14 +328,14 @@ export default class Auth0Client {
   public async getUser(
     options: GetUserOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.DEFAULT_SCOPE
     }
   ) {
     options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
-      ...options,
+      ...options
     });
 
     return cache && cache.decodedToken && cache.decodedToken.user;
@@ -353,7 +353,7 @@ export default class Auth0Client {
   public async getIdTokenClaims(
     options: GetIdTokenClaimsOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.DEFAULT_SCOPE
     }
   ) {
     options.scope = getUniqueScopes(
@@ -364,7 +364,7 @@ export default class Auth0Client {
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
-      ...options,
+      ...options
     });
 
     return cache && cache.decodedToken && cache.decodedToken.claims;
@@ -427,7 +427,7 @@ export default class Auth0Client {
       client_id: this.options.client_id,
       code_verifier: transaction.code_verifier,
       grant_type: 'authorization_code',
-      code,
+      code
     } as OAuthTokenOptions;
 
     // some old versions of the SDK might not have added redirect_uri to the
@@ -448,7 +448,7 @@ export default class Auth0Client {
       decodedToken,
       audience: transaction.audience,
       scope: transaction.scope,
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     };
 
     this.cache.save(cacheEntry);
@@ -456,7 +456,7 @@ export default class Auth0Client {
     ClientStorage.save('auth0.is.authenticated', true, { daysUntilExpire: 1 });
 
     return {
-      appState: transaction.appState,
+      appState: transaction.appState
     };
   }
 
@@ -495,7 +495,7 @@ export default class Auth0Client {
         options.scope
       ),
       ignoreCache: false,
-      ...options,
+      ...options
     };
 
     try {
@@ -503,7 +503,7 @@ export default class Auth0Client {
         const cache = this.cache.get({
           scope: getTokenOptions.scope,
           audience: getTokenOptions.audience || 'default',
-          client_id: this.options.client_id,
+          client_id: this.options.client_id
         });
 
         if (cache && cache.access_token) {
@@ -524,7 +524,7 @@ export default class Auth0Client {
       this.cache.save({ client_id: this.options.client_id, ...authResult });
 
       ClientStorage.save('auth0.is.authenticated', true, {
-        daysUntilExpire: 1,
+        daysUntilExpire: 1
       });
 
       return authResult.access_token;
@@ -549,7 +549,7 @@ export default class Auth0Client {
   public async getTokenWithPopup(
     options: GetTokenWithPopupOptions = {
       audience: this.options.audience,
-      scope: this.options.scope || this.DEFAULT_SCOPE,
+      scope: this.options.scope || this.DEFAULT_SCOPE
     },
     config: PopupConfigOptions = DEFAULT_POPUP_CONFIG_OPTIONS
   ) {
@@ -564,7 +564,7 @@ export default class Auth0Client {
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     });
 
     return cache.access_token;
@@ -649,7 +649,7 @@ export default class Auth0Client {
     const url = this._authorizeUrl({
       ...params,
       prompt: 'none',
-      response_mode: 'web_message',
+      response_mode: 'web_message'
     });
 
     const timeout =
@@ -667,7 +667,7 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri,
+        redirect_uri: params.redirect_uri
       } as OAuthTokenOptions,
       this.worker
     );
@@ -678,7 +678,7 @@ export default class Auth0Client {
       ...tokenResult,
       decodedToken,
       scope: params.scope,
-      audience: params.audience || 'default',
+      audience: params.audience || 'default'
     };
   }
 
@@ -694,7 +694,7 @@ export default class Auth0Client {
     const cache = this.cache.get({
       scope: options.scope,
       audience: options.audience || 'default',
-      client_id: this.options.client_id,
+      client_id: this.options.client_id
     });
 
     // If you don't have a refresh token in memory
@@ -717,7 +717,7 @@ export default class Auth0Client {
           client_id: this.options.client_id,
           grant_type: 'refresh_token',
           refresh_token: cache && cache.refresh_token,
-          redirect_uri,
+          redirect_uri
         } as RefreshTokenOptions,
         this.worker
       );
@@ -735,7 +735,7 @@ export default class Auth0Client {
       ...tokenResult,
       decodedToken,
       scope: options.scope,
-      audience: options.audience || 'default',
+      audience: options.audience || 'default'
     };
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -137,7 +137,7 @@ export class LocalStorageCache implements ICache {
 }
 
 export class InMemoryCache {
-  public enclosedCache: ICache = (function() {
+  public enclosedCache: ICache = (function () {
     let cache: CachePayload = {
       body: {},
       expiresAt: 0

--- a/src/token.worker.ts
+++ b/src/token.worker.ts
@@ -8,14 +8,14 @@ let refreshToken;
 /**
  * @ignore
  */
-const wait: any = (time) => new Promise((resolve) => setTimeout(resolve, time));
+const wait: any = time => new Promise(resolve => setTimeout(resolve, time));
 
 /**
  * @ignore
  */
 const messageHandler = async ({
   data: { url, timeout, ...opts },
-  ports: [port],
+  ports: [port]
 }) => {
   let json;
   try {
@@ -34,12 +34,12 @@ const messageHandler = async ({
     try {
       response = await Promise.race([
         wait(timeout),
-        fetch(url, { ...opts, signal }),
+        fetch(url, { ...opts, signal })
       ]);
     } catch (error) {
       // fetch error, reject `sendMessage` using `error` key so that we retry.
       port.postMessage({
-        error: error.message,
+        error: error.message
       });
       return;
     }
@@ -61,14 +61,14 @@ const messageHandler = async ({
 
     port.postMessage({
       ok: response.ok,
-      json,
+      json
     });
   } catch (error) {
     port.postMessage({
       ok: false,
       json: {
-        error_description: error.message,
-      },
+        error_description: error.message
+      }
     });
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,9 +21,7 @@ export const createAbortController = () => new AbortController();
 
 export const getUniqueScopes = (...scopes: string[]) => {
   const scopeString = scopes.filter(Boolean).join();
-  return dedupe(scopeString.replace(/\s/g, ',').split(','))
-    .join(' ')
-    .trim();
+  return dedupe(scopeString.replace(/\s/g, ',').split(',')).join(' ').trim();
 };
 
 export const parseQueryResult = (queryString: string) => {
@@ -55,7 +53,7 @@ export const runIframe = (
     iframe.setAttribute('width', '0');
     iframe.setAttribute('height', '0');
     iframe.style.display = 'none';
-    
+
     const removeIframe = () => {
       if (window.document.body.contains(iframe)) {
         window.document.body.removeChild(iframe);
@@ -67,22 +65,19 @@ export const runIframe = (
       removeIframe();
     }, timeoutInSeconds * 1000);
 
-    const iframeEventHandler = function(e: MessageEvent) {
+    const iframeEventHandler = function (e: MessageEvent) {
       if (e.origin != eventOrigin) return;
       if (!e.data || e.data.type !== 'authorization_response') return;
       const eventSource = e.source;
       if (eventSource) {
-          (<any>eventSource).close();
+        (<any>eventSource).close();
       }
       e.data.response.error ? rej(e.data.response) : res(e.data.response);
       clearTimeout(timeoutSetTimeoutId);
       window.removeEventListener('message', iframeEventHandler, false);
       // Delay the removal of the iframe to prevent hanging loading status
       // in Chrome: https://github.com/auth0/auth0-spa-js/issues/240
-      setTimeout(
-        removeIframe,
-        CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000
-      );
+      setTimeout(removeIframe, CLEANUP_IFRAME_TIMEOUT_IN_SECONDS * 1000);
     };
     window.addEventListener('message', iframeEventHandler, false);
     window.document.body.appendChild(iframe);
@@ -214,9 +209,9 @@ export const bufferToBase64UrlEncoded = input => {
 };
 
 const sendMessage = (message, to) =>
-  new Promise(function(resolve, reject) {
+  new Promise(function (resolve, reject) {
     const messageChannel = new MessageChannel();
-    messageChannel.port1.onmessage = function(event) {
+    messageChannel.port1.onmessage = function (event) {
       // Only for fetch errors, as these get retried
       if (event.data.error) {
         reject(new Error(event.data.error));


### PR DESCRIPTION
### Description

Some Prettier defaults changed for v2, this PR resets those defaults back to pre-2.0 settings for this codebase:

* [Arrow parens](https://prettier.io/docs/en/options.html#arrow-function-parentheses) - reset to "avoid"
* [Trailing comma](https://prettier.io/docs/en/options.html#trailing-commas) - reset to "none"

We could change these defaults later in one pass, but for now let's reset them.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
