### PR TITLE
Update rollup-plugin-web-worker-loader to 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9280,9 +9280,9 @@
       }
     },
     "rollup-plugin-web-worker-loader": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-0.9.1.tgz",
-      "integrity": "sha512-naWFLgDGCDSk/PJKveGdjxyG/ls1eVoFBrvvC4gRbREnzJDAvgKNyH3DtfA5Hhnrfs10usf5FcWfRCen/rAKrQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.1.1.tgz",
+      "integrity": "sha512-+434+Pa8lvaBMKs2FWCgxvQqMdasr3BMQ8VTZb+JhX6RPSo4PardCGAxER/PEyQJVxYgKihojp0FaMEKSh2lyg==",
       "dev": true
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-typescript2": "^0.27.0",
     "rollup-plugin-visualizer": "^4.0.3",
-    "rollup-plugin-web-worker-loader": "0.9.1",
+    "rollup-plugin-web-worker-loader": "^1.1.1",
     "serve": "^11.3.0",
     "ts-jest": "^24.3.0",
     "tslint": "^6.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,14 +27,8 @@ const getPlugins = (shouldMinify) => {
     }),
     commonjs(),
     typescript({
-      check: false,
       clean: true,
       useTsconfigDeclarationDir: true,
-      include: [
-        'src/**/*.ts',
-        'src/**/*.js',
-        'node_modules/rollup-plugin-web-worker-loader/**/*',
-      ],
       tsconfigOverride: {
         noEmit: false,
         sourceMap: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,15 +15,15 @@ const EXPORT_NAME = 'createAuth0Client';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const shouldGenerateStats = process.env.WITH_STATS === 'true';
-const getPlugins = (shouldMinify) => {
+const getPlugins = shouldMinify => {
   return [
     webWorkerLoader({
       sourceMap: !isProduction,
       preserveSource: !isProduction,
-      pattern: /^[^\/].+\.worker\.ts$/,
+      pattern: /^[^\/].+\.worker\.ts$/
     }),
     resolve({
-      browser: true,
+      browser: true
     }),
     commonjs(),
     typescript({
@@ -33,13 +33,13 @@ const getPlugins = (shouldMinify) => {
         noEmit: false,
         sourceMap: true,
         compilerOptions: {
-          lib: ['dom', 'es6'],
-        },
-      },
+          lib: ['dom', 'es6']
+        }
+      }
     }),
     replace({ 'process.env.NODE_ENV': `'${process.env.NODE_ENV}'` }),
     shouldMinify && terser(),
-    sourcemaps(),
+    sourcemaps()
   ];
 };
 const footer = `('Auth0Client' in this) && this.console && this.console.warn && this.console.warn('Auth0Client already declared on the global namespace');
@@ -53,7 +53,7 @@ let bundles = [
       file: 'dist/auth0-spa-js.development.js',
       footer,
       format: 'umd',
-      sourcemap: true,
+      sourcemap: true
     },
     plugins: [
       ...getPlugins(false),
@@ -61,14 +61,14 @@ let bundles = [
         serve({
           contentBase: ['dist', 'static'],
           open: true,
-          port: 3000,
+          port: 3000
         }),
-      !isProduction && livereload(),
+      !isProduction && livereload()
     ],
     watch: {
-      clearScreen: false,
-    },
-  },
+      clearScreen: false
+    }
+  }
 ];
 
 if (isProduction) {
@@ -80,23 +80,23 @@ if (isProduction) {
           name: EXPORT_NAME,
           file: 'dist/auth0-spa-js.production.js',
           footer,
-          format: 'umd',
-        },
+          format: 'umd'
+        }
       ],
       plugins: [
         ...getPlugins(isProduction),
-        shouldGenerateStats && visualizer(),
-      ],
+        shouldGenerateStats && visualizer()
+      ]
     },
     {
       input: 'src/index.ts',
       output: [
         {
           file: pkg.module,
-          format: 'esm',
-        },
+          format: 'esm'
+        }
       ],
-      plugins: getPlugins(isProduction),
+      plugins: getPlugins(isProduction)
     },
     {
       input: 'src/index.cjs.ts',
@@ -104,11 +104,11 @@ if (isProduction) {
         {
           name: EXPORT_NAME,
           file: pkg.main,
-          format: 'cjs',
-        },
+          format: 'cjs'
+        }
       ],
       plugins: getPlugins(false),
-      external: Object.keys(pkg.dependencies),
+      external: Object.keys(pkg.dependencies)
     }
   );
 }

--- a/static/index.html
+++ b/static/index.html
@@ -106,7 +106,7 @@
             <ul v-for="token in access_tokens">
               <li data-cy="access-token">
                 {{token}} (<a
-                  :href="`https://jwt.io?token=${token}`"
+                  :href="'https://jwt.io?token=' + token"
                   target="_blank"
                   >view</a
                 >)
@@ -121,7 +121,7 @@
           </div>
           <div class="card-body">
             {{ id_token }} (<a
-              :href="`https://jwt.io?token=${id_token}`"
+              :href="'https://jwt.io?token=' + id_token"
               target="_blank"
               >view</a
             >)
@@ -262,7 +262,7 @@
             domain: data.domain || defaultDomain,
             clientId: data.clientId || defaultClientId,
             audience: data.audience || defaultAudience,
-            error: null,
+            error: null
           };
         },
         created: function () {
@@ -283,7 +283,7 @@
           useConstructor: function () {
             this.initializeClient();
             this.saveForm();
-          },
+          }
         },
         methods: {
           initializeClient: function () {
@@ -310,7 +310,7 @@
                     ? 'localstorage'
                     : 'memory',
                   useRefreshTokens: _self.useRefreshTokens,
-                  audience: _self.audience,
+                  audience: _self.audience
                 })
               );
             } else {
@@ -323,7 +323,7 @@
                   ? 'localstorage'
                   : 'memory',
                 useRefreshTokens: _self.useRefreshTokens,
-                audience: _self.audience,
+                audience: _self.audience
               }).then(_init);
             }
           },
