### PR TITLE
Remove the nonce check in handleRedirectCallback

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -497,8 +497,8 @@ export default class Auth0Client {
 
     const transaction = this.transactionManager.get();
 
-    // Transaction should have a `code_verifier` to do PKCE and a `nonce` for CSRF protection
-    if (!transaction || !transaction.code_verifier || !transaction.nonce) {
+    // Transaction should have a `code_verifier` to do PKCE for CSRF protection
+    if (!transaction || !transaction.code_verifier) {
       throw new Error('Invalid state');
     }
 


### PR DESCRIPTION
In a previous PR, additional checks were made to ensure that state validation
could not be bypassed: https://github.com/auth0/auth0-spa-js/pull/560

A check was inserted to also check the nonce as part of this work, but
ultimately is not needed. For ID token validation, a check on the `nonce` value
is only necessary if it is present in the ID token, so enforcing this check
here violates that requirement.

Fixes #669

