### PR TITLE
[SDK-1649] Fix issue where cache was missed when scope parameter was provided

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -512,4 +512,33 @@ describe('Auth0Client', () => {
       value: originalUserAgent
     });
   });
+
+  it('uses the cache for multiple token requests with audience and scope', async () => {
+    const auth0 = setup();
+    await login(auth0);
+    jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+      access_token: 'my_access_token',
+      state: 'MTIz'
+    });
+    mockFetch.mockResolvedValue(
+      fetchResponse(true, {
+        id_token: 'my_id_token',
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token',
+        expires_in: 86400
+      })
+    );
+    let access_token = await auth0.getTokenSilently({
+      audience: 'foo',
+      scope: 'bar'
+    });
+    expect(access_token).toEqual('my_access_token');
+    expect(utils.runIframe).toHaveBeenCalledTimes(1);
+    access_token = await auth0.getTokenSilently({
+      audience: 'foo',
+      scope: 'bar'
+    });
+    expect(access_token).toEqual('my_access_token');
+    expect(utils.runIframe).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -534,11 +534,12 @@ describe('Auth0Client', () => {
     });
     expect(access_token).toEqual('my_access_token');
     expect(utils.runIframe).toHaveBeenCalledTimes(1);
+    (<jest.Mock>utils.runIframe).mockClear();
     access_token = await auth0.getTokenSilently({
       audience: 'foo',
       scope: 'bar'
     });
     expect(access_token).toEqual('my_access_token');
-    expect(utils.runIframe).toHaveBeenCalledTimes(1);
+    expect(utils.runIframe).not.toHaveBeenCalled();
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -501,9 +501,9 @@ export default class Auth0Client {
   public async getTokenSilently(options: GetTokenSilentlyOptions = {}) {
     const { ignoreCache, ...getTokenOptions } = {
       audience: this.options.audience,
-      scope: getUniqueScopes(this.defaultScope, this.scope, options.scope),
       ignoreCache: false,
-      ...options
+      ...options,
+      scope: getUniqueScopes(this.defaultScope, this.scope, options.scope)
     };
 
     try {


### PR DESCRIPTION
### Description

Multiple calls to `getTokenSilently` with the `scope` argument (eg `getTokenSilently({ audience: 'https://api/tv-shows', scope: 'read:shows' })`) will miss the cache because the scope argument is not being applied to the SDKs default scopes correctly

### Testing

Subsequent calls to `getTokenSilently` with `audience` and `scope` should not use the network

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
