### PR TITLE
Improve OIDC compliance

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -30,7 +30,8 @@ const assertUrlEquals = (actualUrl, host, path, queryParams) => {
 const assertPost = (url, body, callNum = 0) => {
   const [actualUrl, opts] = mockFetch.mock.calls[callNum];
   expect(url).toEqual(actualUrl);
-  expect(body).toEqual(JSON.parse(opts.body));
+  const parsedBody = utils.parseQueryResult(opts.body);
+  expect(body).toEqual(parsedBody);
 };
 
 const fetchResponse = (ok, json) =>
@@ -655,7 +656,7 @@ describe('Auth0Client', () => {
       )
     ).toBe(true);
 
-    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+    expect(utils.parseQueryResult(mockFetch.mock.calls[1][1].body)).toEqual({
       redirect_uri: 'my_callback_url',
       client_id: 'auth0_client_id',
       grant_type: 'authorization_code',
@@ -687,7 +688,7 @@ describe('Auth0Client', () => {
       customParam: 'hello world'
     });
 
-    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+    expect(utils.parseQueryResult(mockFetch.mock.calls[1][1].body)).toEqual({
       redirect_uri: 'my_callback_url',
       client_id: 'auth0_client_id',
       grant_type: 'refresh_token',

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -1,5 +1,6 @@
 import unfetch from 'unfetch';
 import { MISSING_REFRESH_TOKEN_ERROR_MESSAGE } from '../src/constants';
+import { parseQueryResult, createQueryParams } from '../src/utils';
 
 jest.mock('unfetch');
 
@@ -55,18 +56,18 @@ describe('token worker', () => {
     await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         grant_type: 'authorization_code'
       })
     });
     await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         grant_type: 'refresh_token'
       })
     });
-    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+    expect(parseQueryResult(mockFetch.mock.calls[1][1].body)).toEqual({
       grant_type: 'refresh_token',
       refresh_token: 'foo'
     });
@@ -76,7 +77,7 @@ describe('token worker', () => {
     const response = await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         grant_type: 'refresh_token'
       })
     });
@@ -90,7 +91,7 @@ describe('token worker', () => {
     const response = await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({})
+      body: createQueryParams({})
     });
     expect(response.error).toEqual('fail');
   });
@@ -113,7 +114,7 @@ describe('token worker', () => {
     await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         grant_type: 'authorization_code'
       })
     });
@@ -121,7 +122,7 @@ describe('token worker', () => {
     await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         grant_type: 'refresh_token'
       })
     });
@@ -129,7 +130,7 @@ describe('token worker', () => {
     const result = await messageHandlerAsync({
       url: '/foo',
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         grant_type: 'refresh_token'
       })
     });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -279,8 +279,8 @@ describe('utils', () => {
 
       expect(mockUnfetch).toBeCalledWith('https://test.com/oauth/token', {
         body:
-          '{"redirect_uri":"http://localhost","grant_type":"authorization_code","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
-        headers: { 'Content-type': 'application/json' },
+          'redirect_uri=http%3A%2F%2Flocalhost&grant_type=authorization_code&client_id=client_idIn&code=codeIn&code_verifier=code_verifierIn',
+        headers: { 'Content-type': 'application/x-www-form-urlencoded' },
         method: 'POST',
         signal: abortController.signal
       });

--- a/src/token.worker.ts
+++ b/src/token.worker.ts
@@ -1,4 +1,5 @@
 import { MISSING_REFRESH_TOKEN_ERROR_MESSAGE } from './constants';
+import { parseQueryResult, createQueryParams } from './utils';
 
 /**
  * @ignore
@@ -19,12 +20,12 @@ const messageHandler = async ({
 }) => {
   let json;
   try {
-    const body = JSON.parse(opts.body);
+    const body = parseQueryResult(opts.body);
     if (!body.refresh_token && body.grant_type === 'refresh_token') {
       if (!refreshToken) {
         throw new Error(MISSING_REFRESH_TOKEN_ERROR_MESSAGE);
       }
-      opts.body = JSON.stringify({ ...body, refresh_token: refreshToken });
+      opts.body = createQueryParams({ ...body, refresh_token: refreshToken });
     }
 
     const abortController = new AbortController();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,10 +30,10 @@ export const parseQueryResult = (queryString: string) => {
     parsedQuery[key] = decodeURIComponent(val);
   });
 
-  return <AuthenticationResult>{
-    ...parsedQuery,
-    expires_in: parseInt(parsedQuery.expires_in)
-  };
+  if (parsedQuery.expires_in) {
+    parsedQuery.expires_in = parseInt(parsedQuery.expires_in);
+  }
+  return <any>parsedQuery;
 };
 
 export const runIframe = (
@@ -307,12 +307,12 @@ export const oauthToken = async (
     timeout,
     {
       method: 'POST',
-      body: JSON.stringify({
+      body: createQueryParams({
         redirect_uri: window.location.origin,
         ...options
       }),
       headers: {
-        'Content-type': 'application/json'
+        'Content-type': 'application/x-www-form-urlencoded'
       }
     },
     worker


### PR DESCRIPTION
### Description

At our company (@nhi), we rely on an Identity Provider that is implemented according to the OIDC spec.

Co-authored with @PetterRein, we are proposing some changes for increased compliance with OIDC.

The token endpoint now uses `application/x-www-form-urlencoded` content type, that matches the [OAuth 2.0 spec](https://tools.ietf.org/html/rfc6749#section-4.4.2)

Remaining tasks:
- [x] adding tests
- [x] adding docs (I added TS descriptions to the new parameters, but if something more is needed, please let me know)

---

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### References

[The spec](https://tools.ietf.org/html/rfc6749#section-4.4.2) says that the token endpoint should use `application/x-www-form-urlencoded`.
### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`