### PR TITLE
Fix issue with create-react-app webpack build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.7.0-beta.5",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9280,9 +9280,9 @@
       }
     },
     "rollup-plugin-web-worker-loader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.1.1.tgz",
-      "integrity": "sha512-+434+Pa8lvaBMKs2FWCgxvQqMdasr3BMQ8VTZb+JhX6RPSo4PardCGAxER/PEyQJVxYgKihojp0FaMEKSh2lyg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.1.3.tgz",
+      "integrity": "sha512-cEcL8z0jWvBuedFwT1yhJuYsKgb2yUgc5KOkJZ2doP3lyw84lZGda6WefU6fGM6zbMZ9UbNyrB6l5omY5SqF7g==",
       "dev": true
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "rollup-plugin-terser": "^5.3.0",
     "rollup-plugin-typescript2": "^0.27.0",
     "rollup-plugin-visualizer": "^4.0.3",
-    "rollup-plugin-web-worker-loader": "^1.1.1",
+    "rollup-plugin-web-worker-loader": "^1.1.3",
     "serve": "^11.3.0",
     "ts-jest": "^24.3.0",
     "tslint": "^6.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,7 @@ const shouldGenerateStats = process.env.WITH_STATS === 'true';
 const getPlugins = shouldMinify => {
   return [
     webWorkerLoader({
+      targetPlatform: 'browser',
       sourceMap: !isProduction,
       preserveSource: !isProduction,
       pattern: /^[^\/].+\.worker\.ts$/


### PR DESCRIPTION
### Description

Fix warning in Gatsby build and error in Create React App build (in CI mode) 

### References

#447 

### Testing

Tested against Gatsby and Create React App starter apps using https://gist.github.com/adamjmcgrath/ff26be1795aeb1689e657c7fbc885021

#### `master`
```
$ ./run.sh master
...
$ gatsby build
...
warning Critical dependency: require function is used in a way in which dependencies cannot be statically extracted                                                                                                       
...
$ react-scripts build
...
Treating warnings as errors because process.env.CI = true.
Most CI servers set it automatically.
Failed to compile.
./node_modules/@auth0/auth0-spa-js/dist/auth0-spa-js.production.esm.js
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
error Command failed with exit code 1. 
...
``` 

#### `bump-rollup-plugin-web-worker-loader`
```
$ ./run.sh bump-rollup-plugin-web-worker-loader
...
$ gatsby build
# No warnings                                                                                                 
$ react-scripts build
# No warnings
Compiled successfully.
``` 

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
