### PR TITLE
[SDK-1634] Pass custom options to the token endpoint

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -528,7 +528,6 @@ describe('Auth0Client', () => {
         expires_in: 86400
       })
     );
-
     let access_token = await auth0.getTokenSilently({
       audience: 'foo',
       scope: 'bar'
@@ -544,7 +543,37 @@ describe('Auth0Client', () => {
     expect(utils.runIframe).not.toHaveBeenCalled();
   });
 
-  it('sends custom options through to the token endpoint', async () => {
+  it('sends custom options through to the token endpoint when using an iframe', async () => {
+    const auth0 = setup();
+
+    await login(auth0, true);
+
+    jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+      access_token: 'my_access_token',
+      state: 'MTIz'
+    });
+
+    await auth0.getTokenSilently({
+      ignoreCache: true,
+      customParam: 'hello world'
+    });
+
+    expect(
+      (<any>utils.runIframe).mock.calls[0][0].includes(
+        'customParam=hello%20world'
+      )
+    ).toBe(true);
+
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+      redirect_uri: 'my_callback_url',
+      client_id: 'auth0_client_id',
+      grant_type: 'authorization_code',
+      customParam: 'hello world',
+      code_verifier: '123'
+    });
+  });
+
+  it('sends custom options through to the token endpoint when using refresh tokens', async () => {
     const auth0 = setup({
       useRefreshTokens: true
     });
@@ -559,6 +588,8 @@ describe('Auth0Client', () => {
         expires_in: 86400
       })
     );
+
+    expect(utils.runIframe).not.toHaveBeenCalled();
 
     const access_token = await auth0.getTokenSilently({
       ignoreCache: true,

--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -528,6 +528,7 @@ describe('Auth0Client', () => {
         expires_in: 86400
       })
     );
+
     let access_token = await auth0.getTokenSilently({
       audience: 'foo',
       scope: 'bar'
@@ -541,5 +542,37 @@ describe('Auth0Client', () => {
     });
     expect(access_token).toEqual('my_access_token');
     expect(utils.runIframe).not.toHaveBeenCalled();
+  });
+
+  it('sends custom options through to the token endpoint', async () => {
+    const auth0 = setup({
+      useRefreshTokens: true
+    });
+
+    await login(auth0, true, { refresh_token: 'a_refresh_token' });
+
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse(true, {
+        id_token: 'my_id_token',
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token',
+        expires_in: 86400
+      })
+    );
+
+    const access_token = await auth0.getTokenSilently({
+      ignoreCache: true,
+      customParam: 'hello world'
+    });
+
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
+      redirect_uri: 'my_callback_url',
+      client_id: 'auth0_client_id',
+      grant_type: 'refresh_token',
+      refresh_token: 'a_refresh_token',
+      customParam: 'hello world'
+    });
+
+    expect(access_token).toEqual('my_access_token');
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -728,7 +728,14 @@ export default class Auth0Client {
       window.location.origin;
 
     let tokenResult;
-    const { scope, audience, ignoreCache, ...customOptions } = options;
+
+    const {
+      scope,
+      audience,
+      ignoreCache,
+      timeoutInSeconds,
+      ...customOptions
+    } = options;
 
     try {
       tokenResult = await oauthToken(
@@ -750,6 +757,7 @@ export default class Auth0Client {
       }
       throw e;
     }
+
     const decodedToken = this._verifyIdToken(tokenResult.id_token);
 
     return {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -693,14 +693,8 @@ export default class Auth0Client {
   private async _getTokenUsingRefreshToken(
     options: GetTokenSilentlyOptions
   ): Promise<any> {
-    options.scope = getUniqueScopes(
-      this.defaultScope,
-      this.scope,
-      options.scope
-    );
-
     const cache = this.cache.get({
-      scope: options.scope,
+      scope: getUniqueScopes(this.defaultScope, this.scope, options.scope),
       audience: options.audience || 'default',
       client_id: this.options.client_id
     });
@@ -718,9 +712,12 @@ export default class Auth0Client {
       window.location.origin;
 
     let tokenResult;
+    const { scope, audience, ignoreCache, ...customOptions } = options;
+
     try {
       tokenResult = await oauthToken(
         {
+          ...customOptions,
           baseUrl: this.domainUrl,
           client_id: this.options.client_id,
           grant_type: 'refresh_token',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -673,6 +673,7 @@ export default class Auth0Client {
       audience,
       redirect_uri,
       ignoreCache,
+      timeoutInSeconds,
       ...customOptions
     } = options;
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -668,8 +668,17 @@ export default class Auth0Client {
       throw new Error('Invalid state');
     }
 
+    const {
+      scope,
+      audience,
+      redirect_uri,
+      ignoreCache,
+      ...customOptions
+    } = options;
+
     const tokenResult = await oauthToken(
       {
+        ...customOptions,
         baseUrl: this.domainUrl,
         client_id: this.options.client_id,
         code_verifier,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -703,8 +703,14 @@ export default class Auth0Client {
   private async _getTokenUsingRefreshToken(
     options: GetTokenSilentlyOptions
   ): Promise<any> {
+    options.scope = getUniqueScopes(
+      this.defaultScope,
+      this.options.scope,
+      options.scope
+    );
+
     const cache = this.cache.get({
-      scope: getUniqueScopes(this.defaultScope, this.scope, options.scope),
+      scope: options.scope,
       audience: options.audience || 'default',
       client_id: this.options.client_id
     });

--- a/src/global.ts
+++ b/src/global.ts
@@ -313,6 +313,7 @@ export interface TokenEndpointOptions {
   client_id: string;
   grant_type: string;
   timeout?: number;
+  [key: string]: any;
 }
 
 /**

--- a/static/index.html
+++ b/static/index.html
@@ -414,7 +414,10 @@
             var _self = this;
 
             _self.auth0
-              .getTokenSilently({ ignoreCache: !_self.useCache })
+              .getTokenSilently({
+                ignoreCache: !_self.useCache,
+                aCustomOption: 'hello world'
+              })
               .then(function (token) {
                 _self.access_tokens.push(token);
                 _self.error = null;


### PR DESCRIPTION
### Description

This fixes the ability to send custom options when using `getTokenSilently` in conjunction with using refresh tokens.

When using custom parameters with `getTokenSilently`, these custom options are now sent to both the **authorize** endpoint in the query string and the **token** endpoint in the request body (when not using refresh tokens), and to the **token** endpoint only, when using refresh tokens.

These custom parameters can then be picked up in a custom Rule.

This functionality appeared to work in when not using refresh tokens, as you could pass custom options and they would be sent, but only to the authorize endpoint.

### References

Fixes #448 

### Testing

Added test coverage, also tested manually using the playground.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
