### PR TITLE
fix: 🐛 Add `scope` to /oauth/token fetch requests

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -188,7 +188,8 @@ describe('Auth0Client', () => {
       client_id: 'auth0_client_id',
       code_verifier: '123',
       grant_type: 'authorization_code',
-      code: 'my_code'
+      code: 'my_code',
+      scope: 'openid profile email'
     });
   });
 
@@ -308,7 +309,8 @@ describe('Auth0Client', () => {
         client_id: 'auth0_client_id',
         grant_type: 'refresh_token',
         redirect_uri: 'my_callback_url',
-        refresh_token: 'my_refresh_token'
+        refresh_token: 'my_refresh_token',
+        scope: 'openid profile email offline_access'
       },
       1
     );
@@ -331,7 +333,8 @@ describe('Auth0Client', () => {
       client_id: 'auth0_client_id',
       code_verifier: '123',
       grant_type: 'authorization_code',
-      code: 'my_code'
+      code: 'my_code',
+      scope: 'openid profile email offline_access'
     });
 
     mockFetch.mockResolvedValueOnce(
@@ -351,7 +354,8 @@ describe('Auth0Client', () => {
         client_id: 'auth0_client_id',
         grant_type: 'refresh_token',
         redirect_uri: 'my_callback_url',
-        refresh_token: 'my_refresh_token'
+        refresh_token: 'my_refresh_token',
+        scope: 'openid profile email offline_access'
       },
       1
     );
@@ -376,7 +380,8 @@ describe('Auth0Client', () => {
       client_id: 'auth0_client_id',
       code_verifier: '123',
       grant_type: 'authorization_code',
-      code: 'my_code'
+      code: 'my_code',
+      scope: 'openid profile email offline_access'
     });
 
     mockFetch.mockResolvedValueOnce(
@@ -396,7 +401,8 @@ describe('Auth0Client', () => {
         client_id: 'auth0_client_id',
         grant_type: 'refresh_token',
         redirect_uri: 'my_callback_url',
-        refresh_token: 'my_refresh_token'
+        refresh_token: 'my_refresh_token',
+        scope: 'openid profile email offline_access'
       },
       1
     );
@@ -723,7 +729,8 @@ describe('Auth0Client', () => {
       grant_type: 'authorization_code',
       custom_param: 'hello world',
       another_custom_param: 'bar',
-      code_verifier: '123'
+      code_verifier: '123',
+      scope: 'openid profile email'
     });
   });
 
@@ -763,7 +770,8 @@ describe('Auth0Client', () => {
       grant_type: 'refresh_token',
       refresh_token: 'a_refresh_token',
       custom_param: 'hello world',
-      another_custom_param: 'bar'
+      another_custom_param: 'bar',
+      scope: 'openid profile email offline_access'
     });
 
     expect(access_token).toEqual('my_access_token');

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -304,6 +304,7 @@ describe('utils', () => {
       const spy = jest.spyOn(worker, 'postMessage');
       const body = {
         redirect_uri: 'http://localhost',
+        scope: '__test_scope__',
         grant_type: 'authorization_code',
         client_id: 'client_idIn',
         code: 'codeIn',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -325,6 +325,7 @@ export const oauthToken = async (
       method: 'POST',
       body: JSON.stringify({
         redirect_uri: window.location.origin,
+        scope,
         ...options
       }),
       headers: {


### PR DESCRIPTION
The `scope` is missing on `/oauth/token` requests to the IdP. This creates an issue whereby the initial login request is the only request that has the `scope` and as such Auth0 Rules requiring the `scope` cannot run on token refreshes or the code exchange.

At the moment, the only way to access the `scope` is from the request context in the rule.
https://auth0.com/docs/rules/references/context-object

This PR adds the `scope` to the request body to ensure that it is available in Auth0 Rules.

CC: @trevorgk @vikasjayaram
