### PR TITLE
Prevent uncaught timeout promise rejection. Fixes #483

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -350,10 +350,9 @@ describe('Auth0Client', () => {
     await expect(auth0.getTokenSilently({ ignoreCache: true })).rejects.toThrow(
       `Timeout when executing 'fetch'`
     );
-    // Called once for the authorization grant (noop)
     // Called thrice for the refresh token grant in utils (noop)
     // Called thrice for the refresh token grant in token worker
-    expect(AbortController.prototype.abort).toBeCalledTimes(7);
+    expect(AbortController.prototype.abort).toBeCalledTimes(6);
     expect(mockFetch).toBeCalledTimes(3);
     Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
       get: () => originalDefaultFetchTimeoutMs
@@ -448,9 +447,8 @@ describe('Auth0Client', () => {
     await expect(auth0.getTokenSilently({ ignoreCache: true })).rejects.toThrow(
       `Timeout when executing 'fetch'`
     );
-    // Called once for the authorization grant (noop)
     // Called thrice for the refresh token grant in utils
-    expect(AbortController.prototype.abort).toBeCalledTimes(4);
+    expect(AbortController.prototype.abort).toBeCalledTimes(3);
     expect(mockFetch).toBeCalledTimes(3);
     Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
       get: () => originalDefaultFetchTimeoutMs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,7 +229,7 @@ const switchFetch = async (url, opts, timeout, worker) => {
   }
 };
 
-const fetchWithTimeout = (
+export const fetchWithTimeout = (
   url,
   options,
   worker,
@@ -243,16 +243,19 @@ const fetchWithTimeout = (
     signal
   };
 
+  let timeoutId;
   // The promise will resolve with one of these two promises (the fetch or the timeout), whichever completes first.
   return Promise.race([
     switchFetch(url, fetchOptions, timeout, worker),
     new Promise((_, reject) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         controller.abort();
         reject(new Error("Timeout when executing 'fetch'"));
       }, timeout);
     })
-  ]);
+  ]).finally(() => {
+    clearTimeout(timeoutId);
+  });
 };
 
 const getJSON = async (url, timeout, options, worker) => {


### PR DESCRIPTION
### Description

Recap of #483:
> Even when the `fetchWithTimeout` function (in src/utils.ts) resolves successfully (i.e. there is no timeout) it still produces an uncaught promise rejection (Error: Timeout when executing 'fetch'). While this has no impact on the application, it does causes Chrome devtools to pause it's debugger (when the "Pause on exceptions" option is enabled). As an application developer, this behavior is unintuitive since everything appears to work as expected, and there are no network requests timing out.

As suggested by @adamjmcgrath, this change clears the timeout in `fetchWithTimeout` when the `switchFetch` resolves before the timeout promise. 

### References

Fixes #483 

### Testing

I did include a regression test - though I'll be the first to admit that it's less than ideal as it's testing implementation, not behavior. That said, I'm unsure if it's possible to directly verify the absence of an unreferenced & uncaught promise rejection without jumping through hoops. I'm open to other approaches, or to removing the test altogether.

If nothing else, two tests in `Auth0Client.test.ts` indirectly verify this behavior by counting how often `AbortController.prototype.abort` is called.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
