### PR TITLE
Moved es-check to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "rimraf dist && rollup -c --watch",
     "start": "npm run dev",
     "docs": "typedoc --options ./typedoc.js --module commonjs",
-    "build": "rimraf dist && rollup -m -c --environment NODE_ENV:production",
+    "build": "rimraf dist && rollup -m -c --environment NODE_ENV:production && npm run test:es-check",
     "build:stats": "npm run build -- --environment WITH_STATS:true && open stats.html",
     "lint:security": "eslint ./src --ext ts --no-eslintrc --config ./.eslintrc.security",
     "test": "jest --coverage",
@@ -24,7 +24,7 @@
     "test:integration:tests": "wait-on http://localhost:3000/ && cypress run",
     "test:integration": "concurrently --raw --kill-others --success first npm:test:integration:server npm:test:integration:tests",
     "print-bundle-size": "node ./scripts/print-bundle-size",
-    "prepack": "npm run build && npm run test:es-check && npm run test && node ./scripts/prepack",
+    "prepack": "npm run build && npm run test && node ./scripts/prepack",
     "release": "node ./scripts/release",
     "release:clean": "node ./scripts/cleanup",
     "publish:cdn": "ccu --trace"


### PR DESCRIPTION
### Description

This PR moves the `es-check` step from `prepack` to `build` in the NPM script block, to help catch ES-related errors earlier.

### References

Inspired by a recent ES error that was caught by happenstance when we upgraded to `1.1.0` of [`rollup-plugin-web-worker-loader`](https://github.com/darionco/rollup-plugin-web-worker-loader/pull/18).

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
