### PR TITLE
Do not send useCookiesForTransactions to authorize request

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -220,6 +220,7 @@ export default class Auth0Client {
       domain,
       leeway,
       useRefreshTokens,
+      useCookiesForTransactions,
       auth0Client,
       cacheLocation,
       advancedOptions,


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

useCookiesForTransactions was being sent to the /authorize endpoint which seems like not intended.

This appears to be a common thing, because we rely on allowing any additional parameters to be sent to /authorize, as soon as we start adding additional configurations (for client side use only), they end up being sent to the /authorize endpoint anyway.

We talked about this before, but I guess the SDK would benefit from having the configuration options reconsidered and restructured.

### References

https://github.com/auth0/auth0-react/issues/170

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
