### PR TITLE
[SDK-2053] Refactor and move logout tests

### DIFF
--- a/__tests__/Auth0Client.helpers.ts
+++ b/__tests__/Auth0Client.helpers.ts
@@ -6,21 +6,18 @@ import {
   PopupLoginOptions,
   RedirectLoginOptions
 } from '../src';
-import Auth0Client from '../src/Auth0Client';
-import { DEFAULT_SCOPE } from '../src/constants';
 
-export const TEST_DOMAIN = 'auth0_domain';
-export const TEST_CLIENT_ID = 'auth0_client_id';
-export const TEST_REDIRECT_URI = 'my_callback_url';
-export const TEST_ID_TOKEN = 'my_id_token';
-export const TEST_ACCESS_TOKEN = 'my_access_token';
-export const TEST_REFRESH_TOKEN = 'my_refresh_token';
-export const TEST_STATE = 'MTIz';
-export const TEST_NONCE = 'MTIz';
-export const TEST_CODE = 'my_code';
-export const TEST_SCOPES = DEFAULT_SCOPE;
-export const TEST_CODE_CHALLENGE = 'TEST_CODE_CHALLENGE';
-export const TEST_CODE_VERIFIER = '123';
+import Auth0Client from '../src/Auth0Client';
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_CLIENT_ID,
+  TEST_CODE,
+  TEST_DOMAIN,
+  TEST_ID_TOKEN,
+  TEST_REDIRECT_URI,
+  TEST_REFRESH_TOKEN,
+  TEST_STATE
+} from './constants';
 
 const authorizationResponse: AuthenticationResult = {
   code: 'my_code',

--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -1692,4 +1692,84 @@ describe('Auth0Client', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('logout()', () => {
+    it('removes `auth0.is.authenticated` key from storage', async () => {
+      const auth0 = setup();
+      auth0.logout();
+
+      expect(esCookie.remove).toHaveBeenCalledWith('auth0.is.authenticated');
+    });
+
+    it('calls `window.location.assign` with the correct url', async () => {
+      const auth0 = setup();
+
+      auth0.logout();
+
+      expect(window.location.assign).toHaveBeenCalledWith(
+        `https://${TEST_DOMAIN}/v2/logout?client_id=${TEST_CLIENT_ID}${TEST_AUTH0_CLIENT_QUERY_STRING}`
+      );
+    });
+
+    it('calls `window.location.assign` with the correct url when `options.federated` is true', async () => {
+      const auth0 = setup();
+
+      auth0.logout({ federated: true });
+
+      expect(window.location.assign).toHaveBeenCalledWith(
+        `https://${TEST_DOMAIN}/v2/logout?client_id=${TEST_CLIENT_ID}${TEST_AUTH0_CLIENT_QUERY_STRING}&federated`
+      );
+    });
+
+    it('calls `window.location.assign` with the correct url with custom `options.auth0Client`', async () => {
+      const auth0Client = { name: '__test_client_name__', version: '9.9.9' };
+      const auth0 = setup({ auth0Client });
+
+      auth0.logout();
+
+      expectToHaveBeenCalledWithAuth0ClientParam(
+        window.location.assign,
+        auth0Client
+      );
+    });
+
+    it('clears the cache', async () => {
+      const auth0 = setup();
+      jest.spyOn(auth0['cache'], 'clear').mockReturnValueOnce(undefined);
+
+      auth0.logout();
+
+      expect(auth0['cache']['clear']).toHaveBeenCalled();
+    });
+
+    it('removes `auth0.is.authenticated` key from storage when `options.localOnly` is true', async () => {
+      const auth0 = setup();
+
+      auth0.logout({ localOnly: true });
+
+      expect(esCookie.remove).toHaveBeenCalledWith('auth0.is.authenticated');
+    });
+
+    it('skips `window.location.assign` when `options.localOnly` is true', async () => {
+      const auth0 = setup();
+
+      auth0.logout({ localOnly: true });
+
+      expect(window.location.assign).not.toHaveBeenCalledWith();
+    });
+
+    it('calls `window.location.assign` when `options.localOnly` is false', async () => {
+      const auth0 = setup();
+
+      auth0.logout({ localOnly: false });
+      expect(window.location.assign).toHaveBeenCalled();
+    });
+
+    it('throws when both `options.localOnly` and `options.federated` are true', async () => {
+      const auth0 = setup();
+
+      const fn = () => auth0.logout({ localOnly: true, federated: true });
+      expect(fn).toThrow();
+    });
+  });
 });