@@ -337,7 +337,7 @@
                 useRefreshTokens: this.useRefreshTokens,
                 useConstructor: this.useConstructor,
                 useCache: this.useCache,
-                audience: this.audience,
+                audience: this.audience
               })
             );
           },
@@ -372,7 +372,7 @@
 
             _self.auth0
               .loginWithPopup({
-                redirect_uri: 'http://localhost:3000/callback.html',
+                redirect_uri: 'http://localhost:3000/callback.html'
               })
               .then(function () {
                 auth0.isAuthenticated().then(function (isAuthenticated) {
@@ -383,7 +383,7 @@
           },
           loginRedirect: function () {
             this.auth0.loginWithRedirect({
-              redirect_uri: 'http://localhost:3000/',
+              redirect_uri: 'http://localhost:3000/'
             });
           },
           loginHandleRedirectCallback: function () {
@@ -430,7 +430,7 @@
 
             Promise.all([
               _self.auth0.getTokenSilently({ ignoreCache: true }),
-              _self.auth0.getTokenSilently({ ignoreCache: true }),
+              _self.auth0.getTokenSilently({ ignoreCache: true })
             ]).then(function (tokens) {
               _self.access_tokens = [tokens[0], tokens[1]];
             });
@@ -441,7 +441,7 @@
             _self.auth0
               .getTokenWithPopup({
                 audience: 'https://brucke.auth0.com/api/v2/',
-                scope: 'read:rules',
+                scope: 'read:rules'
               })
               .then(function (token) {
                 _self.access_tokens = [token];
@@ -454,7 +454,7 @@
               audience: 'https://brucke.auth0.com/api/v2/',
               scope: 'read:rules',
               redirect_uri: 'http://localhost:3000/callback.html',
-              ignoreCache: !_self.useCache,
+              ignoreCache: !_self.useCache
             };
 
             _self.auth0
@@ -465,16 +465,16 @@
           },
           logout: function () {
             this.auth0.logout({
-              returnTo: 'http://localhost:3000/',
+              returnTo: 'http://localhost:3000/'
             });
           },
           logoutNoClient: function () {
             this.auth0.logout({
               client_id: null,
-              returnTo: 'http://localhost:3000/',
+              returnTo: 'http://localhost:3000/'
             });
-          },
-        },
+          }
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
### Description

This PR updates [`rollup-plugin-web-worker-loader`](https://github.com/darionco/rollup-plugin-web-worker-loader) to `1.1.1`, to fix an issue with incorrectly detecting node/browser environments during build in a Gatsby/SSR framework.

### References

Fixes #437 
Fixes #424 

### Testing

Tested manually in a new Gatsby site:

```
$ npx gatsby new auth0-gatsby-site
$ cd auth0-gatsby-site
$ npm install @auth0/auth0-spa-js
Add "import createAuth0Client from '@auth0/auth0-spa-js';" to `pages/index.js`
$ gatsby build
```

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
