### PR TITLE
[SDK-1699] Fix ID token validation for auth_time

### DIFF
--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -59,6 +59,21 @@ const verifier = new IDTokenVerifier({
 verifier.getRsaVerifier = (_, __, cb) => cb(null, { verify: () => true });
 
 describe('jwt', () => {
+  const IDTOKEN_ERROR_MESSAGE = 'ID token could not be decoded';
+  let now: number;
+  let realDateNowFn: () => number;
+
+  beforeEach(() => {
+    // Mock the date, but pin it to the current time so that everything gets the same time
+    realDateNowFn = Date.now;
+    now = realDateNowFn();
+    global.Date.now = jest.fn(() => now);
+  });
+
+  afterEach(() => {
+    global.Date.now = realDateNowFn;
+  });
+
   it('decodes correctly', () => {
     const id_token =
       'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp0cnVlLCJpYXQiOjE1NTEzNjIzOTAsImV4cCI6MTU1MTM2NTk5MCwiYXVkIjoiazV1M28yZmlBQThYd2VYRUVYNjA0S0N3Q2p6anRNVTYiLCJpc3MiOiJodHRwczovL2JydWNrZS5hdXRoMC5jb20vIn0.MeU2xC4qwr6JvYeDjCRbzT78mvugpVcSlkoGqRsA-ig-JUHuKMsBO1mNgsilRaxulf_zEl-XktKpq9IisamKSRe1UeboESXsZ02nbZqP5i0X4pdYnTI9Z51Iuet2GAJqPDTMpyj-BA0yiROd1X3Ot91_Fh1ZU7EyZmYdoyJrx_Cue1ituMMIWBk1JOs6rMKy1xVCFoDk20upQzf5Xuy2oGtaRhrQzz5sdRR9Y5yxEN5kzcHrGVaZ_fLMYkUDF_aKv4PTFU-I-0HpP_-4PtcjTUJpeXDK_7BzpA6fAdnqaRTl6iYgNKl7R19_8QfQpoTkeJBmZ7HxW_13s03G5jNLSg';
@@ -89,21 +104,6 @@ describe('jwt', () => {
     });
   });
   describe('validates id_token', () => {
-    const IDTOKEN_ERROR_MESSAGE = 'ID token could not be decoded';
-    let now: number;
-    let realDateNowFn: () => number;
-
-    beforeEach(() => {
-      // Mock the date, but pin it to the current time so that everything gets the same time
-      realDateNowFn = Date.now;
-      now = realDateNowFn();
-      global.Date.now = jest.fn(() => now);
-    });
-
-    afterEach(() => {
-      global.Date.now = realDateNowFn;
-    });
-
     it('throws when there is less than 3 parts', () => {
       expect(() => decode('test')).toThrow(IDTOKEN_ERROR_MESSAGE);
       expect(() => decode('test.')).toThrow(IDTOKEN_ERROR_MESSAGE);
@@ -122,6 +122,7 @@ describe('jwt', () => {
       expect(() => decode('test.test.')).toThrow(IDTOKEN_ERROR_MESSAGE);
     });
   });
+
   it('verifies correctly', async done => {
     const id_token = await createJWT();
     const { encoded, header, claims } = verify({

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -296,7 +296,7 @@ describe('jwt', () => {
   });
 
   it('validate auth_time + max_age is in the future', async () => {
-    const yesterday = new Date(now);
+    const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
 
     const maxAge = 1;

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -159,13 +159,15 @@ export const verify = (options: JWTVerifyOptions) => {
   }
 
   const leeway = options.leeway || 60;
-  const now = new Date();
+  const now = new Date(Date.now());
   const expDate = new Date(0);
   const nbfDate = new Date(0);
   const authTimeDate = new Date(0);
+
   authTimeDate.setUTCSeconds(
-    (parseInt(decoded.claims.auth_time) + options.max_age) / 1000 + leeway
+    parseInt(decoded.claims.auth_time) + options.max_age + leeway
   );
+
   expDate.setUTCSeconds(decoded.claims.exp + leeway);
   nbfDate.setUTCSeconds(decoded.claims.nbf - leeway);
 


### PR DESCRIPTION
### Description

The `auth_time` claim was being incorrectly validated in milliseconds, where this should be seconds.

### References

Fixes #489 

### Testing

The relevant test was also incorrectly suppling test data in ms, so this has been updated. The test also only validated half of the validation message (the part which doesn't include the time), so this has been improved to correctly validate the entire string.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