--- a/__tests__/Auth0Client.test.ts
+++ b/__tests__/Auth0Client.test.ts
@@ -4,19 +4,26 @@ import unfetch from 'unfetch';
 import { verify } from '../src/jwt';
 import { MessageChannel } from 'worker_threads';
 import * as utils from '../src/utils';
-import { AuthenticationResult, PopupConfigOptions } from '../src';
 import * as scope from '../src/scope';
+
 import {
   expectToHaveBeenCalledWithAuth0ClientParam,
   expectToHaveBeenCalledWithHash
 } from './helpers';
+
+import { TEST_AUTH0_CLIENT_QUERY_STRING } from './constants';
+
 // @ts-ignore
 import { acquireLockSpy } from 'browser-tabs-lock';
+
 import {
   checkSessionFn,
   loginWithPopupFn,
   loginWithRedirectFn,
-  setupFn,
+  setupFn
+} from './Auth0Client.helpers';
+
+import {
   TEST_ACCESS_TOKEN,
   TEST_CLIENT_ID,
   TEST_CODE,
@@ -29,7 +36,8 @@ import {
   TEST_REFRESH_TOKEN,
   TEST_SCOPES,
   TEST_STATE
-} from './Auth0Client.helpers';
+} from './constants';
+
 import { DEFAULT_POPUP_CONFIG_OPTIONS } from '../src/constants';
 
 jest.mock('unfetch');

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -1,0 +1,34 @@
+import version from '../src/version';
+import { DEFAULT_SCOPE } from '../src/constants';
+
+export const TEST_AUTH0_CLIENT_QUERY_STRING = `&auth0Client=${encodeURIComponent(
+  btoa(
+    JSON.stringify({
+      name: 'auth0-spa-js',
+      version: version
+    })
+  )
+)}`;
+
+export const TEST_DOMAIN = 'auth0_domain';
+export const TEST_CLIENT_ID = 'auth0_client_id';
+export const TEST_REDIRECT_URI = 'my_callback_url';
+export const TEST_ID_TOKEN = 'my_id_token';
+export const TEST_ACCESS_TOKEN = 'my_access_token';
+export const TEST_REFRESH_TOKEN = 'my_refresh_token';
+export const TEST_STATE = 'MTIz';
+export const TEST_NONCE = 'MTIz';
+export const TEST_CODE = 'my_code';
+export const TEST_SCOPES = DEFAULT_SCOPE;
+export const TEST_CODE_CHALLENGE = 'TEST_CODE_CHALLENGE';
+export const TEST_CODE_VERIFIER = '123';
+export const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
+export const TEST_QUERY_PARAMS = 'query=params';
+export const TEST_ENCODED_STATE = 'encoded-state';
+export const TEST_RANDOM_STRING = 'random-string';
+export const TEST_ARRAY_BUFFER = 'this-is-an-array-buffer';
+export const TEST_BASE64_ENCODED_STRING = 'base64-url-encoded-string';
+export const TEST_USER_ID = 'user-id';
+export const TEST_USER_EMAIL = 'user@email.com';
+export const TEST_APP_STATE = { bestPet: 'dog' };
+export const TEST_ORG_ID = 'org_id_123';

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { expectToHaveBeenCalledWithAuth0ClientParam } from './helpers';
 import { CacheLocation, Auth0ClientOptions } from '../src/global';
 import * as scope from '../src/scope';
+
 // @ts-ignore
 import { acquireLockSpy, releaseLockSpy } from 'browser-tabs-lock';
 
@@ -32,37 +33,27 @@ import createAuth0Client, {
 } from '../src/index';
 
 import { AuthenticationError } from '../src/errors';
-import version from '../src/version';
+import { DEFAULT_POPUP_CONFIG_OPTIONS } from '../src/constants';
 
