### PR TITLE
Add `checkSession` and ignore recoverable errors

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -1,4 +1,5 @@
 import 'fast-text-encoding';
+import * as esCookie from 'es-cookie';
 import Auth0Client from '../src/Auth0Client';
 import unfetch from 'unfetch';
 import { verify } from '../src/jwt';
@@ -8,6 +9,7 @@ import { Auth0ClientOptions, IdToken } from '../src';
 import * as scope from '../src/scope';
 
 jest.mock('unfetch');
+jest.mock('es-cookie');
 jest.mock('../src/jwt');
 jest.mock('../src/token.worker');
 
@@ -605,5 +607,36 @@ describe('Auth0Client', () => {
     });
 
     expect(access_token).toEqual('my_access_token');
+  });
+
+  it("skips checking the auth0 session when there's no auth cookie", async () => {
+    const auth0 = setup();
+
+    jest.spyOn(<any>utils, 'runIframe');
+
+    await auth0.checkSession();
+
+    expect(utils.runIframe).not.toHaveBeenCalled();
+  });
+
+  it('checks the auth0 session when there is an auth cookie', async () => {
+    const auth0 = setup();
+
+    jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+      access_token: 'my_access_token',
+      state: 'MTIz'
+    });
+    (<jest.Mock>esCookie.get).mockReturnValue(true);
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse(true, {
+        id_token: 'my_id_token',
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token',
+        expires_in: 86400
+      })
+    );
+    await auth0.checkSession();
+
+    expect(utils.runIframe).toHaveBeenCalled();
   });
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -205,7 +205,28 @@ describe('Auth0', () => {
       expect(utils.runIframe).toHaveBeenCalled();
     });
 
-    it('should throw other errors that are not "login_required"', async () => {
+    it('should absorb "consent_required" errors', async () => {
+      const { utils, storage } = await setup();
+
+      utils.runIframe.mockImplementation(() => {
+        throw {
+          error: 'consent_required',
+          error_message: 'Consent required'
+        };
+      });
+
+      storage.get.mockReturnValue(true);
+
+      const auth0 = await createAuth0Client({
+        domain: TEST_DOMAIN,
+        client_id: TEST_CLIENT_ID
+      });
+
+      expect(auth0).toBeInstanceOf(Auth0Client);
+      expect(utils.runIframe).toHaveBeenCalled();
+    });
+
+    it('should throw for other errors that are not recoverable', async () => {
       const { utils, storage } = await setup();
 
       utils.runIframe.mockImplementation(() => {
@@ -217,18 +238,17 @@ describe('Auth0', () => {
 
       storage.get.mockReturnValue(true);
 
-      // We expect one assertion, meaning that if the function under test
-      // does not throw, it will still fail the test.
-      expect.assertions(1);
+      await expect(Promise.reject(new Error('foo'))).rejects.toThrow(Error);
 
-      try {
-        await createAuth0Client({
+      await expect(
+        createAuth0Client({
           domain: TEST_DOMAIN,
           client_id: TEST_CLIENT_ID
-        });
-      } catch (e) {
-        expect(e.error).toEqual('some_other_error');
-      }
+        })
+      ).rejects.toStrictEqual({
+        error: 'some_other_error',
+        error_message: 'This is a different error to login_required'
+      });
     });
   });
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -2149,7 +2149,7 @@ describe('default creation function', () => {
       client_id: TEST_CLIENT_ID
     });
 
-    expect(auth0.getTokenSilently).toHaveBeenCalledWith();
+    expect(auth0.getTokenSilently).toHaveBeenCalledWith(undefined);
   });
 
   describe('when refresh tokens are not used', () => {
@@ -2171,7 +2171,7 @@ describe('default creation function', () => {
         ...options
       });
 
-      expect(auth0.getTokenSilently).toHaveBeenCalledWith();
+      expect(auth0.getTokenSilently).toHaveBeenCalledWith(undefined);
     });
   });
 
