### PR TITLE
Don't include mocks in build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "declarationDir": "./dist/typings",
     "moduleResolution": "node"
   },
-  "exclude": ["./__tests__", "./dist/typings"]
+  "exclude": ["./__tests__", "./dist/typings", "**/__mocks__/**"]
 }


### PR DESCRIPTION
### Description

We don't need to include `__mocks__` in the output build. It also breaks ts when using `typeRoots`

### References

Fixes #498 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
