### PR TITLE
[SDK-2172] Add SDK metrics to all API calls

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -38,6 +38,7 @@ import {
 } from '../constants';
 
 import { releaseLockSpy } from '../../__mocks__/browser-tabs-lock';
+import version from '../../src/version';
 
 jest.mock('unfetch');
 jest.mock('es-cookie');
@@ -179,13 +180,24 @@ describe('Auth0Client', () => {
 
       await getTokenSilently(auth0);
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        code_verifier: TEST_CODE_VERIFIER,
-        grant_type: 'authorization_code',
-        code: TEST_CODE
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        }
+      );
     });
 
     it('calls the token endpoint with the correct params when using refresh tokens', async () => {
@@ -351,6 +363,7 @@ describe('Auth0Client', () => {
 
       jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
         access_token: TEST_ACCESS_TOKEN,
+        code: TEST_CODE,
         state: TEST_STATE
       });
 
@@ -359,6 +372,19 @@ describe('Auth0Client', () => {
       await getTokenSilently(auth0);
 
       expectToHaveBeenCalledWithAuth0ClientParam(utils.runIframe, auth0Client);
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(auth0Client))
+        }
+      );
     });
 
     it('refreshes the token when cache available without access token', async () => {
@@ -458,6 +484,14 @@ describe('Auth0Client', () => {
           redirect_uri: TEST_REDIRECT_URI,
           refresh_token: TEST_REFRESH_TOKEN
         },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        },
         1
       );
 
@@ -474,13 +508,24 @@ describe('Auth0Client', () => {
 
       await loginWithRedirect(auth0);
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        code_verifier: TEST_CODE_VERIFIER,
-        grant_type: 'authorization_code',
-        code: TEST_CODE
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        }
+      );
 
       mockFetch.mockResolvedValueOnce(
         fetchResponse(true, {
@@ -501,6 +546,14 @@ describe('Auth0Client', () => {
           redirect_uri: TEST_REDIRECT_URI,
           refresh_token: TEST_REFRESH_TOKEN
         },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        },
         1
       );
 
@@ -519,13 +572,24 @@ describe('Auth0Client', () => {
 
       await loginWithRedirect(auth0);
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        code_verifier: TEST_CODE_VERIFIER,
-        grant_type: 'authorization_code',
-        code: TEST_CODE
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        }
+      );
 
       const access_token = await getTokenSilently(auth0, { ignoreCache: true });
 
@@ -536,6 +600,14 @@ describe('Auth0Client', () => {
           grant_type: 'refresh_token',
           redirect_uri: TEST_REDIRECT_URI,
           refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
         },
         1
       );

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -38,7 +38,7 @@ import {
 } from '../constants';
 
 import { releaseLockSpy } from '../../__mocks__/browser-tabs-lock';
-import version from '../../src/version';
+import { DEFAULT_AUTH0_CLIENT } from '../../src/constants';
 
 jest.mock('unfetch');
 jest.mock('es-cookie');
@@ -190,12 +190,7 @@ describe('Auth0Client', () => {
           code: TEST_CODE
         },
         {
-          'Auth0-Client': btoa(
-            JSON.stringify({
-              name: 'auth0-spa-js',
-              version: version
-            })
-          )
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         }
       );
     });
@@ -213,12 +208,18 @@ describe('Auth0Client', () => {
         ignoreCache: true
       });
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        grant_type: 'refresh_token',
-        refresh_token: TEST_REFRESH_TOKEN
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        }
+      );
     });
 
     it('calls the token endpoint with the correct params when passing redirect uri and using refresh tokens', async () => {
@@ -236,12 +237,18 @@ describe('Auth0Client', () => {
         ignoreCache: true
       });
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri,
-        client_id: TEST_CLIENT_ID,
-        grant_type: 'refresh_token',
-        refresh_token: TEST_REFRESH_TOKEN
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri,
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        }
+      );
     });
 
     it('calls the token endpoint with the correct params when not providing any redirect uri and using refresh tokens', async () => {
@@ -259,12 +266,18 @@ describe('Auth0Client', () => {
         ignoreCache: true
       });
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: 'http://localhost',
-        client_id: TEST_CLIENT_ID,
-        grant_type: 'refresh_token',
-        refresh_token: TEST_REFRESH_TOKEN
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: 'http://localhost',
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        }
+      );
     });
 
     it('calls the token endpoint with the correct timeout when using refresh tokens', async () => {
@@ -485,12 +498,7 @@ describe('Auth0Client', () => {
           refresh_token: TEST_REFRESH_TOKEN
         },
         {
-          'Auth0-Client': btoa(
-            JSON.stringify({
-              name: 'auth0-spa-js',
-              version: version
-            })
-          )
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         },
         1
       );
@@ -518,12 +526,7 @@ describe('Auth0Client', () => {
           code: TEST_CODE
         },
         {
-          'Auth0-Client': btoa(
-            JSON.stringify({
-              name: 'auth0-spa-js',
-              version: version
-            })
-          )
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         }
       );
 
@@ -547,12 +550,7 @@ describe('Auth0Client', () => {
           refresh_token: TEST_REFRESH_TOKEN
         },
         {
-          'Auth0-Client': btoa(
-            JSON.stringify({
-              name: 'auth0-spa-js',
-              version: version
-            })
-          )
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         },
         1
       );
@@ -582,12 +580,7 @@ describe('Auth0Client', () => {
           code: TEST_CODE
         },
         {
-          'Auth0-Client': btoa(
-            JSON.stringify({
-              name: 'auth0-spa-js',
-              version: version
-            })
-          )
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         }
       );
 
@@ -602,12 +595,7 @@ describe('Auth0Client', () => {
           refresh_token: TEST_REFRESH_TOKEN
         },
         {
-          'Auth0-Client': btoa(
-            JSON.stringify({
-              name: 'auth0-spa-js',
-              version: version
-            })
-          )
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         },
         1
       );

--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -26,10 +26,15 @@ const authorizationResponse: AuthenticationResult = {
 };
 
 export const assertPostFn = mockFetch => {
-  return (url, body, callNum = 0) => {
+  return (url, body, headers = null, callNum = 0) => {
     const [actualUrl, opts] = mockFetch.mock.calls[callNum];
     expect(url).toEqual(actualUrl);
     expect(body).toEqual(JSON.parse(opts.body));
+    if (headers) {
+      Object.keys(headers).forEach(header =>
+        expect(headers[header]).toEqual(opts.headers[header])
+      );
+    }
   };
 };
 

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -29,7 +29,11 @@ import {
   TEST_STATE
 } from '../constants';
 
-import { DEFAULT_POPUP_CONFIG_OPTIONS } from '../../src/constants';
+import {
+  DEFAULT_AUTH0_CLIENT,
+  DEFAULT_POPUP_CONFIG_OPTIONS
+} from '../../src/constants';
+import version from '../../src/version';
 
 jest.mock('unfetch');
 jest.mock('es-cookie');
@@ -236,13 +240,19 @@ describe('Auth0Client', () => {
       await loginWithPopup(auth0);
 
       expect(mockWindow.open).toHaveBeenCalled();
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        code_verifier: TEST_CODE_VERIFIER,
-        grant_type: 'authorization_code',
-        code: 'my_code'
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: 'my_code'
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        }
+      );
     });
 
     it('uses default config', async () => {
@@ -313,13 +323,19 @@ describe('Auth0Client', () => {
       await loginWithPopup(auth0, {}, { popup });
 
       expect(mockWindow.open).not.toHaveBeenCalled();
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        code_verifier: TEST_CODE_VERIFIER,
-        grant_type: 'authorization_code',
-        code: 'my_code'
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: 'my_code'
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        }
+      );
     });
 
     it('opens popup with custom auth0Client', async () => {

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -33,6 +33,7 @@ import {
   TEST_SCOPES,
   TEST_STATE
 } from '../constants';
+import version from '../../src/version';
 
 jest.mock('unfetch');
 jest.mock('es-cookie');
@@ -115,13 +116,24 @@ describe('Auth0Client', () => {
         code_challenge_method: 'S256'
       });
 
-      assertPost('https://auth0_domain/oauth/token', {
-        redirect_uri: TEST_REDIRECT_URI,
-        client_id: TEST_CLIENT_ID,
-        code_verifier: TEST_CODE_VERIFIER,
-        grant_type: 'authorization_code',
-        code: TEST_CODE
-      });
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        }
+      );
     });
 
     it('should log the user in using different default scope', async () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -275,12 +275,10 @@ describe('utils', () => {
           res({ ok: true, json: () => new Promise(ress => ress(true)) })
         )
       );
-      const auth0Client = btoa(
-        JSON.stringify({
-          name: 'auth0-spa-js',
-          version: version
-        })
-      );
+      const auth0Client = {
+        name: 'auth0-spa-js',
+        version: version
+      };
 
       await oauthToken({
         grant_type: 'authorization_code',
@@ -296,7 +294,7 @@ describe('utils', () => {
           '{"redirect_uri":"http://localhost","grant_type":"authorization_code","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
         headers: {
           'Content-type': 'application/json',
-          'Auth0-Client': auth0Client
+          'Auth0-Client': btoa(JSON.stringify(auth0Client))
         },
         method: 'POST',
         signal: abortController.signal
@@ -320,12 +318,10 @@ describe('utils', () => {
         code: 'codeIn',
         code_verifier: 'code_verifierIn'
       };
-      const auth0Client = btoa(
-        JSON.stringify({
-          name: 'auth0-spa-js',
-          version: version
-        })
-      );
+      const auth0Client = {
+        name: 'auth0-spa-js',
+        version: version
+      };
 
       await oauthToken(
         {
@@ -345,7 +341,7 @@ describe('utils', () => {
         body: JSON.stringify(body),
         headers: {
           'Content-type': 'application/json',
-          'Auth0-Client': auth0Client
+          'Auth0-Client': btoa(JSON.stringify(auth0Client))
         },
         method: 'POST',
         signal: abortController.signal
@@ -359,7 +355,7 @@ describe('utils', () => {
           scope: '__test_scope__',
           headers: {
             'Content-type': 'application/json',
-            'Auth0-Client': auth0Client
+            'Auth0-Client': btoa(JSON.stringify(auth0Client))
           },
           method: 'POST',
           timeout: 10000,

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -24,6 +24,7 @@ import { MessageChannel } from 'worker_threads';
 import unfetch from 'unfetch';
 // @ts-ignore
 import Worker from '../src/token.worker';
+import version from '../src/version';
 
 jest.mock('../src/token.worker');
 jest.mock('unfetch');
@@ -274,19 +275,29 @@ describe('utils', () => {
           res({ ok: true, json: () => new Promise(ress => ress(true)) })
         )
       );
+      const auth0Client = btoa(
+        JSON.stringify({
+          name: 'auth0-spa-js',
+          version: version
+        })
+      );
 
       await oauthToken({
         grant_type: 'authorization_code',
         baseUrl: 'https://test.com',
         client_id: 'client_idIn',
         code: 'codeIn',
-        code_verifier: 'code_verifierIn'
+        code_verifier: 'code_verifierIn',
+        auth0Client
       });
 
       expect(mockUnfetch).toBeCalledWith('https://test.com/oauth/token', {
         body:
           '{"redirect_uri":"http://localhost","grant_type":"authorization_code","client_id":"client_idIn","code":"codeIn","code_verifier":"code_verifierIn"}',
-        headers: { 'Content-type': 'application/json' },
+        headers: {
+          'Content-type': 'application/json',
+          'Auth0-Client': auth0Client
+        },
         method: 'POST',
         signal: abortController.signal
       });
@@ -309,6 +320,12 @@ describe('utils', () => {
         code: 'codeIn',
         code_verifier: 'code_verifierIn'
       };
+      const auth0Client = btoa(
+        JSON.stringify({
+          name: 'auth0-spa-js',
+          version: version
+        })
+      );
 
       await oauthToken(
         {
@@ -318,14 +335,18 @@ describe('utils', () => {
           code: 'codeIn',
           code_verifier: 'code_verifierIn',
           audience: '__test_audience__',
-          scope: '__test_scope__'
+          scope: '__test_scope__',
+          auth0Client
         },
         worker
       );
 
       expect(mockUnfetch).toBeCalledWith('https://test.com/oauth/token', {
         body: JSON.stringify(body),
-        headers: { 'Content-type': 'application/json' },
+        headers: {
+          'Content-type': 'application/json',
+          'Auth0-Client': auth0Client
+        },
         method: 'POST',
         signal: abortController.signal
       });
@@ -337,7 +358,8 @@ describe('utils', () => {
           audience: '__test_audience__',
           scope: '__test_scope__',
           headers: {
-            'Content-type': 'application/json'
+            'Content-type': 'application/json',
+            'Auth0-Client': auth0Client
           },
           method: 'POST',
           timeout: 10000,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -382,14 +382,7 @@ export default class Auth0Client {
         code: codeResult.code,
         grant_type: 'authorization_code',
         redirect_uri: params.redirect_uri,
-        auth0Client: btoa(
-          JSON.stringify(
-            this.options.auth0Client || {
-              name: 'auth0-spa-js',
-              version: version
-            }
-          )
-        )
+        auth0Client: this.options.auth0Client
       } as OAuthTokenOptions,
       this.worker
     );
@@ -526,14 +519,7 @@ export default class Auth0Client {
       code_verifier: transaction.code_verifier,
       grant_type: 'authorization_code',
       code,
-      auth0Client: btoa(
-        JSON.stringify(
-          this.options.auth0Client || {
-            name: 'auth0-spa-js',
-            version: version
-          }
-        )
-      )
+      auth0Client: this.options.auth0Client
     } as OAuthTokenOptions;
 
     // some old versions of the SDK might not have added redirect_uri to the
@@ -847,14 +833,7 @@ export default class Auth0Client {
         code: codeResult.code,
         grant_type: 'authorization_code',
         redirect_uri: params.redirect_uri,
-        auth0Client: btoa(
-          JSON.stringify(
-            this.options.auth0Client || {
-              name: 'auth0-spa-js',
-              version: version
-            }
-          )
-        )
+        auth0Client: this.options.auth0Client
       } as OAuthTokenOptions,
       this.worker
     );
@@ -924,14 +903,7 @@ export default class Auth0Client {
           refresh_token: cache && cache.refresh_token,
           redirect_uri,
           ...(timeout && { timeout }),
-          auth0Client: btoa(
-            JSON.stringify(
-              this.options.auth0Client || {
-                name: 'auth0-spa-js',
-                version: version
-              }
-            )
-          )
+          auth0Client: this.options.auth0Client
         } as RefreshTokenOptions,
         this.worker
       );

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -32,10 +32,9 @@ import {
   MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_SCOPE,
   RECOVERABLE_ERRORS,
-  DEFAULT_SESSION_CHECK_EXPIRY_DAYS
+  DEFAULT_SESSION_CHECK_EXPIRY_DAYS,
+  DEFAULT_AUTH0_CLIENT
 } from './constants';
-
-import version from './version';
 
 import {
   Auth0ClientOptions,
@@ -200,14 +199,7 @@ export default class Auth0Client {
 
   private _url(path) {
     const auth0Client = encodeURIComponent(
-      btoa(
-        JSON.stringify(
-          this.options.auth0Client || {
-            name: 'auth0-spa-js',
-            version: version
-          }
-        )
-      )
+      btoa(JSON.stringify(this.options.auth0Client || DEFAULT_AUTH0_CLIENT))
     );
     return `${this.domainUrl}${path}&auth0Client=${auth0Client}`;
   }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -381,7 +381,15 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri
+        redirect_uri: params.redirect_uri,
+        auth0Client: btoa(
+          JSON.stringify(
+            this.options.auth0Client || {
+              name: 'auth0-spa-js',
+              version: version
+            }
+          )
+        )
       } as OAuthTokenOptions,
       this.worker
     );
@@ -517,7 +525,15 @@ export default class Auth0Client {
       client_id: this.options.client_id,
       code_verifier: transaction.code_verifier,
       grant_type: 'authorization_code',
-      code
+      code,
+      auth0Client: btoa(
+        JSON.stringify(
+          this.options.auth0Client || {
+            name: 'auth0-spa-js',
+            version: version
+          }
+        )
+      )
     } as OAuthTokenOptions;
 
     // some old versions of the SDK might not have added redirect_uri to the
@@ -830,7 +846,15 @@ export default class Auth0Client {
         code_verifier,
         code: codeResult.code,
         grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri
+        redirect_uri: params.redirect_uri,
+        auth0Client: btoa(
+          JSON.stringify(
+            this.options.auth0Client || {
+              name: 'auth0-spa-js',
+              version: version
+            }
+          )
+        )
       } as OAuthTokenOptions,
       this.worker
     );
@@ -899,7 +923,15 @@ export default class Auth0Client {
           grant_type: 'refresh_token',
           refresh_token: cache && cache.refresh_token,
           redirect_uri,
-          ...(timeout && { timeout })
+          ...(timeout && { timeout }),
+          auth0Client: btoa(
+            JSON.stringify(
+              this.options.auth0Client || {
+                name: 'auth0-spa-js',
+                version: version
+              }
+            )
+          )
         } as RefreshTokenOptions,
         this.worker
       );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import { PopupConfigOptions } from './global';
+import version from './version';
 
 /**
  * @ignore
@@ -58,3 +59,11 @@ export const RECOVERABLE_ERRORS = [
  * @ignore
  */
 export const DEFAULT_SESSION_CHECK_EXPIRY_DAYS = 1;
+
+/**
+ * @ignore
+ */
+export const DEFAULT_AUTH0_CLIENT = {
+  name: 'auth0-spa-js',
+  version: version
+};

--- a/src/global.ts
+++ b/src/global.ts
@@ -403,6 +403,7 @@ export interface OAuthTokenOptions extends TokenEndpointOptions {
   redirect_uri: string;
   audience: string;
   scope: string;
+  auth0Client: string;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -391,6 +391,7 @@ export interface TokenEndpointOptions {
   client_id: string;
   grant_type: string;
   timeout?: number;
+  auth0Client: any;
   [key: string]: any;
 }
 
@@ -403,7 +404,6 @@ export interface OAuthTokenOptions extends TokenEndpointOptions {
   redirect_uri: string;
   audience: string;
   scope: string;
-  auth0Client: string;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -358,7 +358,14 @@ const getJSON = async (
 };
 
 export const oauthToken = async (
-  { baseUrl, timeout, audience, scope, ...options }: TokenEndpointOptions,
+  {
+    baseUrl,
+    timeout,
+    audience,
+    scope,
+    auth0Client,
+    ...options
+  }: TokenEndpointOptions,
   worker: Worker
 ) =>
   await getJSON(
@@ -373,7 +380,8 @@ export const oauthToken = async (
         ...options
       }),
       headers: {
-        'Content-type': 'application/json'
+        'Content-type': 'application/json',
+        'Auth0-Client': auth0Client
       }
     },
     worker

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ import {
 } from './constants';
 
 import { PopupTimeoutError, TimeoutError, GenericError } from './errors';
+import version from './version';
 
 export const createAbortController = () => new AbortController();
 
@@ -381,7 +382,14 @@ export const oauthToken = async (
       }),
       headers: {
         'Content-type': 'application/json',
-        'Auth0-Client': auth0Client
+        'Auth0-Client': btoa(
+          JSON.stringify(
+            auth0Client || {
+              name: 'auth0-spa-js',
+              version: version
+            }
+          )
+        )
       }
     },
     worker

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,8 @@ import {
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
   DEFAULT_SILENT_TOKEN_RETRY_COUNT,
   DEFAULT_FETCH_TIMEOUT_MS,
-  CLEANUP_IFRAME_TIMEOUT_IN_SECONDS
+  CLEANUP_IFRAME_TIMEOUT_IN_SECONDS,
+  DEFAULT_CLIENT
 } from './constants';
 
 import { PopupTimeoutError, TimeoutError, GenericError } from './errors';
@@ -383,12 +384,7 @@ export const oauthToken = async (
       headers: {
         'Content-type': 'application/json',
         'Auth0-Client': btoa(
-          JSON.stringify(
-            auth0Client || {
-              name: 'auth0-spa-js',
-              version: version
-            }
-          )
+          JSON.stringify(auth0Client || DEFAULT_AUTH0_CLIENT)
         )
       }
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,11 +11,10 @@ import {
   DEFAULT_SILENT_TOKEN_RETRY_COUNT,
   DEFAULT_FETCH_TIMEOUT_MS,
   CLEANUP_IFRAME_TIMEOUT_IN_SECONDS,
-  DEFAULT_CLIENT
+  DEFAULT_AUTH0_CLIENT
 } from './constants';
 
 import { PopupTimeoutError, TimeoutError, GenericError } from './errors';
-import version from './version';
 
 export const createAbortController = () => new AbortController();
 


### PR DESCRIPTION
The requests to the /token endpoint did not include the `Auth0-Client` header, making it harder to pull metrics from our data.

This PR ensures the token endpoint gets added the appropriate header in the following situations:

- Get a token after LoginWithPopup
- Get a token after LoginWithRedirect
- Refreshing a token with a worker
- Refreshing a token without a worker