### PR TITLE
[SDK-2092] Do not use Web Worker for Safari < 12.1

### DIFF
--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -857,6 +857,66 @@ describe('Auth0Client', () => {
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
     });
 
+    describe('Worker browser support', () => {
+      [
+        {
+          name: 'IE11',
+          userAgent:
+            'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko',
+          supported: false
+        },
+        {
+          name: 'Safari 10',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8',
+          supported: false
+        },
+        {
+          name: 'Safari 11',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.28 (KHTML, like Gecko) Version/11.0 Safari/604.1.28',
+          supported: false
+        },
+        {
+          name: 'Safari 12',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.1 Safari/605.1.15',
+          supported: false
+        },
+        {
+          name: 'Safari 12.1',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15',
+          supported: true
+        }
+      ].forEach(({ name, userAgent, supported }) =>
+        it(`refreshes the token ${
+          supported ? 'with' : 'without'
+        } the worker, when ${name}`, async () => {
+          const originalUserAgent = window.navigator.userAgent;
+          Object.defineProperty(window.navigator, 'userAgent', {
+            value: userAgent,
+            configurable: true
+          });
+
+          const auth0 = setup({
+            useRefreshTokens: true,
+            cacheLocation: 'memory'
+          });
+
+          if (supported) {
+            expect((<any>auth0).worker).toBeDefined();
+          } else {
+            expect((<any>auth0).worker).toBeUndefined();
+          }
+
+          Object.defineProperty(window.navigator, 'userAgent', {
+            value: originalUserAgent
+          });
+        })
+      );
+    });
+
     it('handles fetch errors from the worker', async () => {
       const auth0 = setup({
         useRefreshTokens: true

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -58,6 +58,7 @@ import {
 
 // @ts-ignore
 import TokenWorker from './token.worker.ts';
+import { isIE11, isSafari10, isSafari11, isSafari12_0 } from './user-agent';
 
 /**
  * @ignore
@@ -87,7 +88,8 @@ const cacheFactory = (location: string) => {
 /**
  * @ignore
  */
-const isIE11 = () => /Trident.*rv:11\.0/.test(navigator.userAgent);
+const supportWebWorker = () =>
+  !isIE11() && !isSafari10() && !isSafari11() && !isSafari12_0();
 
 /**
  * @ignore
@@ -187,7 +189,7 @@ export default class Auth0Client {
       window.Worker &&
       this.options.useRefreshTokens &&
       this.cacheLocation === CACHE_LOCATION_MEMORY &&
-      !isIE11()
+      supportWebWorker()
     ) {
       this.worker = new TokenWorker();
     }

--- a/src/token.worker.ts
+++ b/src/token.worker.ts
@@ -1,4 +1,3 @@
-import 'abortcontroller-polyfill/dist/umd-polyfill';
 import { MISSING_REFRESH_TOKEN_ERROR_MESSAGE } from './constants';
 
 let refreshTokens = {};

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -1,0 +1,21 @@
+/**
+ * @ignore
+ */
+export const isIE11 = () => /Trident.*rv:11\.0/.test(navigator.userAgent);
+/**
+ * @ignore
+ */
+export const isSafari10 = () =>
+  /AppleWebKit.*Version\/10/.test(navigator.userAgent);
+
+/**
+ * @ignore
+ */
+export const isSafari11 = () =>
+  /AppleWebKit.*Version\/11/.test(navigator.userAgent);
+
+/**
+ * @ignore
+ */
+export const isSafari12_0 = () =>
+  /AppleWebKit.*Version\/12\.0/.test(navigator.userAgent);


### PR DESCRIPTION
- Drop web worker support for Safari 10, 11 and 12.0
- Drop polyfill from web worker

Fixes #608