@@ -2195,7 +2195,7 @@ describe('default creation function', () => {
 
       expect((<any>auth0).scope).toBe('the-scope offline_access');
 
-      expect(auth0.getTokenSilently).toHaveBeenCalledWith();
+      expect(auth0.getTokenSilently).toHaveBeenCalledWith(undefined);
     });
   });
 
@@ -2219,7 +2219,7 @@ describe('default creation function', () => {
         ...options
       });
 
-      expect(auth0.getTokenSilently).toHaveBeenCalledWith();
+      expect(auth0.getTokenSilently).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -25,7 +25,8 @@ import {
   DEFAULT_POPUP_CONFIG_OPTIONS,
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
   MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
-  DEFAULT_SCOPE
+  DEFAULT_SCOPE,
+  RECOVERABLE_ERRORS
 } from './constants';
 
 import version from './version';
@@ -471,6 +472,38 @@ export default class Auth0Client {
     return {
       appState: transaction.appState
     };
+  }
+
+  /**
+   * ```js
+   * await auth0.checkSession();
+   * ```
+   *
+   * Check if the user is logged in using `getTokenSilently`. The difference
+   * with `getTokenSilently` is that this doesn't return a token, but it will
+   * pre-fill the token cache.
+   *
+   * It should be used for silently logging in the user when you instantiate the
+   * `Auth0Client` constructor. You should not need this if you are using the
+   * `createAuth0Client` factory.
+   *
+   * @param options
+   */
+  public async checkSession(options?: GetTokenSilentlyOptions) {
+    if (
+      this.cacheLocation === CACHE_LOCATION_MEMORY &&
+      !ClientStorage.get('auth0.is.authenticated')
+    ) {
+      return;
+    }
+
+    try {
+      await this.getTokenSilently(options);
+    } catch (error) {
+      if (!RECOVERABLE_ERRORS.includes(error.error)) {
+        throw error;
+      }
+    }
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,3 +36,20 @@ export const MISSING_REFRESH_TOKEN_ERROR_MESSAGE =
  * @ignore
  */
 export const DEFAULT_SCOPE = 'openid profile email';
+
+/**
+ * A list of errors that can be issued by the authorization server which the
+ * user can recover from by signing in interactively.
+ * https://openid.net/specs/openid-connect-core-1_0.html#AuthError
+ * @ignore
+ */
+export const RECOVERABLE_ERRORS = [
+  'login_required',
+  'consent_required',
+  'interaction_required',
+  'account_selection_required',
+  // Strictly speaking the user can't recover from `access_denied` - but they
+  // can get more information about their access being denied by logging in
+  // interactively.
+  'access_denied'
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,7 @@ import 'fast-text-encoding';
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 
 import Auth0Client from './Auth0Client';
-import * as ClientStorage from './storage';
 import { Auth0ClientOptions } from './global';
-import { CACHE_LOCATION_MEMORY } from './constants';
 
 import './global';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,22 +19,7 @@ export * from './global';
 
 export default async function createAuth0Client(options: Auth0ClientOptions) {
   const auth0 = new Auth0Client(options);
-
-  if (
-    auth0.cacheLocation === CACHE_LOCATION_MEMORY &&
-    !ClientStorage.get('auth0.is.authenticated')
-  ) {
-    return auth0;
-  }
-
-  try {
-    await auth0.getTokenSilently();
-  } catch (error) {
-    if (error.error !== 'login_required') {
-      throw error;
-    }
-  }
-
+  await auth0.checkSession();
   return auth0;
 }
 


### PR DESCRIPTION
### Description

Add `checkSession` method as a convenience for those who want to use the constructor.

e.g.

```js
const auth0 = new Auth0Client({ ... });
await auth0.checkSession();
const isAuthenticated = await auth0.isAuthenticated();
```

Also added some additional errors that are 'recoverable' - meaning that `checkSession` should ignore them because the user can recover from those errors and successfully login interactively.

### References

#402
#470 
#485
https://dev.to/kleeut/solving-consentrequired-auth0-spa-sdk-1le2

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
