### PR TITLE
Refactor logout to use new buildLogoutUrl method

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -670,20 +670,19 @@ export default class Auth0Client {
 
   /**
    * ```js
-   * auth0.logout();
+   * auth0.buildLogoutUrl(options);
    * ```
    *
-   * Clears the application session and performs a redirect to `/v2/logout`, using
-   * the parameters provided as arguments, to clear the Auth0 session.
+   * Builds a `/logout` URL for logout using the parameters provided as arguments,
+   * to clear the Auth0 session.
    * If the `federated` option is specified it also clears the Identity Provider session.
    * If the `localOnly` option is specified, it only clears the application session.
    * It is invalid to set both the `federated` and `localOnly` options to `true`,
    * and an error will be thrown if you do.
-   * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
    *
    * @param options
    */
-  public logout(options: LogoutOptions = {}) {
+  public buildLogoutUrl(options: LogoutOptions = {}) {
     if (options.client_id !== null) {
       options.client_id = options.client_id || this.options.client_id;
     } else {
@@ -708,7 +707,34 @@ export default class Auth0Client {
     const federatedQuery = federated ? `&federated` : '';
     const url = this._url(`/v2/logout?${createQueryParams(logoutOptions)}`);
 
-    window.location.assign(`${url}${federatedQuery}`);
+    return `${url}${federatedQuery}`;
+  }
+
+  /**
+   * ```js
+   * auth0.logout();
+   * ```
+   *
+   * Clears the application session and performs a redirect to `/v2/logout`, using
+   * the parameters provided as arguments, to clear the Auth0 session.
+   * If the `federated` option is specified it also clears the Identity Provider session.
+   * If the `localOnly` option is specified, it only clears the application session.
+   * It is invalid to set both the `federated` and `localOnly` options to `true`,
+   * and an error will be thrown if you do.
+   * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
+   *
+   * @param options
+   */
+  public logout(options: LogoutOptions = {}) {
+    const { localOnly } = options;
+
+    if (localOnly) {
+      return;
+    }
+
+    const url = this.buildLogoutUrl(options);
+
+    window.location.assign(url);
   }
 
   private async _getTokenFromIFrame(


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR follows on from #280 and adds the ability to return the log out URL in order to allow a user to be sent to it using methods other than `location.assign`. This will be particularly helpful for hybrid mobile apps built with Cordova or Capacitor.

### References
#273 

### Testing
`__tests__/index.test.ts` has been updated accordingly to mirror the changes made to `Auth0Client`.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
