### PR TITLE
Enable use of a different port for the playground

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,4 +81,10 @@ npm start
 
 This will open a web server on `http://localhost:3000` and display a simple web app that allows you to manually perform various features of the SDK. This is preconfigured with an Auth0 tenant and client ID but you may change this to your own for testing.
 
+You may specify a different port for the development server by specifying the `DEV_PORT` environment variable:
+
+```
+DEV_PORT=8080 npm start
+```
+
 The Playground may not cover all use cases. In this case, modify the [index.html file](https://github.com/auth0/auth0-spa-js/blob/master/static/index.html) to configure the SDK as desired to invoke different behaviors.

--- a/cypress/integration/loginWithRedirect.js
+++ b/cypress/integration/loginWithRedirect.js
@@ -26,7 +26,7 @@ describe('loginWithRedirect', function () {
       shouldNotBeUndefined(pageParams.code_challenge_method);
       shouldNotBeUndefined(pageParams.state);
       shouldNotBeUndefined(pageParams.nonce);
-      shouldBe(pageParams.redirect_uri, 'http://localhost:3000/');
+      shouldBe(pageParams.redirect_uri, 'http://localhost:3000');
       shouldBe(pageParams.response_mode, 'query');
       shouldBe(pageParams.response_type, 'code');
       shouldBe(pageParams.scope, 'openid profile email');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const EXPORT_NAME = 'createAuth0Client';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const shouldGenerateStats = process.env.WITH_STATS === 'true';
+const defaultDevPort = 3000;
 
 const visualizerOptions = {
   filename: 'bundle-stats/index.html'
@@ -74,7 +75,7 @@ let bundles = [
         serve({
           contentBase: ['dist', 'static'],
           open: true,
-          port: 3000
+          port: process.env.DEV_PORT || defaultDevPort
         }),
       !isProduction && livereload()
     ],

--- a/static/index.html
+++ b/static/index.html
@@ -375,7 +375,8 @@
               cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory',
               useRefreshTokens: _self.useRefreshTokens,
               audience: _self.audience,
-              useCookiesForTransactions: _self.useCookiesForTransactions
+              useCookiesForTransactions: _self.useCookiesForTransactions,
+              redirect_uri: window.location.origin
             };
 
             var _init = function (auth0) {
@@ -445,7 +446,7 @@
 
             _self.auth0
               .loginWithPopup({
-                redirect_uri: 'http://localhost:3000/callback.html'
+                redirect_uri: `${window.location.origin}/callback.html`
               })
               .then(function () {
                 auth0.isAuthenticated().then(function (isAuthenticated) {
@@ -458,7 +459,6 @@
             var _self = this;
 
             this.auth0.loginWithRedirect({
-              redirect_uri: 'http://localhost:3000/',
               scope: _self.audienceScopes[0].scope
             });
           },
@@ -520,13 +520,13 @@
           },
           logout: function () {
             this.auth0.logout({
-              returnTo: 'http://localhost:3000/'
+              returnTo: window.location.origin
             });
           },
           logoutNoClient: function () {
             this.auth0.logout({
               client_id: null,
-              returnTo: 'http://localhost:3000/'
+              returnTo: window.location.origin
             });
           }
         }

--- a/static/index.html
+++ b/static/index.html
@@ -446,7 +446,7 @@
 
             _self.auth0
               .loginWithPopup({
-                redirect_uri: `${window.location.origin}/callback.html`
+                redirect_uri: window.location.origin + '/callback.html'
               })
               .then(function () {
                 auth0.isAuthenticated().then(function (isAuthenticated) {


### PR DESCRIPTION
Some small improvements to the playground and startup config that was useful
when working with SPA SDK and Lock combined (which both run on the same port by
default). A consequence of this is that the playground needs to be more generic
about which redirect URI it uses.

**Commit summary**

- Allow use of DEV_PORT to serve playground on an alternative port
- Configure playground to use origin as opposed to a specific port
