### PR TITLE
Update docs for returnTo and client_id params on logout

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -269,17 +269,25 @@ export interface LogoutOptions {
   /**
    * The URL where Auth0 will redirect your browser to after the logout.
    *
-   * > Note that if the `client_id` parameter is included, the
+   * **Note**: If the `client_id` parameter is included, the
    * `returnTo` URL that is provided must be listed in the
    * Application's "Allowed Logout URLs" in the Auth0 dashboard.
    * However, if the `client_id` parameter is not included, the
    * `returnTo` URL must be listed in the "Allowed Logout URLs" at
    * the account level in the Auth0 dashboard.
+   *
+   * [Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)
    */
   returnTo?: string;
 
   /**
    * The `client_id` of your application.
+   *
+   * If this property is not set, then the `client_id` that was used during initialization of the SDK is sent to the logout endpoint.
+   *
+   * If this property is set to `null`, then no client ID value is sent to the logout endpoint.
+   *
+   * [Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)
    */
   client_id?: string;
 


### PR DESCRIPTION
### Description

This PR updates the docs for the `returnTo` and `client_id` params on logout, to make it more clear what happens when certain params are omitted.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
