### PR TITLE
[SDK-1739] Recover and logout when throwing invalid_grant on Refresh Token

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -35,7 +35,8 @@ import {
   DEFAULT_SCOPE,
   RECOVERABLE_ERRORS,
   DEFAULT_SESSION_CHECK_EXPIRY_DAYS,
-  DEFAULT_AUTH0_CLIENT
+  DEFAULT_AUTH0_CLIENT,
+  INVALID_REFRESH_TOKEN_ERROR_MESSAGE
 } from './constants';
 
 import {
@@ -824,46 +825,56 @@ export default class Auth0Client {
 
     const timeout =
       options.timeoutInSeconds || this.options.authorizeTimeoutInSeconds;
-    const codeResult = await runIframe(url, this.domainUrl, timeout);
 
-    if (stateIn !== codeResult.state) {
-      throw new Error('Invalid state');
-    }
+    try {
+      const codeResult = await runIframe(url, this.domainUrl, timeout);
 
-    const {
-      scope,
-      audience,
-      redirect_uri,
-      ignoreCache,
-      timeoutInSeconds,
-      ...customOptions
-    } = options;
+      if (stateIn !== codeResult.state) {
+        throw new Error('Invalid state');
+      }
 
-    const tokenResult = await oauthToken(
-      {
-        ...this.customOptions,
-        ...customOptions,
+      const {
         scope,
         audience,
-        baseUrl: this.domainUrl,
-        client_id: this.options.client_id,
-        code_verifier,
-        code: codeResult.code,
-        grant_type: 'authorization_code',
-        redirect_uri: params.redirect_uri,
-        auth0Client: this.options.auth0Client
-      } as OAuthTokenOptions,
-      this.worker
-    );
+        redirect_uri,
+        ignoreCache,
+        timeoutInSeconds,
+        ...customOptions
+      } = options;
 
-    const decodedToken = this._verifyIdToken(tokenResult.id_token, nonceIn);
+      const tokenResult = await oauthToken(
+        {
+          ...this.customOptions,
+          ...customOptions,
+          scope,
+          audience,
+          baseUrl: this.domainUrl,
+          client_id: this.options.client_id,
+          code_verifier,
+          code: codeResult.code,
+          grant_type: 'authorization_code',
+          redirect_uri: params.redirect_uri,
+          auth0Client: this.options.auth0Client
+        } as OAuthTokenOptions,
+        this.worker
+      );
 
-    return {
-      ...tokenResult,
-      decodedToken,
-      scope: params.scope,
-      audience: params.audience || 'default'
-    };
+      const decodedToken = this._verifyIdToken(tokenResult.id_token, nonceIn);
+
+      return {
+        ...tokenResult,
+        decodedToken,
+        scope: params.scope,
+        audience: params.audience || 'default'
+      };
+    } catch (e) {
+      if (e.error === 'login_required') {
+        this.logout({
+          localOnly: true
+        });
+      }
+      throw e;
+    }
   }
 
   private async _getTokenUsingRefreshToken(
@@ -931,6 +942,15 @@ export default class Auth0Client {
       if (e.message === MISSING_REFRESH_TOKEN_ERROR_MESSAGE) {
         return await this._getTokenFromIFrame(options);
       }
+      // A refresh token was found, but is it no longer valid.
+      // Fallback to an iframe.
+      if (
+        e.message &&
+        e.message.indexOf(INVALID_REFRESH_TOKEN_ERROR_MESSAGE) > -1
+      ) {
+        return await this._getTokenFromIFrame(options);
+      }
+
       throw e;
     }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -945,16 +945,14 @@ export default class Auth0Client {
         this.worker
       );
     } catch (e) {
-      // The web worker didn't have a refresh token in memory so
-      // fallback to an iframe.
-      if (e.message === MISSING_REFRESH_TOKEN_ERROR_MESSAGE) {
-        return await this._getTokenFromIFrame(options);
-      }
-      // A refresh token was found, but is it no longer valid.
-      // Fallback to an iframe.
       if (
-        e.message &&
-        e.message.indexOf(INVALID_REFRESH_TOKEN_ERROR_MESSAGE) > -1
+        // The web worker didn't have a refresh token in memory so
+        // fallback to an iframe.
+        e.message === MISSING_REFRESH_TOKEN_ERROR_MESSAGE ||
+        // A refresh token was found, but is it no longer valid.
+        // Fallback to an iframe.
+        (e.message &&
+          e.message.indexOf(INVALID_REFRESH_TOKEN_ERROR_MESSAGE) > -1)
       ) {
         return await this._getTokenFromIFrame(options);
       }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export const CACHE_LOCATION_MEMORY = 'memory';
 export const CACHE_LOCATION_LOCAL_STORAGE = 'localstorage';
 export const MISSING_REFRESH_TOKEN_ERROR_MESSAGE =
   'The web worker is missing the refresh token';
+export const INVALID_REFRESH_TOKEN_ERROR_MESSAGE = 'invalid refresh token';
 
 /**
  * @ignore

--- a/static/index.html
+++ b/static/index.html
@@ -503,6 +503,10 @@
                 } else {
                   _self.error = e;
                 }
+
+                if (e.error === 'login_required') {
+                  _self.isAuthenticated = false;
+                }
               });
           },
           getTokenPopup: function (audience, scope, access_tokens) {


### PR DESCRIPTION
### Description

This PR ensures the SDK can recover from being instantiated using an invalid Refresh Token.

- When using `getTokenSilently` with RefreshTokens and the Refresh Token is expired:
  - `invalid_grant` error is caught and used to fallback to `loginWithIFrame`
  - loginWithIframe logsout the user when it returns a `login_required` error.
  

### References

Closes https://github.com/auth0/auth0-spa-js/issues/654
https://github.com/auth0/auth0-spa-js/issues/449

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
