### PR TITLE
Refresh Tokens to keep defaultScopes applied

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1558,7 +1558,8 @@ describe('Auth0', () => {
               refresh_token: TEST_REFRESH_TOKEN,
               client_id: TEST_CLIENT_ID,
               grant_type: 'refresh_token',
-              redirect_uri: 'http://localhost'
+              redirect_uri: 'http://localhost',
+              scope: `${TEST_SCOPES} offline_access`
             },
             webWorkerMatcher
           );
@@ -1609,7 +1610,8 @@ describe('Auth0', () => {
               refresh_token: TEST_REFRESH_TOKEN,
               client_id: TEST_CLIENT_ID,
               grant_type: 'refresh_token',
-              redirect_uri: 'http://localhost'
+              redirect_uri: 'http://localhost',
+              scope: `openid email offline_access`
             },
             webWorkerMatcher
           );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -725,7 +725,8 @@ export default class Auth0Client {
           client_id: this.options.client_id,
           grant_type: 'refresh_token',
           refresh_token: cache && cache.refresh_token,
-          redirect_uri
+          redirect_uri,
+          scope: options.scope
         } as RefreshTokenOptions,
         this.worker
       );


### PR DESCRIPTION
### Description

When using refresh tokens and making calls to oauth/token - pass scopes calculated (from defaultScopes + handed in options).

Currently defaultScope is missed after intial login when a refresh happens.

### Testing

Set defaultScope to something, login, call for fresh token (ignoreCache: true) and see scope is not passed to oauth/token.

After applying fix, the scope is sent with the rest of the payload to oauth/token.

- [x] This change updates existing tests for expected functionality passing scope

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
