### PR TITLE
Updated `login_hint` js docs to clarify usage with Lock

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -35,6 +35,8 @@ export interface BaseLoginOptions {
    * The user's email address or other identifier. When your app knows
    * which user is trying to authenticate, you can provide this parameter
    * to pre-fill the email box or select the right session for sign-in.
+   *
+   * This currently only affects the classic Lock experience.
    */
   login_hint?: string;
   acr_values?: string;


### PR DESCRIPTION
### Description

Clarified the usage of `login_hint` to show that it only currently affects using the classic Lock experience; it has no effect when using the newer Universal Login Page.

### References

Fixes #440 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