-import { DEFAULT_POPUP_CONFIG_OPTIONS, DEFAULT_SCOPE } from '../src/constants';
-
-const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
-
-const TEST_DOMAIN = 'test.auth0.com';
-const TEST_CLIENT_ID = 'test-client-id';
-const TEST_QUERY_PARAMS = 'query=params';
-const TEST_SCOPES = DEFAULT_SCOPE;
-const TEST_ENCODED_STATE = 'encoded-state';
-const TEST_RANDOM_STRING = 'random-string';
-const TEST_ARRAY_BUFFER = 'this-is-an-array-buffer';
-const TEST_BASE64_ENCODED_STRING = 'base64-url-encoded-string';
-const TEST_CODE = 'code';
-const TEST_ID_TOKEN = 'id-token';
-const TEST_ACCESS_TOKEN = 'access-token';
-const TEST_REFRESH_TOKEN = 'refresh-token';
-const TEST_USER_ID = 'user-id';
-const TEST_USER_EMAIL = 'user@email.com';
-const TEST_APP_STATE = { bestPet: 'dog' };
-const TEST_ORG_ID = 'org_id_123';
-
-const TEST_AUTH0_CLIENT_QUERY_STRING = `&auth0Client=${encodeURIComponent(
-  btoa(
-    JSON.stringify({
-      name: 'auth0-spa-js',
-      version: version
-    })
-  )
-)}`;
+import {
+  GET_TOKEN_SILENTLY_LOCK_KEY,
+  TEST_ACCESS_TOKEN,
+  TEST_APP_STATE,
+  TEST_ARRAY_BUFFER,
+  TEST_AUTH0_CLIENT_QUERY_STRING,
+  TEST_BASE64_ENCODED_STRING,
+  TEST_CLIENT_ID,
+  TEST_CODE,
+  TEST_DOMAIN,
+  TEST_ENCODED_STATE,
+  TEST_ID_TOKEN,
+  TEST_ORG_ID,
+  TEST_QUERY_PARAMS,
+  TEST_RANDOM_STRING,
+  TEST_REFRESH_TOKEN,
+  TEST_SCOPES,
+  TEST_USER_ID
+} from './constants';
 
 const mockEnclosedCache = {
   get: jest.fn(),
@@ -310,7 +301,7 @@ describe('Auth0', () => {
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -333,7 +324,7 @@ describe('Auth0', () => {
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: 'openid email',
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -354,7 +345,7 @@ describe('Auth0', () => {
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: `${TEST_SCOPES} offline_access`,
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -372,7 +363,7 @@ describe('Auth0', () => {
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -395,7 +386,7 @@ describe('Auth0', () => {
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -417,7 +408,7 @@ describe('Auth0', () => {
       expect(utils.createQueryParams).toHaveBeenCalledWith({
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -437,7 +428,7 @@ describe('Auth0', () => {
         audience: 'test',
         client_id: TEST_CLIENT_ID,
         scope: TEST_SCOPES,
-        response_type: TEST_CODE,
+        response_type: 'code',
         response_mode: 'query',
         state: TEST_ENCODED_STATE,
         nonce: TEST_ENCODED_STATE,
@@ -510,7 +501,7 @@ describe('Auth0', () => {
       });
 
       expect(url).toBe(
-        `https://test.auth0.com/authorize?query=params${TEST_AUTH0_CLIENT_QUERY_STRING}`
+        `https://${TEST_DOMAIN}/authorize?query=params${TEST_AUTH0_CLIENT_QUERY_STRING}`
       );
     });
 
@@ -520,7 +511,7 @@ describe('Auth0', () => {
       const url = await auth0.buildAuthorizeUrl();
 
       expect(url).toBe(
-        `https://test.auth0.com/authorize?query=params${TEST_AUTH0_CLIENT_QUERY_STRING}`
+        `https://${TEST_DOMAIN}/authorize?query=params${TEST_AUTH0_CLIENT_QUERY_STRING}`
       );
     });
   });
@@ -682,8 +673,8 @@ describe('Auth0', () => {
         expect(utils.oauthToken).toHaveBeenCalledWith(
           {
             audience: 'default',
-            scope: 'openid profile email',
-            baseUrl: 'https://test.auth0.com',
+            scope: TEST_SCOPES,
+            baseUrl: `https://${TEST_DOMAIN}`,
             client_id: TEST_CLIENT_ID,
             code: TEST_CODE,
             code_verifier: TEST_RANDOM_STRING,
@@ -731,8 +722,8 @@ describe('Auth0', () => {
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
           nonce: TEST_ENCODED_STATE,
-          aud: 'test-client-id',
-          iss: 'https://test.auth0.com/',
+          aud: TEST_CLIENT_ID,
+          iss: `https://${TEST_DOMAIN}/`,
           leeway: undefined,
           max_age: undefined
         });
@@ -755,8 +746,8 @@ describe('Auth0', () => {
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
           nonce: TEST_RANDOM_STRING,
-          aud: 'test-client-id',
-          iss: 'https://test.auth0.com/',
+          aud: TEST_CLIENT_ID,
+          iss: `https://${TEST_DOMAIN}/`,
           leeway: undefined,
           max_age: undefined,
           organizationId: TEST_ORG_ID
@@ -941,8 +932,8 @@ describe('Auth0', () => {
         expect(utils.oauthToken).toHaveBeenCalledWith(
           {
             audience: 'default',
-            scope: 'openid profile email',
-            baseUrl: 'https://test.auth0.com',
+            scope: TEST_SCOPES,
+            baseUrl: `https://${TEST_DOMAIN}`,
             client_id: TEST_CLIENT_ID,
             code: TEST_CODE,
             code_verifier: TEST_RANDOM_STRING,
@@ -959,8 +950,8 @@ describe('Auth0', () => {
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
           nonce: TEST_ENCODED_STATE,
-          aud: 'test-client-id',
-          iss: 'https://test.auth0.com/',
+          aud: TEST_CLIENT_ID,
+          iss: `https://${TEST_DOMAIN}/`,
           leeway: undefined,
           max_age: undefined
         });
@@ -1140,8 +1131,8 @@ describe('Auth0', () => {
           expect(utils.oauthToken).toHaveBeenCalledWith(
             {
               audience: undefined,
-              scope: 'openid profile email offline_access',
-              baseUrl: 'https://test.auth0.com',
+              scope: `${TEST_SCOPES} offline_access`,
+              baseUrl: `https://${TEST_DOMAIN}`,
               refresh_token: TEST_REFRESH_TOKEN,
               client_id: TEST_CLIENT_ID,
               grant_type: 'refresh_token',
@@ -1210,7 +1201,7 @@ describe('Auth0', () => {
             {
               audience: undefined,
               scope: 'openid email offline_access',
-              baseUrl: 'https://test.auth0.com',
+              baseUrl: `https://${TEST_DOMAIN}`,
               refresh_token: TEST_REFRESH_TOKEN,
               client_id: TEST_CLIENT_ID,
               grant_type: 'refresh_token',
@@ -1287,7 +1278,7 @@ describe('Auth0', () => {
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
           scope: `${TEST_SCOPES} test:scope`,
-          response_type: TEST_CODE,
+          response_type: 'code',
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
@@ -1306,7 +1297,7 @@ describe('Auth0', () => {
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
           scope: `${TEST_SCOPES} test:scope`,
-          response_type: TEST_CODE,
+          response_type: 'code',
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
@@ -1328,7 +1319,7 @@ describe('Auth0', () => {
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
           scope: `${TEST_SCOPES} test:scope`,
-          response_type: TEST_CODE,
+          response_type: 'code',
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
@@ -1348,7 +1339,7 @@ describe('Auth0', () => {
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
           scope: `${TEST_SCOPES} test:scope`,
-          response_type: TEST_CODE,
+          response_type: 'code',
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
@@ -1373,7 +1364,7 @@ describe('Auth0', () => {
           audience: defaultOptionsIgnoreCacheTrue.audience,
           client_id: TEST_CLIENT_ID,
           scope: `${TEST_SCOPES} test:scope`,
-          response_type: TEST_CODE,
+          response_type: 'code',
           response_mode: 'web_message',
           prompt: 'none',
           state: TEST_ENCODED_STATE,
@@ -1389,8 +1380,8 @@ describe('Auth0', () => {
         const { auth0, utils } = await setup();
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
         expect(utils.runIframe).toHaveBeenCalledWith(
-          `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_AUTH0_CLIENT_QUERY_STRING}`,
-          'https://test.auth0.com',
+          `https://${TEST_DOMAIN}/authorize?${TEST_QUERY_PARAMS}${TEST_AUTH0_CLIENT_QUERY_STRING}`,
+          `https://${TEST_DOMAIN}`,
           defaultOptionsIgnoreCacheTrue.timeoutInSeconds
         );
       });
@@ -1399,21 +1390,23 @@ describe('Auth0', () => {
         const { auth0, utils } = await setup({ authorizeTimeoutInSeconds: 1 });
         await auth0.getTokenSilently(defaultOptionsIgnoreCacheTrue);
         expect(utils.runIframe).toHaveBeenCalledWith(
-          `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_AUTH0_CLIENT_QUERY_STRING}`,
-          'https://test.auth0.com',
+          `https://${TEST_DOMAIN}/authorize?${TEST_QUERY_PARAMS}${TEST_AUTH0_CLIENT_QUERY_STRING}`,
+          `https://${TEST_DOMAIN}`,
           1
         );
       });
 
       it('opens iframe with correct urls and custom timeout', async () => {
         const { auth0, utils } = await setup();
+
         await auth0.getTokenSilently({
           ...defaultOptionsIgnoreCacheTrue,
           timeoutInSeconds: 1
         });
+
         expect(utils.runIframe).toHaveBeenCalledWith(
-          `https://test.auth0.com/authorize?${TEST_QUERY_PARAMS}${TEST_AUTH0_CLIENT_QUERY_STRING}`,
-          'https://test.auth0.com',
+          `https://${TEST_DOMAIN}/authorize?${TEST_QUERY_PARAMS}${TEST_AUTH0_CLIENT_QUERY_STRING}`,
+          `https://${TEST_DOMAIN}`,
           1
         );
       });
@@ -1444,8 +1437,8 @@ describe('Auth0', () => {
         expect(utils.oauthToken).toHaveBeenCalledWith(
           {
             audience: 'test:audience',
-            scope: 'openid profile email test:scope',
-            baseUrl: 'https://test.auth0.com',
+            scope: `${TEST_SCOPES} test:scope`,
+            baseUrl: `https://${TEST_DOMAIN}`,
             client_id: TEST_CLIENT_ID,
             code: TEST_CODE,
             code_verifier: TEST_RANDOM_STRING,
@@ -1463,8 +1456,8 @@ describe('Auth0', () => {
         expect(tokenVerifier).toHaveBeenCalledWith({
           id_token: TEST_ID_TOKEN,
           nonce: TEST_ENCODED_STATE,
-          aud: 'test-client-id',
-          iss: 'https://test.auth0.com/',
+          aud: TEST_CLIENT_ID,
+          iss: `https://${TEST_DOMAIN}/`,
           leeway: undefined,
           max_age: undefined
         });
@@ -1673,82 +1666,6 @@ describe('Auth0', () => {
 
       auth0.buildLogoutUrl({ federated: true, client_id: null });
       expect(utils.createQueryParams).toHaveBeenCalledWith({});
-    });
-  });
-
-  describe('logout()', () => {
-    it('removes `auth0.is.authenticated` key from storage', async () => {
-      const { auth0, cookieStorage } = await setup();
-      auth0.logout();
-      expect(cookieStorage.remove).toHaveBeenCalledWith(
-        'auth0.is.authenticated'
-      );
-    });
-
-    it('calls `window.location.assign` with the correct url', async () => {
-      const { auth0 } = await setup();
-
-      auth0.logout();
-      expect(window.location.assign).toHaveBeenCalledWith(
-        `https://test.auth0.com/v2/logout?query=params${TEST_AUTH0_CLIENT_QUERY_STRING}`
-      );
-    });
-
-    it('calls `window.location.assign` with the correct url when `options.federated` is true', async () => {
-      const { auth0 } = await setup();
-
-      auth0.logout({ federated: true });
-      expect(window.location.assign).toHaveBeenCalledWith(
-        `https://test.auth0.com/v2/logout?query=params${TEST_AUTH0_CLIENT_QUERY_STRING}&federated`
-      );
-    });
-
-    it('calls `window.location.assign` with the correct url with custom `options.auth0Client`', async () => {
-      const auth0Client = { name: '__test_client_name__', version: '9.9.9' };
-      const { auth0 } = await setup({ auth0Client });
-      auth0.logout();
-      expectToHaveBeenCalledWithAuth0ClientParam(
-        window.location.assign,
-        auth0Client
-      );
-    });
-
-    it('clears the cache', async () => {
-      const { auth0, cache } = await setup();
-
-      auth0.logout();
-
-      expect(cache.clear).toHaveBeenCalled();
-    });
-
-    it('removes `auth0.is.authenticated` key from storage when `options.localOnly` is true', async () => {
-      const { auth0, cookieStorage } = await setup();
-
-      auth0.logout({ localOnly: true });
-      expect(cookieStorage.remove).toHaveBeenCalledWith(
-        'auth0.is.authenticated'
-      );
-    });
-
-    it('skips `window.location.assign` when `options.localOnly` is true', async () => {
-      const { auth0 } = await setup();
-
-      auth0.logout({ localOnly: true });
-      expect(window.location.assign).not.toHaveBeenCalledWith();
-    });
-
-    it('calls `window.location.assign` when `options.localOnly` is false', async () => {
-      const { auth0 } = await setup();
-
-      auth0.logout({ localOnly: false });
-      expect(window.location.assign).toHaveBeenCalled();
-    });
-
-    it('throws when both `options.localOnly` and `options.federated` are true', async () => {
-      const { auth0 } = await setup();
-
-      const fn = () => auth0.logout({ localOnly: true, federated: true });
-      expect(fn).toThrow();
     });
   });
 });


### PR DESCRIPTION
- Refactor out constants into their own module and update tests
- Move logout tests into Auth0Client.test.ts
