### PR TITLE
Store test results, configure Cypress artefact paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,9 @@ jobs:
       - run: npm run test:integration
       - run: npm run test:es-check
       - run: npm run print-bundle-size
-      - run:
-          name: Copy screenshots
-          command: |
-            mkdir /tmp/screenshots
-            cp -R ~/repo/cypress/screenshots/*/*.png /tmp/screenshots 2>/dev/null || :
-      - run:
-          name: Copy videos
-          command: |
-            mkdir /tmp/videos
-            cp -R ~/repo/cypress/videos/*.mp4 /tmp/videos 2>/dev/null || :
+      - store_test_results:
+          path: test-results
       - store_artifacts:
-          path: /tmp/screenshots
+          path: cypress/screenshots
       - store_artifacts:
-          path: /tmp/videos
+          path: cypress/videos

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cypress/screenshots
 cypress/videos
 .release
 .idea
+test-results

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,10 @@ module.exports = {
     './cypress',
     './jest.config.js'
   ],
+  reporters: [
+    'default',
+    ['jest-junit', { outputDirectory: 'test-results/jest' }]
+  ],
   coverageReporters: ['lcov', 'text', 'text-summary'],
   preset: 'ts-jest',
   setupFiles: ['jest-localstorage-mock']

--- a/package-lock.json
+++ b/package-lock.json
@@ -5908,6 +5908,47 @@
         }
       }
     },
+    "jest-junit": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-11.0.1.tgz",
+      "integrity": "sha512-stgc0mBoiSg/F9qWd4KkmR3K7Nk2u+M/dc1oup7gxz9mrzGcEaU2YL9/0QscVqqg3IOaA1P5ZXtozG/XR6j6nw==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
@@ -11048,6 +11089,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "husky": "^4.2.3",
     "idtoken-verifier": "^2.0.2",
     "jest": "^24.9.0",
+    "jest-junit": "^11.0.1",
     "jest-localstorage-mock": "^2.4.0",
     "jsonwebtoken": "^8.5.1",
     "pem": "^1.14.4",


### PR DESCRIPTION
### Description

- Upload Cypress artefacts from the Cypress dir rather than do this weird tmp directory dance
- Install `jest-junit` and upload test results to Circle

### References

Made these improvements after noticing a previous failing build was missing artefacts.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
