### PR TITLE
Do not use AbortController in the worker if not available

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -617,12 +617,19 @@ describe('Auth0Client', () => {
           userAgent:
             'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko',
           supported: false
+        },
+        {
+          name: 'Chrome',
+          userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36',
+          supported: true
         }
       ].forEach(({ name, userAgent, supported }) =>
         it(`refreshes the token ${
           supported ? 'with' : 'without'
         } the worker, when ${name}`, async () => {
           const originalUserAgent = window.navigator.userAgent;
+
           Object.defineProperty(window.navigator, 'userAgent', {
             value: userAgent,
             configurable: true

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -617,30 +617,6 @@ describe('Auth0Client', () => {
           userAgent:
             'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko',
           supported: false
-        },
-        {
-          name: 'Safari 10',
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8',
-          supported: false
-        },
-        {
-          name: 'Safari 11',
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.28 (KHTML, like Gecko) Version/11.0 Safari/604.1.28',
-          supported: false
-        },
-        {
-          name: 'Safari 12',
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0.1 Safari/605.1.15',
-          supported: false
-        },
-        {
-          name: 'Safari 12.1',
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Safari/605.1.15',
-          supported: true
         }
       ].forEach(({ name, userAgent, supported }) =>
         it(`refreshes the token ${

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -131,7 +131,8 @@ describe('oauthToken', () => {
             'Content-type': 'application/json',
             'Auth0-Client': btoa(JSON.stringify(auth0Client))
           },
-          method: 'POST'
+          method: 'POST',
+          signal: new AbortController().signal
         },
         auth: {
           audience: '__test_audience__',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -92,8 +92,7 @@ const cacheFactory = (location: string) => {
 /**
  * @ignore
  */
-const supportWebWorker = () =>
-  !isIE11() && !isSafari10() && !isSafari11() && !isSafari12_0();
+const supportWebWorker = () => !isIE11();
 
 /**
  * @ignore

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -61,7 +61,7 @@ import {
 
 // @ts-ignore
 import TokenWorker from './worker/token.worker.ts';
-import { isIE11, isSafari10, isSafari11, isSafari12_0 } from './user-agent';
+import { isIE11 } from './user-agent';
 import { singlePromise, retryPromise } from './promise-utils';
 
 /**

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -1,10 +1,1 @@
 export const isIE11 = () => /Trident.*rv:11\.0/.test(navigator.userAgent);
-
-export const isSafari10 = () =>
-  /AppleWebKit.*Version\/10/.test(navigator.userAgent);
-
-export const isSafari11 = () =>
-  /AppleWebKit.*Version\/11/.test(navigator.userAgent);
-
-export const isSafari12_0 = () =>
-  /AppleWebKit.*Version\/12\.0/.test(navigator.userAgent);

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -46,15 +46,19 @@ const messageHandler = async ({
       });
     }
 
-    const abortController = new AbortController();
-    const { signal } = abortController;
+    let abortController: AbortController;
+
+    if (typeof AbortController === 'function') {
+      abortController = new AbortController();
+      fetchOptions.signal = abortController.signal;
+    }
 
     let response: any;
 
     try {
       response = await Promise.race([
         wait(timeout),
-        fetch(fetchUrl, { ...fetchOptions, signal })
+        fetch(fetchUrl, { ...fetchOptions })
       ]);
     } catch (error) {
       // fetch error, reject `sendMessage` using `error` key so that we retry.
@@ -67,7 +71,8 @@ const messageHandler = async ({
 
     if (!response) {
       // If the request times out, abort it and let `fetchWithTimeout` raise the error.
-      abortController.abort();
+      if (abortController) abortController.abort();
+
       return;
     }
 

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -73,6 +73,10 @@ const messageHandler = async ({
       // If the request times out, abort it and let `fetchWithTimeout` raise the error.
       if (abortController) abortController.abort();
 
+      port.postMessage({
+        error: "Timeout when executing 'fetch'"
+      });
+
       return;
     }
 


### PR DESCRIPTION
This PR excludes the use of `AbortController` inside the web worker if it is
not natively supported by the browser. Currently, this generates errors if it
is not available, but we wouldn't like to polyfill it due to the size.

I have changed the code to allow browsers that support WebWorker but not AbortController to once again use the web worker.

Tested in Safari 10, 11, 12 and Firefox 52.

Fixes #675
