### PR TITLE
Fix SSR

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,3 +1,4 @@
+import 'jest-localstorage-mock';
 import { InMemoryCache, LocalStorageCache, ICache } from '../src/cache';
 
 const nowSeconds = () => Math.floor(Date.now() / 1000);

--- a/__tests__/transaction-manager.test.ts
+++ b/__tests__/transaction-manager.test.ts
@@ -1,3 +1,4 @@
+import 'jest-localstorage-mock';
 import TransactionManager from '../src/transaction-manager';
 import { SessionStorage } from '../src/storage';
 import { mocked } from 'ts-jest/utils';

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,5 @@ module.exports = {
     ['jest-junit', { outputDirectory: 'test-results/jest' }]
   ],
   coverageReporters: ['lcov', 'text', 'text-summary'],
-  preset: 'ts-jest',
-  setupFiles: ['jest-localstorage-mock']
+  preset: 'ts-jest'
 };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -85,6 +85,9 @@ export const CookieStorageWithLegacySameSite = {
  */
 export const SessionStorage = {
   get<T extends Object>(key: string) {
+    if (typeof sessionStorage === 'undefined') {
+      return;
+    }
     const value = sessionStorage.getItem(key);
     if (typeof value === 'undefined') {
       return;


### PR DESCRIPTION
### Description

We've introduced a regression where calling `new Auth0Client({ ... })` will fail in an SSR environment because it relies on `sessionStorage` https://github.com/stevehobbsdev/auth0-spa-js/commit/937025c2e28b5c4d5df64e9d67a0ff6397e32564#diff-7edf092a689fc6f24b10820757119ce4L24 (see where the check for window undefined has been removed)

Unfortunately our ssr tests which are designed to catch this, didn't pick this up because we stub `sessionStorage` in all environments. I've only noticed it because the auth0-react tests don't stub it https://app.circleci.com/pipelines/github/auth0/auth0-react/251/workflows/0cc79dde-40bd-4b7e-852d-eee41fbd50dc/jobs/263

Our 'check all the frameworks' tests didn't catch it because we only check importing the class, not instantiating it https://gist.github.com/adamjmcgrath/ff26be1795aeb1689e657c7fbc885021#file-run-sh-L6

I'll need to release a patch for this before I publish auth0-react