### PR TITLE
[SDK-1798] prevent unnecessary token requests

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -14,6 +14,8 @@ jest.mock('es-cookie');
 jest.mock('../src/jwt');
 jest.mock('../src/token.worker');
 
+jest.unmock('browser-tabs-lock');
+
 const mockWindow = <any>global;
 const mockFetch = (mockWindow.fetch = <jest.Mock>unfetch);
 const mockVerify = <jest.Mock>verify;
@@ -602,6 +604,30 @@ describe('Auth0Client', () => {
     Object.defineProperty(window.navigator, 'userAgent', {
       value: originalUserAgent
     });
+  });
+
+  it('uses the cache for subsequent requests that occur before the response', async () => {
+    const auth0 = setup();
+    await login(auth0);
+    (auth0 as any).cache.clear();
+    jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+      access_token: 'my_access_token',
+      state: 'MTIz'
+    });
+    mockFetch.mockResolvedValue(
+      fetchResponse(true, {
+        id_token: 'my_id_token',
+        access_token: 'my_access_token',
+        expires_in: 86400
+      })
+    );
+    let [access_token] = await Promise.all([
+      auth0.getTokenSilently(),
+      auth0.getTokenSilently(),
+      auth0.getTokenSilently()
+    ]);
+    expect(access_token).toEqual('my_access_token');
+    expect(utils.runIframe).toHaveBeenCalledTimes(1);
   });
 
   it('uses the cache for multiple token requests with audience and scope', async () => {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -544,6 +544,8 @@ export default class Auth0Client {
     };
 
     try {
+      await lock.acquireLock(GET_TOKEN_SILENTLY_LOCK_KEY, 5000);
+
       if (!ignoreCache) {
         const cache = this.cache.get(
           {
@@ -555,11 +557,10 @@ export default class Auth0Client {
         );
 
         if (cache && cache.access_token) {
+          await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
           return cache.access_token;
         }
       }
-
-      await lock.acquireLock(GET_TOKEN_SILENTLY_LOCK_KEY, 5000);
 
       // Only get an access token using a refresh token if:
       // * refresh tokens are enabled


### PR DESCRIPTION
### Description

Prevents multiple requests when tokens are requested before the first token response (if you're hammering the `getTokenSilently` button)

### References

See #480 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
