### PR TITLE
Add command to easily show coverage report

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,6 +42,16 @@ To perform these tests interactively and watch the output, use:
 npm run test:watch:integration
 ```
 
+### Test coverage
+
+Coverage is automatically generated just by running `npm test`. To view the coverage output, use:
+
+```
+npm run coverage:show
+```
+
+Then, browse to http://localhost:5000 to view an HTML-based coverage report.
+
 ## The SDK Playground
 
 The SDK provides a simple [Vue JS](https://vuejs.org/) app to test out and experiment with features of the SDK. This Playground is also used by the integration tests to verify behaviors. If you make changes to the Playground that are to be commited, ensure that the integration tests pass.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:integration:server": "cp static/index.html dist/index.html && serve ./dist/ -p 3000 -n",
     "test:integration:tests": "wait-on http://localhost:3000/ && cypress run",
     "test:integration": "concurrently --raw --kill-others --success first npm:test:integration:server npm:test:integration:tests",
+    "coverage:show": "serve coverage/lcov-report -n",
     "print-bundle-size": "node ./scripts/print-bundle-size",
     "prepack": "npm run build && npm run test && node ./scripts/prepack",
     "release": "node ./scripts/release",


### PR DESCRIPTION
- Adds `coverage:show` NPM command to start a server using `serve` that shows
  coverage
- Updates the development guide with this info

![image](https://user-images.githubusercontent.com/766403/98134215-6c9c5d00-1eb6-11eb-8811-e885de2f9df2.png)
