### PR TITLE
[SDK-2156] Heed timeoutInSeconds when calling getTokenSilently with refresh tokens

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1120,7 +1120,10 @@ describe('Auth0', () => {
 
           cache.get.mockReturnValue({ refresh_token: TEST_REFRESH_TOKEN });
 
-          await auth0.getTokenSilently({ ignoreCache: true });
+          await auth0.getTokenSilently({
+            ignoreCache: true,
+            timeoutInSeconds: 10
+          });
 
           expect(cache.get).toHaveBeenCalledWith({
             audience: 'default',
@@ -1136,7 +1139,8 @@ describe('Auth0', () => {
               refresh_token: TEST_REFRESH_TOKEN,
               client_id: TEST_CLIENT_ID,
               grant_type: 'refresh_token',
-              redirect_uri: 'http://localhost'
+              redirect_uri: 'http://localhost',
+              timeout: 10000
             },
             webWorkerMatcher
           );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -876,6 +876,11 @@ export default class Auth0Client {
       ...customOptions
     } = options;
 
+    const timeout =
+      typeof options.timeoutInSeconds === 'number'
+        ? options.timeoutInSeconds * 1000
+        : null;
+
     try {
       tokenResult = await oauthToken(
         {
@@ -887,7 +892,8 @@ export default class Auth0Client {
           client_id: this.options.client_id,
           grant_type: 'refresh_token',
           refresh_token: cache && cache.refresh_token,
-          redirect_uri
+          redirect_uri,
+          ...(timeout && { timeout })
         } as RefreshTokenOptions,
         this.worker
       );


### PR DESCRIPTION
### Description

This PR fixes an issue where specifying `timeoutInSeconds` to `getTokenSilently` would have no effect, and instead always defaulting to 10 seconds.

Fixes #636 


### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
