### PR TITLE
Add an option to extend cookie expire day

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -623,7 +623,7 @@ describe('Auth0', () => {
     });
     it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
       const { auth0, cookieStorage } = await setup({
-        daysUntilAuthenticateCookieExpire: 2
+        sessionCheckExpiryDays: 2
       });
 
       await auth0.loginWithPopup({});
@@ -909,7 +909,7 @@ describe('Auth0', () => {
 
     describe('when there is a valid query string in the url', () => {
       const localSetup = async (
-        clientOptions: Partial<Auth0ClientOptions> = {}
+        clientOptions?: Partial<Auth0ClientOptions>
       ) => {
         window.history.pushState(
           {},
@@ -1140,16 +1140,18 @@ describe('Auth0', () => {
       });
       it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
         const { auth0, cookieStorage } = await localSetup({
-          daysUntilAuthenticateCookieExpire: 2
+          sessionCheckExpiryDays: 2
         });
 
         await auth0.handleRedirectCallback();
 
-        expect(
-          cookieStorage.save
-        ).toHaveBeenCalledWith('auth0.is.authenticated', true, {
-          daysUntilExpire: 2
-        });
+        expect(cookieStorage.save).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          true,
+          {
+            daysUntilExpire: 2
+          }
+        );
       });
       it('returns the transactions appState', async () => {
         const { auth0 } = await localSetup();
@@ -1162,7 +1164,7 @@ describe('Auth0', () => {
     });
     describe('when there is a valid query string in a hash', () => {
       const localSetup = async (
-        clientOptions: Partial<Auth0ClientOptions> = {}
+        clientOptions?: Partial<Auth0ClientOptions>
       ) => {
         window.history.pushState({}, 'Test', `/`);
         window.history.pushState(
@@ -1340,16 +1342,18 @@ describe('Auth0', () => {
       });
       it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
         const { auth0, cookieStorage } = await localSetup({
-          daysUntilAuthenticateCookieExpire: 2
+          sessionCheckExpiryDays: 2
         });
 
         await auth0.handleRedirectCallback();
 
-        expect(
-          cookieStorage.save
-        ).toHaveBeenCalledWith('auth0.is.authenticated', true, {
-          daysUntilExpire: 2
-        });
+        expect(cookieStorage.save).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          true,
+          {
+            daysUntilExpire: 2
+          }
+        );
       });
       it('returns the transactions appState', async () => {
         const { auth0 } = await localSetup();
@@ -2027,7 +2031,7 @@ describe('Auth0', () => {
       });
       it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
         const { auth0, cookieStorage } = await setup({
-          daysUntilAuthenticateCookieExpire: 2
+          sessionCheckExpiryDays: 2
         });
 
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
@@ -2056,8 +2060,8 @@ describe('Auth0', () => {
   });
 
   describe('getTokenWithPopup()', () => {
-    const localSetup = async (options: Partial<Auth0ClientOptions> = {}) => {
-      const result = await setup(options);
+    const localSetup = async (clientOptions?: Partial<Auth0ClientOptions>) => {
+      const result = await setup(clientOptions);
       result.auth0.loginWithPopup = jest.fn();
       result.cache.get.mockReturnValue({ access_token: TEST_ACCESS_TOKEN });
       return result;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -621,6 +621,18 @@ describe('Auth0', () => {
         { daysUntilExpire: 1 }
       );
     });
+    it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+      const { auth0, cookieStorage } = await setup({
+        daysUntilAuthenticateCookieExpire: 2
+      });
+
+      await auth0.loginWithPopup({});
+      expect(cookieStorage.save).toHaveBeenCalledWith(
+        'auth0.is.authenticated',
+        true,
+        { daysUntilExpire: 2 }
+      );
+    });
     it('can be called with no arguments', async () => {
       const { auth0, utils } = await setup();
 
@@ -896,13 +908,15 @@ describe('Auth0', () => {
     });
 
     describe('when there is a valid query string in the url', () => {
-      const localSetup = async () => {
+      const localSetup = async (
+        clientOptions: Partial<Auth0ClientOptions> = {}
+      ) => {
         window.history.pushState(
           {},
           'Test',
           `?code=${TEST_CODE}&state=${TEST_ENCODED_STATE}`
         );
-        const result = await setup();
+        const result = await setup(clientOptions);
         result.transactionManager.get.mockReturnValue({
           code_verifier: TEST_RANDOM_STRING,
           nonce: TEST_ENCODED_STATE,
@@ -1124,6 +1138,19 @@ describe('Auth0', () => {
           }
         );
       });
+      it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+        const { auth0, cookieStorage } = await localSetup({
+          daysUntilAuthenticateCookieExpire: 2
+        });
+
+        await auth0.handleRedirectCallback();
+
+        expect(
+          cookieStorage.save
+        ).toHaveBeenCalledWith('auth0.is.authenticated', true, {
+          daysUntilExpire: 2
+        });
+      });
       it('returns the transactions appState', async () => {
         const { auth0 } = await localSetup();
         const response = await auth0.handleRedirectCallback();
@@ -1134,14 +1161,16 @@ describe('Auth0', () => {
       });
     });
     describe('when there is a valid query string in a hash', () => {
-      const localSetup = async () => {
+      const localSetup = async (
+        clientOptions: Partial<Auth0ClientOptions> = {}
+      ) => {
         window.history.pushState({}, 'Test', `/`);
         window.history.pushState(
           {},
           'Test',
           `#/callback/?code=${TEST_CODE}&state=${TEST_ENCODED_STATE}`
         );
-        const result = await setup();
+        const result = await setup(clientOptions);
         result.transactionManager.get.mockReturnValue({
           code_verifier: TEST_RANDOM_STRING,
           nonce: TEST_ENCODED_STATE,
@@ -1308,6 +1337,19 @@ describe('Auth0', () => {
             daysUntilExpire: 1
           }
         );
+      });
+      it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+        const { auth0, cookieStorage } = await localSetup({
+          daysUntilAuthenticateCookieExpire: 2
+        });
+
+        await auth0.handleRedirectCallback();
+
+        expect(
+          cookieStorage.save
+        ).toHaveBeenCalledWith('auth0.is.authenticated', true, {
+          daysUntilExpire: 2
+        });
       });
       it('returns the transactions appState', async () => {
         const { auth0 } = await localSetup();
@@ -1980,6 +2022,20 @@ describe('Auth0', () => {
           true,
           {
             daysUntilExpire: 1
+          }
+        );
+      });
+      it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+        const { auth0, cookieStorage } = await setup({
+          daysUntilAuthenticateCookieExpire: 2
+        });
+
+        await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
+        expect(cookieStorage.save).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          true,
+          {
+            daysUntilExpire: 2
           }
         );
       });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:integration:tests": "wait-on http://localhost:3000/ && cypress run",
     "test:integration": "concurrently --raw --kill-others --success first npm:test:integration:server npm:test:integration:tests",
     "print-bundle-size": "node ./scripts/print-bundle-size",
-    "prepack": "npm run build && npm run test && node ./scripts/prepack",
+    "prepack": "npm run build && node ./scripts/prepack",
     "release": "node ./scripts/release",
     "release:clean": "node ./scripts/cleanup",
     "publish:cdn": "ccu --trace"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:integration:tests": "wait-on http://localhost:3000/ && cypress run",
     "test:integration": "concurrently --raw --kill-others --success first npm:test:integration:server npm:test:integration:tests",
     "print-bundle-size": "node ./scripts/print-bundle-size",
-    "prepack": "npm run build && node ./scripts/prepack",
+    "prepack": "npm run build && npm run test && node ./scripts/prepack",
     "release": "node ./scripts/release",
     "release:clean": "node ./scripts/cleanup",
     "publish:cdn": "ccu --trace"

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -32,7 +32,7 @@ import {
   MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_SCOPE,
   RECOVERABLE_ERRORS,
-  DEFAULT_DAYS_UNTIL_EXPIRE
+  DEFAULT_SESSION_CHECK_EXPIRY_DAYS
 } from './constants';
 
 import version from './version';
@@ -135,7 +135,7 @@ export default class Auth0Client {
   private defaultScope: string;
   private scope: string;
   private cookieStorage: ClientStorage;
-  private daysUntilAuthenticateCookieExpire: number;
+  private sessionCheckExpiryDays: number;
 
   cacheLocation: CacheLocation;
   private worker: Worker;
@@ -147,8 +147,8 @@ export default class Auth0Client {
       options.legacySameSiteCookie === false
         ? CookieStorage
         : CookieStorageWithLegacySameSite;
-    this.daysUntilAuthenticateCookieExpire =
-      options.daysUntilAuthenticateCookieExpire || DEFAULT_DAYS_UNTIL_EXPIRE;
+    this.sessionCheckExpiryDays =
+      options.sessionCheckExpiryDays || DEFAULT_SESSION_CHECK_EXPIRY_DAYS;
 
     if (!cacheFactory(this.cacheLocation)) {
       throw new Error(`Invalid cache location "${this.cacheLocation}"`);
@@ -382,7 +382,7 @@ export default class Auth0Client {
     this.cache.save(cacheEntry);
 
     this.cookieStorage.save('auth0.is.authenticated', true, {
-      daysUntilExpire: this.daysUntilAuthenticateCookieExpire
+      daysUntilExpire: this.sessionCheckExpiryDays
     });
   }
 
@@ -518,7 +518,7 @@ export default class Auth0Client {
     this.cache.save(cacheEntry);
 
     this.cookieStorage.save('auth0.is.authenticated', true, {
-      daysUntilExpire: this.daysUntilAuthenticateCookieExpire
+      daysUntilExpire: this.sessionCheckExpiryDays
     });
 
     return {
@@ -632,7 +632,7 @@ export default class Auth0Client {
       this.cache.save({ client_id: this.options.client_id, ...authResult });
 
       this.cookieStorage.save('auth0.is.authenticated', true, {
-        daysUntilExpire: this.daysUntilAuthenticateCookieExpire
+        daysUntilExpire: this.sessionCheckExpiryDays
       });
 
       return authResult.access_token;

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -31,7 +31,8 @@ import {
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
   MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_SCOPE,
-  RECOVERABLE_ERRORS
+  RECOVERABLE_ERRORS,
+  DEFAULT_DAYS_UNTIL_EXPIRE
 } from './constants';
 
 import version from './version';
@@ -134,6 +135,7 @@ export default class Auth0Client {
   private defaultScope: string;
   private scope: string;
   private cookieStorage: ClientStorage;
+  private daysUntilAuthenticateCookieExpire: number;
 
   cacheLocation: CacheLocation;
   private worker: Worker;
@@ -145,6 +147,8 @@ export default class Auth0Client {
       options.legacySameSiteCookie === false
         ? CookieStorage
         : CookieStorageWithLegacySameSite;
+    this.daysUntilAuthenticateCookieExpire =
+      options.daysUntilAuthenticateCookieExpire || DEFAULT_DAYS_UNTIL_EXPIRE;
 
     if (!cacheFactory(this.cacheLocation)) {
       throw new Error(`Invalid cache location "${this.cacheLocation}"`);
@@ -378,7 +382,7 @@ export default class Auth0Client {
     this.cache.save(cacheEntry);
 
     this.cookieStorage.save('auth0.is.authenticated', true, {
-      daysUntilExpire: 1
+      daysUntilExpire: this.daysUntilAuthenticateCookieExpire
     });
   }
 
@@ -514,7 +518,7 @@ export default class Auth0Client {
     this.cache.save(cacheEntry);
 
     this.cookieStorage.save('auth0.is.authenticated', true, {
-      daysUntilExpire: 1
+      daysUntilExpire: this.daysUntilAuthenticateCookieExpire
     });
 
     return {
@@ -628,7 +632,7 @@ export default class Auth0Client {
       this.cache.save({ client_id: this.options.client_id, ...authResult });
 
       this.cookieStorage.save('auth0.is.authenticated', true, {
-        daysUntilExpire: 1
+        daysUntilExpire: this.daysUntilAuthenticateCookieExpire
       });
 
       return authResult.access_token;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,4 +57,4 @@ export const RECOVERABLE_ERRORS = [
 /**
  * @ignore
  */
-export const DEFAULT_DAYS_UNTIL_EXPIRE = 1;
+export const DEFAULT_SESSION_CHECK_EXPIRY_DAYS = 1;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,3 +53,8 @@ export const RECOVERABLE_ERRORS = [
   // interactively.
   'access_denied'
 ];
+
+/**
+ * @ignore
+ */
+export const DEFAULT_DAYS_UNTIL_EXPIRE = 1;

--- a/src/global.ts
+++ b/src/global.ts
@@ -144,6 +144,11 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * Changes to recommended defaults, like defaultScope
    */
   advancedOptions?: AdvancedOptions;
+
+  /**
+   * Number of days until the cookie `auth0.is.authenticated` will expire
+   */
+  daysUntilAuthenticateCookieExpire?: number;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -147,8 +147,9 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
 
   /**
    * Number of days until the cookie `auth0.is.authenticated` will expire
+   * Defaults to 1.
    */
-  daysUntilAuthenticateCookieExpire?: number;
+  sessionCheckExpiryDays?: number;
 }
 
 /**


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Add an option to extend the cookie `auth0.is.authenticated` expire date to the desired amount of days or 1, the default value.


### References

Closes: #584

### Testing

In order to test this behaviour, you'll need to add the `sessionCheckExpiryDays ` option when creating the Auth0 client passing a value other than 1.

```js
createAuth0Client({
  domain: '<AUTH0_DOMAIN>',
  client_id: '<AUTH0_CLIENT_ID>',
  redirect_uri: '<MY_CALLBACK_URL>',
  cacheLocation: 'memory',
  sessionCheckExpiryDays: 10
});
```

After that, you can run your application, login and double check if the browser cookie `auth0.is.authenticated` will expire according to the configuration, in this case in 10 days.

---

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
