### PR TITLE
feat: 🎸 Add `nonce` override to `buildAuthorizeUrl`

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -627,6 +627,30 @@ describe('Auth0', () => {
       });
     });
 
+    it('passes through the `nonce` if provided', async () => {
+      const { auth0, utils } = await setup();
+
+      const NONCE = 'abcd';
+
+      await auth0.buildAuthorizeUrl({
+        ...REDIRECT_OPTIONS,
+        nonce: NONCE
+      });
+
+      expect(utils.createQueryParams).toHaveBeenCalledWith({
+        client_id: TEST_CLIENT_ID,
+        scope: TEST_SCOPES,
+        response_type: TEST_CODE,
+        response_mode: 'query',
+        state: TEST_ENCODED_STATE,
+        nonce: NONCE,
+        redirect_uri: REDIRECT_OPTIONS.redirect_uri,
+        code_challenge: TEST_BASE64_ENCODED_STRING,
+        code_challenge_method: 'S256',
+        connection: 'test-connection'
+      });
+    });
+
     it('creates correct query params with different default scopes', async () => {
       const { auth0, utils } = await setup({
         advancedOptions: {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -220,7 +220,7 @@ export default class Auth0Client {
     const { redirect_uri, appState, ...authorizeOptions } = options;
 
     const stateIn = encode(createRandomString());
-    const nonceIn = encode(createRandomString());
+    const nonceIn = options.nonce || encode(createRandomString());
     const code_verifier = createRandomString();
     const code_challengeBuffer = await sha256(code_verifier);
     const code_challenge = bufferToBase64UrlEncoded(code_challengeBuffer);

--- a/src/global.ts
+++ b/src/global.ts
@@ -165,6 +165,10 @@ export interface RedirectLoginOptions extends BaseLoginOptions {
    * Used to add to the URL fragment before redirecting
    */
   fragment?: string;
+  /**
+   * Used to override the nonce
+   */
+  nonce?: string;
 }
 
 export interface RedirectLoginResult {


### PR DESCRIPTION
### Description

Supplying a `nonce` will override the generated value stored in the
transaction prior to construction of the authorize URL. This may be
useful for systems where the webserver provides a value for CSRF
protection that may need to be correlated to Auth0 events.

The `nonce` can now be optionally supplied to the `loginWithRedirect`, `loginWithPopup` and `buildAuthorizeUrl` methods.

### References

- [Persist nonce across requests](https://auth0.com/docs/api-auth/tutorials/nonce#persist-nonces-across-requests)

### Testing

Supply a `nonce` value to one of the methods making use of `buildAuthorizeUrl`. The `nonce` is then stored in the transaction manager.

-  ~~I have added documentation for new/changed functionality in this PR or in auth0.com/docs~~
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
