### PR TITLE
[SDK-1912] Unnecessary latency in `getTokenSilently` with primed cache

### DIFF
--- a/__mocks__/browser-tabs-lock/index.ts
+++ b/__mocks__/browser-tabs-lock/index.ts
@@ -1,7 +1,15 @@
-export const acquireLockMock = jest.fn();
-export const releaseLockMock = jest.fn();
+const Lock = jest.requireActual('browser-tabs-lock').default;
 
-export default class FakeLock {
-  acquireLock = acquireLockMock;
-  releaseLock = releaseLockMock;
+export const acquireLockSpy = jest.fn();
+export const releaseLockSpy = jest.fn();
+
+export default class extends Lock {
+  acquireLock(...args) {
+    acquireLockSpy(...args);
+    return super.acquireLock(...args);
+  }
+  releaseLock(...args) {
+    releaseLockSpy(...args);
+    return super.releaseLock(...args);
+  }
 }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -582,22 +582,36 @@ export default class Auth0Client {
       scope: getUniqueScopes(this.defaultScope, this.scope, options.scope)
     };
 
+    const getAccessTokenFromCache = () => {
+      const cache = this.cache.get(
+        {
+          scope: getTokenOptions.scope,
+          audience: getTokenOptions.audience || 'default',
+          client_id: this.options.client_id
+        },
+        60 // get a new token if within 60 seconds of expiring
+      );
+
+      return cache && cache.access_token;
+    };
+
+    // Check the cache before acquiring the lock to avoid the latency of
+    // `lock.acquireLock` when the cache is populated.
+    if (!ignoreCache) {
+      let accessToken = getAccessTokenFromCache();
+      if (accessToken) {
+        return accessToken;
+      }
+    }
+
     try {
       await lock.acquireLock(GET_TOKEN_SILENTLY_LOCK_KEY, 5000);
-
+      // Check the cache a second time, because it may have been populated
+      // by a previous call while this call was waiting to acquire the lock.
       if (!ignoreCache) {
-        const cache = this.cache.get(
-          {
-            scope: getTokenOptions.scope,
-            audience: getTokenOptions.audience || 'default',
-            client_id: this.options.client_id
-          },
-          60 // get a new token if within 60 seconds of expiring
-        );
-
-        if (cache && cache.access_token) {
-          await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
-          return cache.access_token;
+        let accessToken = getAccessTokenFromCache();
+        if (accessToken) {
+          return accessToken;
         }
       }
 


### PR DESCRIPTION
### Description

Check the cache before acquiring lock to avoid latency when the cache is populated (see #552)
Check the cache after acquiring lock to prevent unnecessary requests, because a previous call might have populated the cache while the current call was waiting to acquire the lock (see #480)

### References

fixes #552

### Testing

To check #552:

Call `getTokenSilently` with a primed cache, latency should be <20ms

Check regression of #480:

Hammer the `getTokenSilently` button in the SPA js playground with "Use token cache when fetching new tokens" enabled and check that only one token is requested 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
