### PR TITLE
[SDK-1994] GMaps breaks SPA JS on IE11

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import 'core-js/es/string/starts-with';
+import 'core-js/es/symbol';
 import 'core-js/es/array/from';
 import 'core-js/es/typed-array/slice';
 import 'core-js/es/array/includes';


### PR DESCRIPTION
### Description

Google Maps adds a `Symbol` polyfill which causes `core-js`'s `Array.from` polyfill to incorrectly return an empty array, eg when doing `dedupe = (a) => Array.from(new Set(a))` (https://github.com/auth0/auth0-spa-js/blob/master/src/scope.ts#L4)

To fix see the 2 worksrounds in https://github.com/zloirock/core-js/issues/618

1. Put the maps api before the spa js SDK2.
2. Add `import 'core-js/es6/symbol';` before importing `array-from`

Since we can't expect customers to do #1, we should do #2 (adds 2.9kb GZipped to the spa binary)

### References

https://auth0team.atlassian.net/browse/ESD-9069
https://github.com/zloirock/core-js/issues/618#issuecomment-522117950

### Testing

Add the Google Maps JS API v3 to your page after the SPA SDK
Login through the SPA JS SDK

**Expected Behavior**
The user is logged in

**Actual Behavior**
The handle redirect callback will fail with "ID Token is required but missing"
