### PR TITLE
Use AbortController polyfill in Web Worker

### DIFF
--- a/src/token.worker.ts
+++ b/src/token.worker.ts
@@ -1,3 +1,4 @@
+import 'abortcontroller-polyfill/dist/umd-polyfill';
 import { MISSING_REFRESH_TOKEN_ERROR_MESSAGE } from './constants';
 
 let refreshTokens = {};


### PR DESCRIPTION
The Web Worker was using Abort Controller but not specifying any polyfill, meaning it will break on browsers that do not support AbortController.

I imported the UMD polyfill based on how it is recommended in the polyfill repo https://github.com/mo/abortcontroller-polyfill/blob/master/tests/web-worker.js

Fixes #594