### PR TITLE
[SDK-2037] Remove cacheLocation guard from checkSession

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -551,10 +551,7 @@ export default class Auth0Client {
    * @param options
    */
   public async checkSession(options?: GetTokenSilentlyOptions) {
-    if (
-      this.cacheLocation === CACHE_LOCATION_MEMORY &&
-      !this.cookieStorage.get('auth0.is.authenticated')
-    ) {
+    if (!this.cookieStorage.get('auth0.is.authenticated')) {
       return;
     }
 


### PR DESCRIPTION
Remove cacheLocation guard from checkSession to ensure the cookie value is always used to determine whether or not a session call should occur.