### PR TITLE
[SDK-2238] Only use timeout promise when using fetchWithTimeout without a worker

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -893,7 +893,7 @@ describe('Auth0Client', () => {
       await expect(
         auth0.getTokenSilently({ ignoreCache: true })
       ).rejects.toThrow(`Timeout when executing 'fetch'`);
-      // Called thrice for the refresh token grant in http.fetchWithTimeout
+      // Called thrice for the refresh token grant in http.switchFetch
       expect(AbortController.prototype.abort).toBeCalledTimes(3);
       expect(mockFetch).toBeCalledTimes(3);
       Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -792,9 +792,8 @@ describe('Auth0Client', () => {
         auth0.getTokenSilently({ ignoreCache: true })
       ).rejects.toThrow(`Timeout when executing 'fetch'`);
 
-      // Called thrice for the refresh token grant in utils (noop)
       // Called thrice for the refresh token grant in token worker
-      expect(AbortController.prototype.abort).toBeCalledTimes(6);
+      expect(AbortController.prototype.abort).toBeCalledTimes(3);
       expect(mockFetch).toBeCalledTimes(3);
 
       Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {
@@ -894,7 +893,7 @@ describe('Auth0Client', () => {
       await expect(
         auth0.getTokenSilently({ ignoreCache: true })
       ).rejects.toThrow(`Timeout when executing 'fetch'`);
-      // Called thrice for the refresh token grant in utils
+      // Called thrice for the refresh token grant in http.fetchWithTimeout
       expect(AbortController.prototype.abort).toBeCalledTimes(3);
       expect(mockFetch).toBeCalledTimes(3);
       Object.defineProperty(constants, 'DEFAULT_FETCH_TIMEOUT_MS', {

--- a/__tests__/http.test.ts
+++ b/__tests__/http.test.ts
@@ -1,12 +1,12 @@
 import fetch from 'unfetch';
-import { fetchWithTimeout } from '../src/http';
+import { switchFetch } from '../src/http';
 
 jest.mock('../src/worker/token.worker');
 jest.mock('unfetch');
 
 const mockUnfetch = <jest.Mock>fetch;
 
-describe('fetchWithTimeout', () => {
+describe('switchFetch', () => {
   it('clears timeout when successful', async () => {
     mockUnfetch.mockImplementation(() =>
       Promise.resolve({
@@ -15,7 +15,7 @@ describe('fetchWithTimeout', () => {
       })
     );
     jest.spyOn(window, 'clearTimeout');
-    await fetchWithTimeout('https://test.com/', null, null, {}, undefined);
+    await switchFetch('https://test.com/', null, null, {}, undefined);
     expect(clearTimeout).toBeCalledTimes(1);
   });
 });

--- a/src/http.ts
+++ b/src/http.ts
@@ -11,73 +11,83 @@ import { GenericError } from './errors';
 
 export const createAbortController = () => new AbortController();
 
-const switchFetch = async (
+const fetchAndSerialize = async (
+  fetchUrl: string,
+  fetchOptions: FetchOptions
+) => {
+  const response = await fetch(fetchUrl, fetchOptions);
+  return {
+    ok: response.ok,
+    json: await response.json()
+  };
+};
+
+const fetchWithoutWorker = async (
+  fetchUrl: string,
+  fetchOptions: FetchOptions,
+  timeout: number
+) => {
+  const controller = createAbortController();
+  fetchOptions.signal = controller.signal;
+
+  let timeoutId: NodeJS.Timeout;
+
+  // The promise will resolve with one of these two promises (the fetch or the timeout), whichever completes first.
+  return Promise.race([
+    fetchAndSerialize(fetchUrl, fetchOptions),
+    new Promise((_, reject) => {
+      timeoutId = setTimeout(() => {
+        controller.abort();
+        reject(new Error("Timeout when executing 'fetch'"));
+      }, timeout);
+    })
+  ]).finally(() => {
+    clearTimeout(timeoutId);
+  });
+};
+
+const fetchWithWorker = async (
   fetchUrl: string,
   audience: string,
   scope: string,
   fetchOptions: FetchOptions,
   timeout: number,
   worker?: Worker
-): Promise<any> => {
-  if (worker) {
-    // AbortSignal is not serializable, need to implement in the Web Worker
-    delete fetchOptions.signal;
-
-    return sendMessage(
-      {
-        auth: {
-          audience,
-          scope
-        },
-        timeout,
-        fetchUrl,
-        fetchOptions
+) => {
+  return sendMessage(
+    {
+      auth: {
+        audience,
+        scope
       },
-      worker
-    );
-  } else {
-    const response = await fetch(fetchUrl, fetchOptions);
-    return {
-      ok: response.ok,
-      json: await response.json()
-    };
-  }
+      timeout,
+      fetchUrl,
+      fetchOptions
+    },
+    worker
+  );
 };
 
-export const fetchWithTimeout = (
-  url: string,
+export const switchFetch = async (
+  fetchUrl: string,
   audience: string,
   scope: string,
-  options: FetchOptions,
+  fetchOptions: FetchOptions,
   worker?: Worker,
   timeout = DEFAULT_FETCH_TIMEOUT_MS
 ): Promise<any> => {
-  const controller = createAbortController();
-  const signal = controller.signal;
-
-  const fetchOptions = {
-    ...options,
-    signal
-  };
-
-  let timeoutId: NodeJS.Timeout;
-
-  // The promise will resolve with one of these two promises (the fetch or the timeout), whichever completes first.
-  return Promise.race([
-    switchFetch(url, audience, scope, fetchOptions, timeout, worker),
-    ...(worker
-      ? []
-      : [
-          new Promise((_, reject) => {
-            timeoutId = setTimeout(() => {
-              controller.abort();
-              reject(new Error("Timeout when executing 'fetch'"));
-            }, timeout);
-          })
-        ])
-  ]).finally(() => {
-    timeoutId && clearTimeout(timeoutId);
-  });
+  if (worker) {
+    return fetchWithWorker(
+      fetchUrl,
+      audience,
+      scope,
+      fetchOptions,
+      timeout,
+      worker
+    );
+  } else {
+    return fetchWithoutWorker(fetchUrl, fetchOptions, timeout);
+  }
 };
 
 export async function getJSON<T>(
@@ -93,7 +103,7 @@ export async function getJSON<T>(
 
   for (let i = 0; i < DEFAULT_SILENT_TOKEN_RETRY_COUNT; i++) {
     try {
-      response = await fetchWithTimeout(
+      response = await switchFetch(
         url,
         audience,
         scope,

--- a/src/http.ts
+++ b/src/http.ts
@@ -11,10 +11,7 @@ import { GenericError } from './errors';
 
 export const createAbortController = () => new AbortController();
 
-const fetchAndSerialize = async (
-  fetchUrl: string,
-  fetchOptions: FetchOptions
-) => {
+const dofetch = async (fetchUrl: string, fetchOptions: FetchOptions) => {
   const response = await fetch(fetchUrl, fetchOptions);
   return {
     ok: response.ok,
@@ -34,7 +31,7 @@ const fetchWithoutWorker = async (
 
   // The promise will resolve with one of these two promises (the fetch or the timeout), whichever completes first.
   return Promise.race([
-    fetchAndSerialize(fetchUrl, fetchOptions),
+    dofetch(fetchUrl, fetchOptions),
     new Promise((_, reject) => {
       timeoutId = setTimeout(() => {
         controller.abort();

--- a/src/http.ts
+++ b/src/http.ts
@@ -65,14 +65,18 @@ export const fetchWithTimeout = (
   // The promise will resolve with one of these two promises (the fetch or the timeout), whichever completes first.
   return Promise.race([
     switchFetch(url, audience, scope, fetchOptions, timeout, worker),
-    new Promise((_, reject) => {
-      timeoutId = setTimeout(() => {
-        controller.abort();
-        reject(new Error("Timeout when executing 'fetch'"));
-      }, timeout);
-    })
+    ...(worker
+      ? []
+      : [
+          new Promise((_, reject) => {
+            timeoutId = setTimeout(() => {
+              controller.abort();
+              reject(new Error("Timeout when executing 'fetch'"));
+            }, timeout);
+          })
+        ])
   ]).finally(() => {
-    clearTimeout(timeoutId);
+    timeoutId && clearTimeout(timeoutId);
   });
 };
 

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -70,7 +70,7 @@ const messageHandler = async ({
     }
 
     if (!response) {
-      // If the request times out, abort it and let `fetchWithTimeout` raise the error.
+      // If the request times out, abort it and let `switchFetch` raise the error.
       if (abortController) abortController.abort();
 
       port.postMessage({


### PR DESCRIPTION
fetchWithTimeout is, as the name implies, configured to timeout after a certain `timeout`.

```
return Promise.race([
    switchFetch(url, audience, scope, fetchOptions, timeout, worker),
    new Promise((_, reject) => {
      timeoutId = setTimeout(() => {
        controller.abort();
        reject(new Error("Timeout when executing 'fetch'"));
      }, timeout);
    })
  ]).finally(() => {
    clearTimeout(timeoutId);
  });
```

In the above snippet, there are two promises:
- **switchFetch**, which is configured internally to timeout after `timeout` seconds. Important here is that this timeout is only for inside the worker. So when there is no worker, the timeout is ignored
- a **timeout promise** to ensure the promise.race is rejected when the timeout is hit.

When we are not using a worker, the second promise is what is being used to reject on a timeout.
When a worker is used, both fetchTimeout and the timeout promise will reject. However, it will not always be the same promise that rejects first, occasionally the switchFetch rejects before the timeout promise.

In case of a worker, the fact that we have two promises to handle the sme timeout can be a bit weird. So this PR resolves this to only use the timeout promise in case of not using a worker.