### PR TITLE
Node v to active LTS tests require worker_threads

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 ## Environment
 
-- Node >= 10.x
+- Node >= 12.x
 
 ## Building
 


### PR DESCRIPTION
### Description

The tests fail on <12 because `worker_threads` isn't available.
Bump the v node required for development to 12. 
12 is the active LTS so this seems reasonable.

### References

fixes #587 

