### PR TITLE
[SDK-1885] Add some additional state validation

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -202,6 +202,22 @@ describe('Auth0Client', () => {
     );
   });
 
+  it('should not attempt to log the user in with Object prototype properties as state', async () => {
+    window.history.pushState({}, '', `/?code=foo&state=constructor`);
+    const auth0 = await setup();
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse(true, {
+        id_token: 'my_id_token',
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token',
+        expires_in: 86400
+      })
+    );
+    await expect(auth0.handleRedirectCallback()).rejects.toThrow(
+      'Invalid state'
+    );
+  });
+
   it('uses the cache when expires_in > constant leeway', async () => {
     const auth0 = setup();
     await login(auth0, true, { expires_in: 70 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -974,7 +974,11 @@ describe('Auth0', () => {
           key: 'property'
         };
 
-        transactionManager.get.mockReturnValue({ appState });
+        transactionManager.get.mockReturnValue({
+          appState,
+          nonce: 'foo',
+          code_verifier: 'bar'
+        });
 
         const queryResult = {
           error: 'unauthorized',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -459,7 +459,8 @@ export default class Auth0Client {
 
     const transaction = this.transactionManager.get(state);
 
-    if (!transaction) {
+    // Transaction should have a `code_verifier` to do PKCE and a `nonce` for CSRF protection
+    if (!transaction || !transaction.code_verifier || !transaction.nonce) {
       throw new Error('Invalid state');
     }
 


### PR DESCRIPTION
### Description

State validation can be bypassed by passing `Object.prototype` properties as `state` in the callback url params

### Testing

Visit http://localhost:3000?code=foo&state=constructor on the SPA JS playground
Click "handle redirect callback"

Expected: `Invalid State`
Actual: Code exchange is attempted

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
