### PR TITLE
[SDK-1789] Add custom initial options to the 2 getToken methods

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -635,7 +635,10 @@ describe('Auth0Client', () => {
   });
 
   it('sends custom options through to the token endpoint when using an iframe', async () => {
-    const auth0 = setup();
+    const auth0 = setup({
+      custom_param: 'foo',
+      another_custom_param: 'bar'
+    });
 
     await login(auth0, true);
 
@@ -644,14 +647,23 @@ describe('Auth0Client', () => {
       state: 'MTIz'
     });
 
+    mockFetch.mockResolvedValue(
+      fetchResponse(true, {
+        id_token: 'my_id_token',
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token',
+        expires_in: 86400
+      })
+    );
+
     await auth0.getTokenSilently({
       ignoreCache: true,
-      customParam: 'hello world'
+      custom_param: 'hello world'
     });
 
     expect(
       (<any>utils.runIframe).mock.calls[0][0].includes(
-        'customParam=hello%20world'
+        'custom_param=hello%20world&another_custom_param=bar'
       )
     ).toBe(true);
 
@@ -659,19 +671,27 @@ describe('Auth0Client', () => {
       redirect_uri: 'my_callback_url',
       client_id: 'auth0_client_id',
       grant_type: 'authorization_code',
-      customParam: 'hello world',
+      custom_param: 'hello world',
+      another_custom_param: 'bar',
       code_verifier: '123'
     });
   });
 
   it('sends custom options through to the token endpoint when using refresh tokens', async () => {
     const auth0 = setup({
-      useRefreshTokens: true
+      useRefreshTokens: true,
+      custom_param: 'foo',
+      another_custom_param: 'bar'
     });
 
     await login(auth0, true, { refresh_token: 'a_refresh_token' });
 
-    mockFetch.mockResolvedValueOnce(
+    jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+      access_token: 'my_access_token',
+      state: 'MTIz'
+    });
+
+    mockFetch.mockResolvedValue(
       fetchResponse(true, {
         id_token: 'my_id_token',
         refresh_token: 'my_refresh_token',
@@ -684,7 +704,7 @@ describe('Auth0Client', () => {
 
     const access_token = await auth0.getTokenSilently({
       ignoreCache: true,
-      customParam: 'hello world'
+      custom_param: 'hello world'
     });
 
     expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({
@@ -692,7 +712,8 @@ describe('Auth0Client', () => {
       client_id: 'auth0_client_id',
       grant_type: 'refresh_token',
       refresh_token: 'a_refresh_token',
-      customParam: 'hello world'
+      custom_param: 'hello world',
+      another_custom_param: 'bar'
     });
 
     expect(access_token).toEqual('my_access_token');

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -83,11 +83,37 @@ const cacheFactory = (location: string) => {
 const isIE11 = () => /Trident.*rv:11\.0/.test(navigator.userAgent);
 
 /**
+ * @ignore
+ */
+const getCustomInitialOptions = (
+  options: Auth0ClientOptions
+): BaseLoginOptions => {
+  const {
+    advancedOptions,
+    audience,
+    auth0Client,
+    authorizeTimeoutInSeconds,
+    cacheLocation,
+    client_id,
+    domain,
+    issuer,
+    leeway,
+    max_age,
+    redirect_uri,
+    scope,
+    useRefreshTokens,
+    ...customParams
+  } = options;
+  return customParams;
+};
+
+/**
  * Auth0 SDK for Single Page Applications using [Authorization Code Grant Flow with PKCE](https://auth0.com/docs/api-auth/tutorials/authorization-code-grant-pkce).
  */
 export default class Auth0Client {
   private cache: ICache;
   private transactionManager: TransactionManager;
+  private customOptions: BaseLoginOptions;
   private domainUrl: string;
   private tokenIssuer: string;
   private defaultScope: string;
@@ -137,6 +163,8 @@ export default class Auth0Client {
     ) {
       this.worker = new TokenWorker();
     }
+
+    this.customOptions = getCustomInitialOptions(options);
   }
 
   private _url(path) {
@@ -719,6 +747,7 @@ export default class Auth0Client {
 
     const tokenResult = await oauthToken(
       {
+        ...this.customOptions,
         ...customOptions,
         baseUrl: this.domainUrl,
         client_id: this.options.client_id,
@@ -780,6 +809,7 @@ export default class Auth0Client {
     try {
       tokenResult = await oauthToken(
         {
+          ...this.customOptions,
           ...customOptions,
           baseUrl: this.domainUrl,
           client_id: this.options.client_id,


### PR DESCRIPTION
### Description

Custom auth params that are declared in the constructor should be passed to the token endpoint for the 2 get token methods (iframe and code exchange and refresh token)

### References

fixes #514 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
