### PR TITLE
[SDK-1650] Add `message` to errors that don't have one

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,7 +4,12 @@ export class GenericError extends Error {
 
     Object.setPrototypeOf(this, GenericError.prototype);
   }
+
+  static fromPayload({ error, error_description }) {
+    return new GenericError(error, error_description);
+  }
 }
+
 export class AuthenticationError extends GenericError {
   constructor(
     error: string,
@@ -15,5 +20,21 @@ export class AuthenticationError extends GenericError {
     super(error, error_description);
     //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, AuthenticationError.prototype);
+  }
+}
+
+export class TimeoutError extends GenericError {
+  constructor() {
+    super('timeout', 'Timeout');
+    //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, TimeoutError.prototype);
+  }
+}
+
+export class PopupTimeoutError extends TimeoutError {
+  constructor(public popup: Window) {
+    super();
+    //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, PopupTimeoutError.prototype);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ import {
   CLEANUP_IFRAME_TIMEOUT_IN_SECONDS
 } from './constants';
 
-const TIMEOUT_ERROR = { error: 'timeout', error_description: 'Timeout' };
+import { PopupTimeoutError, TimeoutError, GenericError } from './errors';
 
 export const createAbortController = () => new AbortController();
 
@@ -54,7 +54,7 @@ export const runIframe = (
     };
 
     const timeoutSetTimeoutId = setTimeout(() => {
-      rej(TIMEOUT_ERROR);
+      rej(new TimeoutError());
       removeIframe();
     }, timeoutInSeconds * 1000);
 
@@ -65,7 +65,9 @@ export const runIframe = (
       if (eventSource) {
         (<any>eventSource).close();
       }
-      e.data.response.error ? rej(e.data.response) : res(e.data.response);
+      e.data.response.error
+        ? rej(GenericError.fromPayload(e.data.response))
+        : res(e.data.response);
       clearTimeout(timeoutSetTimeoutId);
       window.removeEventListener('message', iframeEventHandler, false);
       // Delay the removal of the iframe to prevent hanging loading status
@@ -106,7 +108,7 @@ export const runPopup = (authorizeUrl: string, config: PopupConfigOptions) => {
 
   return new Promise<AuthenticationResult>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
-      reject({ ...TIMEOUT_ERROR, popup });
+      reject(new PopupTimeoutError(popup));
     }, (config.timeoutInSeconds || DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS) * 1000);
     window.addEventListener('message', e => {
       if (!e.data || e.data.type !== 'authorization_response') {
@@ -115,7 +117,7 @@ export const runPopup = (authorizeUrl: string, config: PopupConfigOptions) => {
       clearTimeout(timeoutId);
       popup.close();
       if (e.data.response.error) {
-        return reject(e.data.response);
+        return reject(GenericError.fromPayload(e.data.response));
       }
       resolve(e.data.response);
     });
@@ -276,6 +278,9 @@ const getJSON = async (url, timeout, options, worker) => {
   }
 
   if (fetchError) {
+    // unfetch uses XMLHttpRequest under the hood which throws
+    // ProgressEvents on error, which don't have message properties
+    fetchError.message = fetchError.message || 'Failed to fetch';
     throw fetchError;
   }
 


### PR DESCRIPTION
### Description

All errors from the SDK should have a `message` property

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
