### PR TITLE
[SDK-1417] Customizable default scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ import createAuth0Client from '@auth0/auth0-spa-js';
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   client_id: '<AUTH0_CLIENT_ID>',
-  redirect_uri: '<MY_CALLBACK_URL>',
+  redirect_uri: '<MY_CALLBACK_URL>'
 });
 
 //with promises
 createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   client_id: '<AUTH0_CLIENT_ID>',
-  redirect_uri: '<MY_CALLBACK_URL>',
-}).then((auth0) => {
+  redirect_uri: '<MY_CALLBACK_URL>'
+}).then(auth0 => {
   //...
 });
 
@@ -74,7 +74,7 @@ import { Auth0Client } from '@auth0/auth0-spa-js';
 const auth0 = new Auth0Client({
   domain: '<AUTH0_DOMAIN>',
   client_id: '<AUTH0_CLIENT_ID>',
-  redirect_uri: '<MY_CALLBACK_URL>',
+  redirect_uri: '<MY_CALLBACK_URL>'
 });
 
 //if you do this, you'll need to check the session yourself
@@ -120,9 +120,9 @@ document.getElementById('login').addEventListener('click', () => {
 
 //in your callback route (<MY_CALLBACK_URL>)
 window.addEventListener('load', () => {
-  auth0.handleRedirectCallback().then((redirectResult) => {
+  auth0.handleRedirectCallback().then(redirectResult => {
     //logged in. you can get the user profile like this:
-    auth0.getUser().then((user) => {
+    auth0.getUser().then(user => {
       console.log(user);
     });
   });
@@ -142,8 +142,8 @@ document.getElementById('call-api').addEventListener('click', async () => {
   const result = await fetch('https://myapi.com', {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
+      Authorization: `Bearer ${accessToken}`
+    }
   });
   const data = await result.json();
   console.log(data);
@@ -153,16 +153,16 @@ document.getElementById('call-api').addEventListener('click', async () => {
 document.getElementById('call-api').addEventListener('click', () => {
   auth0
     .getTokenSilently()
-    .then((accessToken) =>
+    .then(accessToken =>
       fetch('https://myapi.com', {
         method: 'GET',
         headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
+          Authorization: `Bearer ${accessToken}`
+        }
       })
     )
-    .then((result) => result.json())
-    .then((data) => {
+    .then(result => result.json())
+    .then(data => {
       console.log(data);
     });
 });
@@ -193,7 +193,7 @@ await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   client_id: '<AUTH0_CLIENT_ID>',
   redirect_uri: '<MY_CALLBACK_URL>',
-  cacheLocation: 'localstorage', // valid values are: 'memory' or 'localstorage'
+  cacheLocation: 'localstorage' // valid values are: 'memory' or 'localstorage'
 });
 ```
 
@@ -210,7 +210,7 @@ await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   client_id: '<AUTH0_CLIENT_ID>',
   redirect_uri: '<MY_CALLBACK_URL>',
-  useRefreshTokens: true,
+  useRefreshTokens: true
 });
 ```
 
@@ -225,6 +225,20 @@ In all cases where a refresh token is not available, the SDK falls back to the l
 If the fallback mechanism fails, a `login_required` error will be thrown and could be handled in order to put the user back through the authentication process.
 
 **Note**: This fallback mechanism does still require access to the Auth0 session cookie, so if third-party cookies are being blocked then this fallback will not work and the user must re-authenticate in order to get a new refresh token.
+
+### Advanced options
+
+Advanced options can be set by specifying the `advancedOptions` property when configuring `Auth0Client`. Learn about the complete set of advanced options in the [API documentation](https://auth0.github.io/auth0-spa-js/interfaces/advancedoptions.html)
+
+```js
+createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  client_id: '<AUTH0_CLIENT_ID>',
+  advancedOptions: {
+    defaultScope: 'email' // change the scopes that are applied to every authz request. **Note**: `openid` is always specified regardless of this setting
+  }
+});
+```
 
 ## Contributing
 

--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -111,25 +111,32 @@ describe('Auth0Client', () => {
   });
 
   it('automatically adds the offline_access scope during construction', () => {
-    setup({
+    const auth0 = setup({
       useRefreshTokens: true,
       scope: 'test-scope'
     });
 
-    expect(scope.getUniqueScopes).toHaveBeenCalledWith(
-      'test-scope',
-      'offline_access'
-    );
+    expect((<any>auth0).scope).toBe('test-scope offline_access');
   });
 
   it('ensures the openid scope is defined when customizing default scopes', () => {
-    setup({
+    const auth0 = setup({
       advancedOptions: {
         defaultScope: 'test-scope'
       }
     });
 
-    expect(scope.getUniqueScopes).toHaveBeenCalledWith('openid', 'test-scope');
+    expect((<any>auth0).defaultScope).toBe('openid test-scope');
+  });
+
+  it('allows an empty custom default scope', () => {
+    const auth0 = setup({
+      advancedOptions: {
+        defaultScope: null
+      }
+    });
+
+    expect((<any>auth0).defaultScope).toBe('openid');
   });
 
   it('should log the user in and get the token', async () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -223,24 +223,6 @@ describe('Auth0', () => {
         expect(e.error).toEqual('some_other_error');
       }
     });
-
-    it('should respect advanced defaultScope option when provided', async () => {
-      const { auth0, utils, cache } = await setup({
-        advancedOptions: { defaultScope: 'openid jaffa' }
-      });
-      await auth0.getIdTokenClaims({
-        audience: 'the-audience',
-        scope: 'the-scope'
-      });
-      expect(cache.get).toHaveBeenCalledWith({
-        audience: 'the-audience',
-        scope: TEST_SCOPES
-      });
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid jaffa',
-        'the-scope'
-      );
-    });
   });
 
   describe('loginWithPopup()', () => {
@@ -1344,6 +1326,29 @@ describe('Auth0', () => {
       cache.get.mockReturnValue(userIn);
       const userOut = await auth0.getIdTokenClaims();
       expect(userOut).toEqual(userIn.decodedToken.claims);
+    });
+
+    it('should respect advanced defaultScope option when provided', async () => {
+      const { auth0, utils, cache } = await setup({
+        advancedOptions: { defaultScope: 'openid jaffa' }
+      });
+
+      await auth0.getIdTokenClaims({
+        audience: 'the-audience',
+        scope: 'the-scope'
+      });
+
+      expect(cache.get).toHaveBeenCalledWith({
+        audience: 'the-audience',
+        client_id: TEST_CLIENT_ID,
+        scope: TEST_SCOPES
+      });
+
+      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
+        'openid jaffa',
+        undefined,
+        'the-scope'
+      );
     });
 
     describe('when using refresh tokens', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -4,7 +4,8 @@ jest.mock('../src/storage');
 jest.mock('../src/transaction-manager');
 jest.mock('../src/utils');
 
-import { CacheLocation } from '../src/global';
+import { CacheLocation, Auth0ClientOptions } from '../src/global';
+const scope = require('../src/scope');
 
 import createAuth0Client, {
   Auth0Client,
@@ -14,12 +15,14 @@ import createAuth0Client, {
 import { AuthenticationError } from '../src/errors';
 import version from '../src/version';
 
+import { DEFAULT_POPUP_CONFIG_OPTIONS, DEFAULT_SCOPE } from '../src/constants';
+
 const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
 
 const TEST_DOMAIN = 'test.auth0.com';
 const TEST_CLIENT_ID = 'test-client-id';
 const TEST_QUERY_PARAMS = 'query=params';
-const TEST_SCOPES = 'unique:scopes';
+const TEST_SCOPES = DEFAULT_SCOPE;
 const TEST_ENCODED_STATE = 'encoded-state';
 const TEST_RANDOM_STRING = 'random-string';
 const TEST_ARRAY_BUFFER = 'this-is-an-array-buffer';
@@ -40,8 +43,6 @@ const TEST_TELEMETRY_QUERY_STRING = `&auth0Client=${encodeURIComponent(
   )
 )}`;
 
-import { DEFAULT_POPUP_CONFIG_OPTIONS } from '../src/constants';
-
 const mockEnclosedCache = {
   get: jest.fn(),
   save: jest.fn(),
@@ -61,11 +62,11 @@ const webWorkerMatcher = expect.objectContaining({
   postMessage: expect.any(Function)
 });
 
-const setup = async (options = {}) => {
+const setup = async (clientOptions: Partial<Auth0ClientOptions> = {}) => {
   const auth0 = await createAuth0Client({
     domain: TEST_DOMAIN,
     client_id: TEST_CLIENT_ID,
-    ...options
+    ...clientOptions
   });
 
   const getDefaultInstance = m => require(m).default.mock.instances[0];
@@ -84,7 +85,6 @@ const setup = async (options = {}) => {
   const utils = require('../src/utils');
 
   utils.createQueryParams.mockReturnValue(TEST_QUERY_PARAMS);
-  utils.getUniqueScopes.mockReturnValue(TEST_SCOPES);
   utils.encode.mockReturnValue(TEST_ENCODED_STATE);
   utils.createRandomString.mockReturnValue(TEST_RANDOM_STRING);
   utils.sha256.mockReturnValue(Promise.resolve(TEST_ARRAY_BUFFER));
@@ -139,8 +139,6 @@ const setup = async (options = {}) => {
 
 describe('Auth0', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
-
     window.location.assign = jest.fn();
     window.Worker = jest.fn();
 
@@ -149,6 +147,10 @@ describe('Auth0', () => {
         digest: () => ''
       }
     };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   describe('createAuth0Client()', () => {
@@ -269,6 +271,7 @@ describe('Auth0', () => {
       await auth0.loginWithPopup({
         connection: 'test-connection'
       });
+
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
@@ -605,12 +608,6 @@ describe('Auth0', () => {
 
       await auth0.buildAuthorizeUrl(REDIRECT_OPTIONS);
 
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        undefined,
-        undefined
-      );
-
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
@@ -626,26 +623,15 @@ describe('Auth0', () => {
     });
 
     it('creates correct query params when using refresh tokens', async () => {
-      const utils = require('../src/utils');
-      utils.getUniqueScopes.mockReturnValue('offline_access');
-
-      const { auth0 } = await setup({
+      const { auth0, utils } = await setup({
         useRefreshTokens: true
       });
 
-      // utils.getUniqueScopes.mockReturnValue(`${TEST_SCOPES} offline_access`);
-
       await auth0.buildAuthorizeUrl(REDIRECT_OPTIONS);
-
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        'offline_access',
-        undefined
-      );
 
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
-        scope: TEST_SCOPES,
+        scope: `${TEST_SCOPES} offline_access`,
         response_type: TEST_CODE,
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
@@ -1279,27 +1265,17 @@ describe('Auth0', () => {
         scope: TEST_SCOPES,
         client_id: TEST_CLIENT_ID
       });
-
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        'openid profile email'
-      );
     });
 
     it('uses custom options when provided', async () => {
-      const { auth0, utils, cache } = await setup();
+      const { auth0, cache } = await setup();
       await auth0.getUser({ audience: 'the-audience', scope: 'the-scope' });
 
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'the-audience',
-        scope: TEST_SCOPES,
+        scope: `${TEST_SCOPES} the-scope`,
         client_id: TEST_CLIENT_ID
       });
-
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        'the-scope'
-      );
     });
   });
 
@@ -1329,33 +1305,24 @@ describe('Auth0', () => {
     });
 
     it('should respect advanced defaultScope option when provided', async () => {
-      const { auth0, utils, cache } = await setup({
-        advancedOptions: { defaultScope: 'openid jaffa' }
+      const { auth0, cache } = await setup({
+        advancedOptions: { defaultScope: 'openid custom-scope' }
       });
 
       await auth0.getIdTokenClaims({
         audience: 'the-audience',
-        scope: 'the-scope'
+        scope: 'openid custom-scope'
       });
 
       expect(cache.get).toHaveBeenCalledWith({
         audience: 'the-audience',
         client_id: TEST_CLIENT_ID,
-        scope: TEST_SCOPES
+        scope: 'openid custom-scope'
       });
-
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid jaffa',
-        undefined,
-        'the-scope'
-      );
     });
 
     describe('when using refresh tokens', () => {
       it('uses default options with offine_access', async () => {
-        const utils = require('../src/utils');
-        utils.getUniqueScopes.mockReturnValue('offline_access');
-
         const { auth0, cache } = await setup({
           useRefreshTokens: true
         });
@@ -1364,22 +1331,13 @@ describe('Auth0', () => {
 
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'default',
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} offline_access`,
           client_id: TEST_CLIENT_ID
         });
-
-        expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-          'openid profile email',
-          'offline_access',
-          'offline_access'
-        );
       });
 
       it('uses custom options when provided with offline_access', async () => {
-        const utils = require('../src/utils');
-        utils.getUniqueScopes.mockReturnValue('offline_access');
-
-        const { auth0, cache } = await setup({
+        const { auth0, cache, utils } = await setup({
           useRefreshTokens: true
         });
 
@@ -1390,21 +1348,15 @@ describe('Auth0', () => {
 
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'the-audience',
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} offline_access the-scope`,
           client_id: TEST_CLIENT_ID
         });
-
-        expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-          'openid profile email',
-          'offline_access',
-          'the-scope'
-        );
       });
     });
 
     describe('when not using refresh tokens', () => {
       it('uses default options', async () => {
-        const { auth0, utils, cache } = await setup();
+        const { auth0, cache } = await setup();
 
         await auth0.getIdTokenClaims();
 
@@ -1413,16 +1365,10 @@ describe('Auth0', () => {
           scope: TEST_SCOPES,
           client_id: TEST_CLIENT_ID
         });
-
-        expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-          'openid profile email',
-          undefined,
-          'openid profile email'
-        );
       });
 
       it('uses custom options when provided', async () => {
-        const { auth0, utils, cache } = await setup();
+        const { auth0, cache } = await setup();
 
         await auth0.getIdTokenClaims({
           audience: 'the-audience',
@@ -1431,15 +1377,9 @@ describe('Auth0', () => {
 
         expect(cache.get).toHaveBeenCalledWith({
           audience: 'the-audience',
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} the-scope`,
           client_id: TEST_CLIENT_ID
         });
-
-        expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-          'openid profile email',
-          undefined,
-          'the-scope'
-        );
       });
     });
   });
@@ -1467,7 +1407,7 @@ describe('Auth0', () => {
     describe('when `options.ignoreCache` is false', () => {
       describe('when refresh tokens are not used', () => {
         it('calls `cache.get` with the correct options', async () => {
-          const { auth0, cache, utils } = await setup();
+          const { auth0, cache } = await setup();
           cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
 
           await auth0.getTokenSilently();
@@ -1477,12 +1417,6 @@ describe('Auth0', () => {
             scope: TEST_SCOPES,
             client_id: TEST_CLIENT_ID
           });
-
-          expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-            'openid profile email',
-            undefined,
-            undefined
-          );
         });
 
         it('returns cached access_token when there is a cache', async () => {
@@ -1518,16 +1452,9 @@ describe('Auth0', () => {
 
       describe('when refresh tokens are used', () => {
         it('calls `cache.get` with the correct options', async () => {
-          const utils = require('../src/utils');
-          utils.getUniqueScopes.mockReturnValue('offline_access');
-
           const { auth0, cache } = await setup({
             useRefreshTokens: true
           });
-
-          utils.getUniqueScopes.mockReturnValue(
-            `${TEST_SCOPES} offline_access`
-          );
 
           cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
 
@@ -1538,22 +1465,12 @@ describe('Auth0', () => {
             scope: `${TEST_SCOPES} offline_access`,
             client_id: TEST_CLIENT_ID
           });
-
-          expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-            'openid profile email',
-            'offline_access',
-            undefined
-          );
         });
 
         it('calls the token endpoint with the correct params', async () => {
           const { auth0, cache, utils } = await setup({
             useRefreshTokens: true
           });
-
-          utils.getUniqueScopes.mockReturnValue(
-            `${TEST_SCOPES} offline_access`
-          );
 
           utils.oauthToken.mockReturnValue(
             Promise.resolve({
@@ -1599,10 +1516,10 @@ describe('Auth0', () => {
         });
 
         it('falls back to the iframe method when an audience is specified', async () => {
-          const utils = require('../src/utils');
-          utils.getUniqueScopes.mockReturnValue('offline_access');
+          // const utils = require('../src/utils');
+          // scope.getUniqueScopes.mockReturnValue('offline_access');
 
-          const { auth0 } = await setup({
+          const { auth0, utils } = await setup({
             useRefreshTokens: true
           });
 
@@ -1669,7 +1586,7 @@ describe('Auth0', () => {
         expect(utils.createQueryParams).toHaveBeenCalledWith({
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} test:scope`,
           response_type: TEST_CODE,
           response_mode: 'web_message',
           prompt: 'none',
@@ -1688,7 +1605,7 @@ describe('Auth0', () => {
         expect(utils.createQueryParams).toHaveBeenCalledWith({
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} test:scope`,
           response_type: TEST_CODE,
           response_mode: 'web_message',
           prompt: 'none',
@@ -1710,7 +1627,7 @@ describe('Auth0', () => {
         expect(utils.createQueryParams).toHaveBeenCalledWith({
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} test:scope`,
           response_type: TEST_CODE,
           response_mode: 'web_message',
           prompt: 'none',
@@ -1730,7 +1647,7 @@ describe('Auth0', () => {
         expect(utils.createQueryParams).toHaveBeenCalledWith({
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} test:scope`,
           response_type: TEST_CODE,
           response_mode: 'web_message',
           prompt: 'none',
@@ -1740,12 +1657,6 @@ describe('Auth0', () => {
           code_challenge: TEST_BASE64_ENCODED_STRING,
           code_challenge_method: 'S256'
         });
-
-        expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-          'openid profile email',
-          undefined,
-          defaultOptionsIgnoreCacheTrue.scope
-        );
       });
 
       it('creates correct query params when providing user specified custom query params', async () => {
@@ -1755,11 +1666,13 @@ describe('Auth0', () => {
           ...defaultOptionsIgnoreCacheTrue,
           foo: 'bar'
         };
+
         await auth0.getTokenSilently(customQueryParameterOptions);
+
         expect(utils.createQueryParams).toHaveBeenCalledWith({
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} test:scope`,
           response_type: TEST_CODE,
           response_mode: 'web_message',
           prompt: 'none',
@@ -1863,7 +1776,7 @@ describe('Auth0', () => {
           access_token: TEST_ACCESS_TOKEN,
           audience: defaultOptionsIgnoreCacheTrue.audience,
           id_token: TEST_ID_TOKEN,
-          scope: TEST_SCOPES,
+          scope: `${TEST_SCOPES} test:scope`,
           decodedToken: {
             claims: { sub: TEST_USER_ID, aud: TEST_CLIENT_ID },
             user: { sub: TEST_USER_ID }
@@ -1908,6 +1821,7 @@ describe('Auth0', () => {
       const { auth0, utils } = await localSetup();
 
       await auth0.getTokenWithPopup();
+
       expect(auth0.loginWithPopup).toHaveBeenCalledWith(
         {
           audience: undefined,
@@ -1915,36 +1829,30 @@ describe('Auth0', () => {
         },
         DEFAULT_POPUP_CONFIG_OPTIONS
       );
-
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        undefined,
-        'openid profile email'
-      );
     });
 
     it('calls `loginWithPopup` with the correct custom options', async () => {
-      const { auth0, utils } = await localSetup();
+      const { auth0 } = await localSetup();
       const loginOptions = {
         audience: 'other-audience',
         scope: 'other-scope'
       };
+
       const configOptions = { timeoutInSeconds: 1 };
 
       await auth0.getTokenWithPopup(loginOptions, configOptions);
+
       expect(auth0.loginWithPopup).toHaveBeenCalledWith(
-        loginOptions,
+        {
+          audience: 'other-audience',
+          scope: `${TEST_SCOPES} other-scope`
+        },
         configOptions
-      );
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        undefined,
-        'other-scope'
       );
     });
 
     it('calls `cache.get` with the correct options', async () => {
-      const { auth0, cache, utils } = await localSetup();
+      const { auth0, cache } = await localSetup();
 
       await auth0.getTokenWithPopup();
 
@@ -1953,12 +1861,6 @@ describe('Auth0', () => {
         scope: TEST_SCOPES,
         client_id: TEST_CLIENT_ID
       });
-
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'openid profile email',
-        undefined,
-        'openid profile email'
-      );
     });
 
     it('returns cached access_token', async () => {
@@ -2114,7 +2016,7 @@ describe('default creation function', () => {
       Auth0Client.prototype.getTokenSilently = jest.fn();
 
       require('../src/storage').get = () => true;
-      utils.getUniqueScopes = jest.fn(() => options.scope);
+      // scope.getUniqueScopes = jest.fn(() => options.scope);
 
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
@@ -2128,8 +2030,6 @@ describe('default creation function', () => {
 
   describe('when refresh tokens are used', () => {
     it('creates the client with the correct scopes', async () => {
-      const utils = require('../src/utils');
-
       const options = {
         audience: 'the-audience',
         scope: 'the-scope',
@@ -2139,7 +2039,6 @@ describe('default creation function', () => {
       Auth0Client.prototype.getTokenSilently = jest.fn();
 
       require('../src/storage').get = () => true;
-      utils.getUniqueScopes = jest.fn(() => `${options.scope} offline_access`);
 
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,
@@ -2147,10 +2046,7 @@ describe('default creation function', () => {
         ...options
       });
 
-      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
-        'the-scope',
-        'offline_access'
-      );
+      expect((<any>auth0).scope).toBe('the-scope offline_access');
 
       expect(auth0.getTokenSilently).toHaveBeenCalledWith();
     });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -223,6 +223,24 @@ describe('Auth0', () => {
         expect(e.error).toEqual('some_other_error');
       }
     });
+
+    it('should respect advanced defaultScope option when provided', async () => {
+      const { auth0, utils, cache } = await setup({
+        advancedOptions: { defaultScope: 'openid jaffa' }
+      });
+      await auth0.getIdTokenClaims({
+        audience: 'the-audience',
+        scope: 'the-scope'
+      });
+      expect(cache.get).toHaveBeenCalledWith({
+        audience: 'the-audience',
+        scope: TEST_SCOPES
+      });
+      expect(utils.getUniqueScopes).toHaveBeenCalledWith(
+        'openid jaffa',
+        'the-scope'
+      );
+    });
   });
 
   describe('loginWithPopup()', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1629,9 +1629,6 @@ describe('Auth0', () => {
         });
 
         it('falls back to the iframe method when an audience is specified', async () => {
-          // const utils = require('../src/utils');
-          // scope.getUniqueScopes.mockReturnValue('offline_access');
-
           const { auth0, utils } = await setup({
             useRefreshTokens: true
           });
@@ -2147,7 +2144,6 @@ describe('default creation function', () => {
       Auth0Client.prototype.getTokenSilently = jest.fn();
 
       require('../src/storage').get = () => true;
-      // scope.getUniqueScopes = jest.fn(() => options.scope);
 
       const auth0 = await createAuth0Client({
         domain: TEST_DOMAIN,

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -5,7 +5,7 @@ jest.mock('../src/transaction-manager');
 jest.mock('../src/utils');
 
 import { CacheLocation, Auth0ClientOptions } from '../src/global';
-const scope = require('../src/scope');
+import * as scope from '../src/scope';
 
 import createAuth0Client, {
   Auth0Client,
@@ -138,6 +138,8 @@ const setup = async (clientOptions: Partial<Auth0ClientOptions> = {}) => {
 };
 
 describe('Auth0', () => {
+  let getUniqueScopesSpy;
+
   beforeEach(() => {
     window.location.assign = jest.fn();
     window.Worker = jest.fn();
@@ -147,10 +149,13 @@ describe('Auth0', () => {
         digest: () => ''
       }
     };
+
+    getUniqueScopesSpy = jest.spyOn(scope, 'getUniqueScopes');
   });
 
   afterEach(() => {
     jest.resetAllMocks();
+    getUniqueScopesSpy.mockRestore();
   });
 
   describe('createAuth0Client()', () => {

--- a/__tests__/scope.test.ts
+++ b/__tests__/scope.test.ts
@@ -1,0 +1,15 @@
+import { getUniqueScopes } from '../src/scope';
+
+describe('getUniqueScopes', () => {
+  it('removes duplicates', () => {
+    expect(getUniqueScopes('openid openid', 'email')).toBe('openid email');
+  });
+  it('handles whitespace', () => {
+    expect(getUniqueScopes(' openid    profile  ', ' ')).toBe('openid profile');
+  });
+  it('handles undefined/empty/null', () => {
+    expect(
+      getUniqueScopes('openid profile', 'email', undefined, '', null)
+    ).toBe('openid profile email');
+  });
+});

--- a/__tests__/scope.test.ts
+++ b/__tests__/scope.test.ts
@@ -4,12 +4,14 @@ describe('getUniqueScopes', () => {
   it('removes duplicates', () => {
     expect(getUniqueScopes('openid openid', 'email')).toBe('openid email');
   });
+
   it('handles whitespace', () => {
     expect(getUniqueScopes(' openid    profile  ', ' ')).toBe('openid profile');
   });
-  it('handles undefined/empty/null', () => {
+
+  it('handles undefined/empty/null/whitespace', () => {
     expect(
-      getUniqueScopes('openid profile', 'email', undefined, '', null)
+      getUniqueScopes('openid profile', ' ', undefined, 'email', '', null)
     ).toBe('openid profile email');
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,6 +1,5 @@
 import 'fast-text-encoding';
 import {
-  getUniqueScopes,
   parseQueryResult,
   createQueryParams,
   bufferToBase64UrlEncoded,
@@ -24,21 +23,6 @@ import {
 (<any>global).TextEncoder = TextEncoder;
 
 describe('utils', () => {
-  describe('getUniqueScopes', () => {
-    it('removes duplicates', () => {
-      expect(getUniqueScopes('openid openid', 'email')).toBe('openid email');
-    });
-    it('handles whitespace', () => {
-      expect(getUniqueScopes(' openid    profile  ', ' ')).toBe(
-        'openid profile'
-      );
-    });
-    it('handles undefined/empty/null', () => {
-      expect(
-        getUniqueScopes('openid profile', 'email', undefined, '', null)
-      ).toBe('openid profile email');
-    });
-  });
   describe('parseQueryResult', () => {
     it('parses the query string', () => {
       expect(

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -19,13 +19,17 @@ import TransactionManager from './transaction-manager';
 import { verify as verifyIdToken } from './jwt';
 import { AuthenticationError } from './errors';
 import * as ClientStorage from './storage';
+
 import {
   CACHE_LOCATION_MEMORY,
   DEFAULT_POPUP_CONFIG_OPTIONS,
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
-  MISSING_REFRESH_TOKEN_ERROR_MESSAGE
+  MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
+  DEFAULT_SCOPE
 } from './constants';
+
 import version from './version';
+
 import {
   Auth0ClientOptions,
   BaseLoginOptions,
@@ -85,7 +89,7 @@ export default class Auth0Client {
   private transactionManager: TransactionManager;
   private domainUrl: string;
   private tokenIssuer: string;
-  private readonly DEFAULT_SCOPE = 'openid profile email';
+  private defaultScope: string;
 
   cacheLocation: CacheLocation;
   private worker: Worker;
@@ -124,6 +128,10 @@ export default class Auth0Client {
     ) {
       this.worker = new TokenWorker();
     }
+    this.defaultScope =
+      this.options.advancedOptions && this.options.advancedOptions.defaultScope
+        ? this.options.advancedOptions.defaultScope
+        : DEFAULT_SCOPE;
   }
 
   private _url(path) {
@@ -157,7 +165,7 @@ export default class Auth0Client {
       ...withoutDomain,
       ...authorizeOptions,
       scope: getUniqueScopes(
-        this.DEFAULT_SCOPE,
+        this.defaultScope,
         this.options.scope,
         authorizeOptions.scope
       ),
@@ -328,10 +336,10 @@ export default class Auth0Client {
   public async getUser(
     options: GetUserOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.defaultScope
     }
   ) {
-    options.scope = getUniqueScopes(this.DEFAULT_SCOPE, options.scope);
+    options.scope = getUniqueScopes(this.defaultScope, options.scope);
 
     const cache = this.cache.get({
       client_id: this.options.client_id,
@@ -353,11 +361,11 @@ export default class Auth0Client {
   public async getIdTokenClaims(
     options: GetIdTokenClaimsOptions = {
       audience: this.options.audience || 'default',
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.defaultScope
     }
   ) {
     options.scope = getUniqueScopes(
-      this.DEFAULT_SCOPE,
+      this.defaultScope,
       this.options.scope,
       options.scope
     );
@@ -490,7 +498,7 @@ export default class Auth0Client {
     const { ignoreCache, ...getTokenOptions } = {
       audience: this.options.audience,
       scope: getUniqueScopes(
-        this.DEFAULT_SCOPE,
+        this.defaultScope,
         this.options.scope,
         options.scope
       ),
@@ -549,12 +557,12 @@ export default class Auth0Client {
   public async getTokenWithPopup(
     options: GetTokenWithPopupOptions = {
       audience: this.options.audience,
-      scope: this.options.scope || this.DEFAULT_SCOPE
+      scope: this.options.scope || this.defaultScope
     },
     config: PopupConfigOptions = DEFAULT_POPUP_CONFIG_OPTIONS
   ) {
     options.scope = getUniqueScopes(
-      this.DEFAULT_SCOPE,
+      this.defaultScope,
       this.options.scope,
       options.scope
     );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1,7 +1,6 @@
 import Lock from 'browser-tabs-lock';
 
 import {
-  getUniqueScopes,
   createQueryParams,
   runPopup,
   parseQueryResult,
@@ -14,6 +13,7 @@ import {
   validateCrypto
 } from './utils';
 
+import { getUniqueScopes } from './scope';
 import { InMemoryCache, ICache, LocalStorageCache } from './cache';
 import TransactionManager from './transaction-manager';
 import { verify as verifyIdToken } from './jwt';
@@ -110,6 +110,13 @@ export default class Auth0Client {
     this.tokenIssuer = this.options.issuer
       ? `https://${this.options.issuer}/`
       : `${this.domainUrl}/`;
+
+    this.defaultScope = getUniqueScopes(
+      'openid',
+      this.options.advancedOptions && this.options.advancedOptions.defaultScope
+        ? this.options.advancedOptions.defaultScope
+        : DEFAULT_SCOPE
+    );
 
     // If using refresh tokens, automatically specify the `offline_access` scope
     if (this.options.useRefreshTokens) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -114,7 +114,8 @@ export default class Auth0Client {
 
     this.defaultScope = getUniqueScopes(
       'openid',
-      this.options.advancedOptions && this.options.advancedOptions.defaultScope
+      this.options.advancedOptions &&
+        this.options.advancedOptions.defaultScope !== undefined
         ? this.options.advancedOptions.defaultScope
         : DEFAULT_SCOPE
     );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -135,10 +135,6 @@ export default class Auth0Client {
     ) {
       this.worker = new TokenWorker();
     }
-    this.defaultScope =
-      this.options.advancedOptions && this.options.advancedOptions.defaultScope
-        ? this.options.advancedOptions.defaultScope
-        : DEFAULT_SCOPE;
   }
 
   private _url(path) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -114,8 +114,7 @@ export default class Auth0Client {
 
     this.defaultScope = getUniqueScopes(
       'openid',
-      this.options.advancedOptions &&
-        this.options.advancedOptions.defaultScope !== undefined
+      this.options?.advancedOptions?.defaultScope !== undefined
         ? this.options.advancedOptions.defaultScope
         : DEFAULT_SCOPE
     );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -165,6 +165,7 @@ export default class Auth0Client {
       leeway,
       useRefreshTokens,
       cacheLocation,
+      advancedOptions,
       ...withoutDomain
     } = this.options;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,3 +31,8 @@ export const CACHE_LOCATION_MEMORY = 'memory';
 export const CACHE_LOCATION_LOCAL_STORAGE = 'localstorage';
 export const MISSING_REFRESH_TOKEN_ERROR_MESSAGE =
   'The web worker is missing the refresh token';
+
+/**
+ * @ignore
+ */
+export const DEFAULT_SCOPE = 'openid profile email';

--- a/src/global.ts
+++ b/src/global.ts
@@ -66,7 +66,7 @@ export interface BaseLoginOptions {
 
 interface AdvancedOptions {
   /**
-   * The default scope to be included with all request.
+   * The default scope to be included with all requests.
    * If not provided, 'openid profile email' is used. This can be set to `null` in order to effectively remove the default scopes.
    *
    * Note: The `openid` scope is **always applied** regardless of this setting.
@@ -125,7 +125,7 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   authorizeTimeoutInSeconds?: number;
 
   /**
-   * Changes to recommeded defaults, like defaultScope
+   * Changes to recommended defaults, like defaultScope
    */
   advancedOptions?: AdvancedOptions;
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -40,7 +40,8 @@ export interface BaseLoginOptions {
   acr_values?: string;
   /**
    * The default scope to be used on authentication requests.
-   * `openid profile email` is always added to all requests.
+   * The defaultScope defined in the Auth0Client is included
+   * along with this scope
    */
   scope?: string;
   /**
@@ -59,6 +60,14 @@ export interface BaseLoginOptions {
    * make sure to use the original parameter name.
    */
   [key: string]: any;
+}
+
+interface AdvancedOptions {
+  /**
+   * The default scope to be included with all request.
+   * If not provided, 'openid profile email' is used.
+   */
+  defaultScope?: string;
 }
 
 export interface Auth0ClientOptions extends BaseLoginOptions {
@@ -110,6 +119,11 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * Defaults to 60s.
    */
   authorizeTimeoutInSeconds?: number;
+
+  /**
+   * Changes to recommeded defaults, like defaultScope
+   */
+  advancedOptions?: AdvancedOptions;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -65,7 +65,9 @@ export interface BaseLoginOptions {
 interface AdvancedOptions {
   /**
    * The default scope to be included with all request.
-   * If not provided, 'openid profile email' is used.
+   * If not provided, 'openid profile email' is used. This can be set to `null` in order to effectively remove the default scopes.
+   *
+   * Note: The `openid` scope is **always applied** regardless of this setting.
    */
   defaultScope?: string;
 }
@@ -110,7 +112,7 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * If true, refresh tokens are used to fetch new access tokens from the Auth0 server. If false, the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` is used.
    * The default setting is `false`.
    *
-   * *Note*: Use of refresh tokens must be enabled by an administrator on your Auth0 client application.
+   * **Note**: Use of refresh tokens must be enabled by an administrator on your Auth0 client application.
    */
   useRefreshTokens?: boolean;
 

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,12 @@
+/**
+ * @ignore
+ */
+const dedupe = arr => arr.filter((x, i) => arr.indexOf(x) === i);
+
+/**
+ * @ignore
+ */
+export const getUniqueScopes = (...scopes: string[]) => {
+  const scopeString = scopes.filter(Boolean).join();
+  return dedupe(scopeString.replace(/\s/g, ',').split(',')).join(' ').trim();
+};

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,12 +1,11 @@
 /**
  * @ignore
  */
-const dedupe = arr => arr.filter((x, i) => arr.indexOf(x) === i);
+const dedupe = (arr: string[]) => Array.from(new Set(arr));
 
 /**
  * @ignore
  */
 export const getUniqueScopes = (...scopes: string[]) => {
-  const scopeString = scopes.filter(Boolean).join();
-  return dedupe(scopeString.replace(/\s/g, ',').split(',')).join(' ').trim();
+  return dedupe(scopes.join(' ').trim().split(/\s+/)).join(' ');
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,16 +13,9 @@ import {
   CLEANUP_IFRAME_TIMEOUT_IN_SECONDS
 } from './constants';
 
-const dedupe = arr => arr.filter((x, i) => arr.indexOf(x) === i);
-
 const TIMEOUT_ERROR = { error: 'timeout', error_description: 'Timeout' };
 
 export const createAbortController = () => new AbortController();
-
-export const getUniqueScopes = (...scopes: string[]) => {
-  const scopeString = scopes.filter(Boolean).join();
-  return dedupe(scopeString.replace(/\s/g, ',').split(',')).join(' ').trim();
-};
 
 export const parseQueryResult = (queryString: string) => {
   if (queryString.indexOf('#') > -1) {


### PR DESCRIPTION
### Description

Adds the ability to customize the default scopes that are used with authorization requests.

Today, the SDK defaults these scopes to `openid profile email` plus whatever the developer specifies. However, there is a need to customize what those defaults are.

This PR adds a new `advancedOptions` object to the SDK configuration were the defaults can be specified.

With this implementation, the `openid` scope is still always applied regardless of the default scope configuration. However, the developer has the ability now to remove profile and email scopes should they wish.

This PR also refactors out the `getUniqueScopes` mock so that the actual implementation is used in all cases. To do this, `getUniqueScopes` has been pulled out of `utils.ts` and moved to a new module `scope.ts`. Tests moved as well to match.

### References

This PR is customized from #389 and takes precedence.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
