### PR TITLE
Release 1.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## [v1.13.6](https://github.com/auth0/auth0-spa-js/tree/v1.13.6) (2021-01-07)
+
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.13.5...v1.13.6)
+
+**Changed**
+
+- Update docs for getIdTokenClaims and getUser [\#690](https://github.com/auth0/auth0-spa-js/pull/690) ([adamjmcgrath](https://github.com/adamjmcgrath))
+- [SDK-2238] Only use timeout promise when using fetchWithTimeout without a worker [\#689](https://github.com/auth0/auth0-spa-js/pull/689) ([frederikprijck](https://github.com/frederikprijck))
+- Do not use AbortController in the worker if not available [\#679](https://github.com/auth0/auth0-spa-js/pull/679) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Do not send useCookiesForTransactions to authorize request [\#673](https://github.com/auth0/auth0-spa-js/pull/673) ([frederikprijck](https://github.com/frederikprijck))
+
+**Fixed**
+
+- Remove the nonce check in handleRedirectCallback [\#678](https://github.com/auth0/auth0-spa-js/pull/678) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+**Security**
+
+- Update wait-on to solve security vulnerability [\#687](https://github.com/auth0/auth0-spa-js/pull/687) ([frederikprijck](https://github.com/frederikprijck))
+- [Security] Bump ini from 1.3.5 to 1.3.7 [\#672](https://github.com/auth0/auth0-spa-js/pull/672) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
 ## [v1.13.5](https://github.com/auth0/auth0-spa-js/tree/v1.13.5) (2020-12-08)
 
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.13.4...v1.13.5)

--- a/docs/classes/auth0client.html
+++ b/docs/classes/auth0client.html
@@ -2900,7 +2900,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L149">src/Auth0Client.ts:149</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L148">src/Auth0Client.ts:148</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2922,7 +2922,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L148">src/Auth0Client.ts:148</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L147">src/Auth0Client.ts:147</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2939,7 +2939,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L283">src/Auth0Client.ts:283</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L283">src/Auth0Client.ts:283</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2972,7 +2972,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L759">src/Auth0Client.ts:759</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L767">src/Auth0Client.ts:767</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3003,7 +3003,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L577">src/Auth0Client.ts:577</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L585">src/Auth0Client.ts:585</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3042,7 +3042,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L447">src/Auth0Client.ts:447</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L455">src/Auth0Client.ts:455</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3050,6 +3050,9 @@ img {
 								<pre><code class="language-js"><span class="hljs-keyword">const</span> claims = <span class="hljs-keyword">await</span> auth0.getIdTokenClaims();</code></pre>
 							</div>
 							<p>Returns all claims from the id_token if available.</p>
+							<p>If you provide an audience or scope, they should match an existing Access Token
+								(the SDK stores a corresponding ID Token with every Access Token, and uses the
+							scope and audience to look up the ID Token)</p>
 						</div>
 						<h4 class="tsd-parameters-title">Parameters</h4>
 						<ul class="tsd-parameters">
@@ -3073,7 +3076,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L617">src/Auth0Client.ts:617</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L625">src/Auth0Client.ts:625</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3117,7 +3120,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L707">src/Auth0Client.ts:707</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L715">src/Auth0Client.ts:715</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3154,7 +3157,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L421">src/Auth0Client.ts:421</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L425">src/Auth0Client.ts:425</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3163,6 +3166,9 @@ img {
 							</div>
 							<p>Returns the user information if available (decoded
 							from the <code>id_token</code>).</p>
+							<p>If you provide an audience or scope, they should match an existing Access Token
+								(the SDK stores a corresponding ID Token with every Access Token, and uses the
+							scope and audience to look up the ID Token)</p>
 						</div>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
 						<ul class="tsd-type-parameters">
@@ -3195,7 +3201,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L484">src/Auth0Client.ts:484</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L492">src/Auth0Client.ts:492</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3226,7 +3232,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L746">src/Auth0Client.ts:746</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L754">src/Auth0Client.ts:754</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3250,7 +3256,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L336">src/Auth0Client.ts:336</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L336">src/Auth0Client.ts:336</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3290,7 +3296,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L473">src/Auth0Client.ts:473</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L481">src/Auth0Client.ts:481</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3323,7 +3329,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/Auth0Client.ts#L788">src/Auth0Client.ts:788</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/Auth0Client.ts#L796">src/Auth0Client.ts:796</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/authenticationerror.html
+++ b/docs/classes/authenticationerror.html
@@ -2879,7 +2879,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L19">src/errors.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L19">src/errors.ts:19</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2910,7 +2910,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L24">src/errors.ts:24</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L24">src/errors.ts:24</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2921,7 +2921,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2932,7 +2932,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2975,7 +2975,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L23">src/errors.ts:23</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L23">src/errors.ts:23</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2993,7 +2993,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L8">src/errors.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L8">src/errors.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/genericerror.html
+++ b/docs/classes/genericerror.html
@@ -2882,7 +2882,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L1">src/errors.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L1">src/errors.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2907,7 +2907,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error_<wbr>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2978,7 +2978,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L8">src/errors.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L8">src/errors.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popuptimeouterror.html
+++ b/docs/classes/popuptimeouterror.html
@@ -2875,7 +2875,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="timeouterror.html">TimeoutError</a>.<a href="timeouterror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L40">src/errors.ts:40</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L40">src/errors.ts:40</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2898,7 +2898,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2909,7 +2909,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2941,7 +2941,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L41">src/errors.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L41">src/errors.ts:41</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2970,7 +2970,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L8">src/errors.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L8">src/errors.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/timeouterror.html
+++ b/docs/classes/timeouterror.html
@@ -2876,7 +2876,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L32">src/errors.ts:32</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L32">src/errors.ts:32</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="timeouterror.html" class="tsd-signature-type">TimeoutError</a></h4>
@@ -2893,7 +2893,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2904,7 +2904,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L2">src/errors.ts:2</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L2">src/errors.ts:2</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2955,7 +2955,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/errors.ts#L8">src/errors.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/errors.ts#L8">src/errors.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/user.html
+++ b/docs/classes/user.html
@@ -2907,7 +2907,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L491">src/global.ts:491</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L491">src/global.ts:491</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">birthdate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L486">src/global.ts:486</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L486">src/global.ts:486</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2927,7 +2927,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L483">src/global.ts:483</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L483">src/global.ts:483</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2937,7 +2937,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L484">src/global.ts:484</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L484">src/global.ts:484</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2947,7 +2947,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">family_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L476">src/global.ts:476</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L476">src/global.ts:476</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2957,7 +2957,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">gender<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L485">src/global.ts:485</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L485">src/global.ts:485</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2967,7 +2967,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">given_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L475">src/global.ts:475</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L475">src/global.ts:475</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2977,7 +2977,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L488">src/global.ts:488</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L488">src/global.ts:488</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2987,7 +2987,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">middle_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L477">src/global.ts:477</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L477">src/global.ts:477</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2997,7 +2997,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L474">src/global.ts:474</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L474">src/global.ts:474</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3007,7 +3007,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">nickname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L478">src/global.ts:478</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L478">src/global.ts:478</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3017,7 +3017,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L489">src/global.ts:489</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L489">src/global.ts:489</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3027,7 +3027,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L490">src/global.ts:490</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L490">src/global.ts:490</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3037,7 +3037,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L481">src/global.ts:481</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L481">src/global.ts:481</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3047,7 +3047,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">preferred_<wbr>username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L479">src/global.ts:479</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L479">src/global.ts:479</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3057,7 +3057,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">profile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L480">src/global.ts:480</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L480">src/global.ts:480</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3067,7 +3067,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">sub<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L493">src/global.ts:493</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L493">src/global.ts:493</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3077,7 +3077,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">updated_<wbr>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L492">src/global.ts:492</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L492">src/global.ts:492</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3087,7 +3087,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">website<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L482">src/global.ts:482</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L482">src/global.ts:482</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3097,7 +3097,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">zoneinfo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L487">src/global.ts:487</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L487">src/global.ts:487</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -3100,7 +3100,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L171">src/global.ts:171</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L171">src/global.ts:171</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3115,7 +3115,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L254">src/global.ts:254</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L254">src/global.ts:254</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3128,7 +3128,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3138,7 +3138,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3155,7 +3155,7 @@ createAuth0Client({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/index.ts#L19">src/index.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/index.ts#L19">src/index.ts:19</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3101,7 +3101,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L171">src/global.ts:171</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L171">src/global.ts:171</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3116,7 +3116,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L254">src/global.ts:254</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L254">src/global.ts:254</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3129,7 +3129,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3139,7 +3139,7 @@ createAuth0Client({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3156,7 +3156,7 @@ createAuth0Client({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/index.ts#L19">src/index.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/index.ts#L19">src/index.ts:19</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/advancedoptions.html
+++ b/docs/interfaces/advancedoptions.html
@@ -2827,7 +2827,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">default<wbr>Scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L74">src/global.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L74">src/global.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/auth0clientoptions.html
+++ b/docs/interfaces/auth0clientoptions.html
@@ -2927,7 +2927,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L42">src/global.ts:42</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L42">src/global.ts:42</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2937,7 +2937,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">advanced<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="advancedoptions.html" class="tsd-signature-type">AdvancedOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L159">src/global.ts:159</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L159">src/global.ts:159</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2953,7 +2953,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L52">src/global.ts:52</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L52">src/global.ts:52</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2968,7 +2968,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">authorize<wbr>Timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L125">src/global.ts:125</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L125">src/global.ts:125</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2984,7 +2984,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L111">src/global.ts:111</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L111">src/global.ts:111</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3000,7 +3000,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3016,7 +3016,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L58">src/global.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L58">src/global.ts:58</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3034,7 +3034,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L11">src/global.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L11">src/global.ts:11</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3054,7 +3054,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L83">src/global.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L83">src/global.ts:83</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3072,7 +3072,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L33">src/global.ts:33</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L33">src/global.ts:33</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3087,7 +3087,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">issuer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L87">src/global.ts:87</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L87">src/global.ts:87</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3102,7 +3102,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">leeway<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L105">src/global.ts:105</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L105">src/global.ts:105</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3119,7 +3119,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">legacy<wbr>Same<wbr>Site<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L141">src/global.ts:141</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L141">src/global.ts:141</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3140,7 +3140,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L41">src/global.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L41">src/global.ts:41</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3159,7 +3159,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L24">src/global.ts:24</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L24">src/global.ts:24</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3177,7 +3177,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L18">src/global.ts:18</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L18">src/global.ts:18</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3197,7 +3197,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L99">src/global.ts:99</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L99">src/global.ts:99</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3217,7 +3217,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3234,7 +3234,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">session<wbr>Check<wbr>Expiry<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L165">src/global.ts:165</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L165">src/global.ts:165</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3251,7 +3251,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L29">src/global.ts:29</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L29">src/global.ts:29</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3267,7 +3267,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Cookies<wbr>For<wbr>Transactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L154">src/global.ts:154</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L154">src/global.ts:154</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3290,7 +3290,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Refresh<wbr>Tokens<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L119">src/global.ts:119</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L119">src/global.ts:119</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/getidtokenclaimsoptions.html
+++ b/docs/interfaces/getidtokenclaimsoptions.html
@@ -2831,7 +2831,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L248">src/global.ts:248</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L248">src/global.ts:248</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2846,7 +2846,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L244">src/global.ts:244</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L244">src/global.ts:244</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokensilentlyoptions.html
+++ b/docs/interfaces/gettokensilentlyoptions.html
@@ -2853,7 +2853,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L281">src/global.ts:281</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L281">src/global.ts:281</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2868,7 +2868,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L261">src/global.ts:261</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L261">src/global.ts:261</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2884,7 +2884,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L271">src/global.ts:271</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L271">src/global.ts:271</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2904,7 +2904,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L276">src/global.ts:276</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L276">src/global.ts:276</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2919,7 +2919,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L286">src/global.ts:286</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L286">src/global.ts:286</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokenwithpopupoptions.html
+++ b/docs/interfaces/gettokenwithpopupoptions.html
@@ -2879,7 +2879,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L42">src/global.ts:42</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L42">src/global.ts:42</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2890,7 +2890,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L52">src/global.ts:52</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L52">src/global.ts:52</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2906,7 +2906,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L58">src/global.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L58">src/global.ts:58</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2924,7 +2924,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L11">src/global.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L11">src/global.ts:11</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2945,7 +2945,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L33">src/global.ts:33</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L33">src/global.ts:33</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2961,7 +2961,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L41">src/global.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L41">src/global.ts:41</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2980,7 +2980,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L24">src/global.ts:24</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L24">src/global.ts:24</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2998,7 +2998,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L18">src/global.ts:18</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L18">src/global.ts:18</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3019,7 +3019,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3037,7 +3037,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L29">src/global.ts:29</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L29">src/global.ts:29</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/getuseroptions.html
+++ b/docs/interfaces/getuseroptions.html
@@ -2831,7 +2831,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L237">src/global.ts:237</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L237">src/global.ts:237</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2846,7 +2846,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L233">src/global.ts:233</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L233">src/global.ts:233</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logoutoptions.html
+++ b/docs/interfaces/logoutoptions.html
@@ -2839,7 +2839,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L356">src/global.ts:356</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L356">src/global.ts:356</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2857,7 +2857,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L365">src/global.ts:365</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L365">src/global.ts:365</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2876,7 +2876,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">local<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L373">src/global.ts:373</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L373">src/global.ts:373</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2894,7 +2894,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L345">src/global.ts:345</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L345">src/global.ts:345</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logouturloptions.html
+++ b/docs/interfaces/logouturloptions.html
@@ -2835,7 +2835,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L321">src/global.ts:321</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L321">src/global.ts:321</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2853,7 +2853,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L329">src/global.ts:329</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L329">src/global.ts:329</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2871,7 +2871,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L310">src/global.ts:310</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L310">src/global.ts:310</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popupconfigoptions.html
+++ b/docs/interfaces/popupconfigoptions.html
@@ -2831,7 +2831,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L226">src/global.ts:226</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L226">src/global.ts:226</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2848,7 +2848,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L219">src/global.ts:219</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L219">src/global.ts:219</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popuploginoptions.html
+++ b/docs/interfaces/popuploginoptions.html
@@ -2884,7 +2884,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L42">src/global.ts:42</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L42">src/global.ts:42</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2895,7 +2895,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L52">src/global.ts:52</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L52">src/global.ts:52</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2911,7 +2911,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L58">src/global.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L58">src/global.ts:58</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2929,7 +2929,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L11">src/global.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L11">src/global.ts:11</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2950,7 +2950,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L33">src/global.ts:33</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L33">src/global.ts:33</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2966,7 +2966,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L41">src/global.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L41">src/global.ts:41</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2985,7 +2985,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L24">src/global.ts:24</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L24">src/global.ts:24</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3003,7 +3003,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L18">src/global.ts:18</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L18">src/global.ts:18</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3024,7 +3024,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3042,7 +3042,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L29">src/global.ts:29</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L29">src/global.ts:29</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2891,7 +2891,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L42">src/global.ts:42</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L42">src/global.ts:42</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2901,7 +2901,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L198">src/global.ts:198</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L198">src/global.ts:198</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2917,7 +2917,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L52">src/global.ts:52</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L52">src/global.ts:52</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2933,7 +2933,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L58">src/global.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L58">src/global.ts:58</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2951,7 +2951,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L11">src/global.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L11">src/global.ts:11</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2971,7 +2971,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">fragment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L202">src/global.ts:202</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L202">src/global.ts:202</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2987,7 +2987,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L33">src/global.ts:33</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L33">src/global.ts:33</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3003,7 +3003,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L41">src/global.ts:41</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L41">src/global.ts:41</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3022,7 +3022,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L24">src/global.ts:24</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L24">src/global.ts:24</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3040,7 +3040,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L18">src/global.ts:18</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L18">src/global.ts:18</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3060,7 +3060,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L194">src/global.ts:194</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L194">src/global.ts:194</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3079,7 +3079,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3097,7 +3097,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L29">src/global.ts:29</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L29">src/global.ts:29</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginresult.html
+++ b/docs/interfaces/redirectloginresult.html
@@ -2827,7 +2827,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/c9ceafb/src/global.ts#L209">src/global.ts:209</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/263b49f/src/global.ts#L209">src/global.ts:209</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.13.5';
+export default '1.13.6';


### PR DESCRIPTION

**Changed**
- Update docs for getIdTokenClaims and getUser [\#690](https://github.com/auth0/auth0-spa-js/pull/690) ([adamjmcgrath](https://github.com/adamjmcgrath))
- [SDK-2238] Only use timeout promise when using fetchWithTimeout without a worker [\#689](https://github.com/auth0/auth0-spa-js/pull/689) ([frederikprijck](https://github.com/frederikprijck))
- Do not use AbortController in the worker if not available [\#679](https://github.com/auth0/auth0-spa-js/pull/679) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Do not send useCookiesForTransactions to authorize request [\#673](https://github.com/auth0/auth0-spa-js/pull/673) ([frederikprijck](https://github.com/frederikprijck))

**Fixed**
- Remove the nonce check in handleRedirectCallback [\#678](https://github.com/auth0/auth0-spa-js/pull/678) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Security**
- Update wait-on to solve security vulnerability [\#687](https://github.com/auth0/auth0-spa-js/pull/687) ([frederikprijck](https://github.com/frederikprijck))
- [Security] Bump ini from 1.3.5 to 1.3.7 [\#672](https://github.com/auth0/auth0-spa-js/pull/672) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))


[SDK-2238]: https://auth0team.atlassian.net/browse/SDK-2238