### PR TITLE
Add passwordless login feature

### DIFF
--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -3,6 +3,7 @@ import {
   AuthenticationResult,
   GetTokenSilentlyOptions,
   IdToken,
+  PasswordlessCodeLoginOptions,
   PopupConfigOptions,
   PopupLoginOptions,
   RedirectLoginOptions
@@ -15,9 +16,12 @@ import {
   TEST_CODE,
   TEST_DOMAIN,
   TEST_ID_TOKEN,
+  TEST_OTP,
+  TEST_REALM,
   TEST_REDIRECT_URI,
   TEST_REFRESH_TOKEN,
-  TEST_STATE
+  TEST_STATE,
+  TEST_USER_EMAIL
 } from '../constants';
 
 const authorizationResponse: AuthenticationResult = {
@@ -211,6 +215,22 @@ const processDefaultLoginWithPopupOptions = config => {
   };
 };
 
+const processDefaultLoginWithPasswordlessCodeOptions = config => {
+  const defaultTokenResponseOptions = {
+    success: true,
+    response: {}
+  };
+
+  const token = {
+    ...defaultTokenResponseOptions,
+    ...(config.token || {})
+  };
+
+  return {
+    token
+  };
+};
+
 export const setupMessageEventLister = (
   mockWindow: any,
   response: any = {},
@@ -277,6 +297,45 @@ export const loginWithPopupFn = (mockWindow, mockFetch) => {
       )
     );
     await auth0.loginWithPopup(options, config);
+  };
+};
+
+export const loginWithPasswordlessCodeFn = mockFetch => {
+  return async (
+    auth0: Auth0Client,
+    options: PasswordlessCodeLoginOptions = {
+      otp: TEST_OTP,
+      realm: TEST_REALM,
+      username: TEST_USER_EMAIL
+    },
+    testConfig: {
+      token?: {
+        success?: boolean;
+        response?: any;
+      };
+    } = {
+      token: {}
+    }
+  ) => {
+    const { token } = processDefaultLoginWithPasswordlessCodeOptions(
+      testConfig
+    );
+
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse(
+        token.success,
+        Object.assign(
+          {
+            id_token: TEST_ID_TOKEN,
+            refresh_token: TEST_REFRESH_TOKEN,
+            access_token: TEST_ACCESS_TOKEN,
+            expires_in: 86400
+          },
+          token.response
+        )
+      )
+    );
+    await auth0.loginWithPasswordlessCode(options);
   };
 };
 

--- a/__tests__/Auth0Client/loginWithPasswordless.test.ts
+++ b/__tests__/Auth0Client/loginWithPasswordless.test.ts
@@ -1,0 +1,668 @@
+import 'fast-text-encoding';
+import * as esCookie from 'es-cookie';
+import unfetch from 'unfetch';
+import { verify } from '../../src/jwt';
+import * as utils from '../../src/utils';
+
+// @ts-ignore
+
+import { assertPostFn, loginWithPasswordlessFn, setupFn } from './helpers';
+
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_CLIENT_ID,
+  TEST_CODE,
+  TEST_CODE_CHALLENGE,
+  TEST_CODE_VERIFIER,
+  TEST_CONNECTION,
+  TEST_ID_TOKEN,
+  TEST_NONCE,
+  TEST_OTP,
+  TEST_REALM,
+  TEST_REDIRECT_URI,
+  TEST_SCOPES,
+  TEST_STATE,
+  TEST_USER_EMAIL
+} from '../constants';
+import version from '../../src/version';
+import { PasswordlessLoginOptions } from '../../src';
+import TransactionManager from '../../src/transaction-manager';
+
+jest.mock('unfetch');
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = (mockWindow.fetch = <jest.Mock>unfetch);
+const mockVerify = <jest.Mock>verify;
+const mockCookies = require('es-cookie');
+const tokenVerifier = require('../../src/jwt').verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue(TEST_CODE_CHALLENGE);
+
+const assertPost = assertPostFn(mockFetch);
+const setup = setupFn(mockVerify);
+const loginWithPasswordless = loginWithPasswordlessFn(mockFetch);
+
+describe('Auth0Client', () => {
+  beforeEach(() => {
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+    sessionStorage.clear();
+    jest.spyOn(TransactionManager.prototype, 'create');
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+  });
+
+  describe('loginWithPasswordless', () => {
+    describe('when using link mode', () => {
+      let defaultLoginWithPasswordlessOptions = Object.freeze<PasswordlessLoginOptions>(
+        {
+          connection: TEST_CONNECTION,
+          send: 'link',
+          email: TEST_USER_EMAIL
+        }
+      );
+
+      it('should log the user in and get the token', async () => {
+        const auth0 = setup();
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        assertPost(
+          'https://auth0_domain/passwordless/start',
+          {
+            client_id: TEST_CLIENT_ID,
+            connection: TEST_CONNECTION,
+            send: 'link',
+            email: TEST_USER_EMAIL,
+            authParams: {
+              redirect_uri: TEST_REDIRECT_URI,
+              scope: TEST_SCOPES,
+              response_type: 'code',
+              response_mode: 'query',
+              state: TEST_STATE,
+              nonce: TEST_NONCE,
+              code_challenge: TEST_CODE_CHALLENGE,
+              code_challenge_method: 'S256'
+            }
+          },
+          {
+            'Auth0-Client': btoa(
+              JSON.stringify({
+                name: 'auth0-spa-js',
+                version: version
+              })
+            )
+          }
+        );
+
+        assertPost(
+          'https://auth0_domain/oauth/token',
+          {
+            redirect_uri: TEST_REDIRECT_URI,
+            client_id: TEST_CLIENT_ID,
+            code_verifier: TEST_CODE_VERIFIER,
+            grant_type: 'authorization_code',
+            code: TEST_CODE
+          },
+          {
+            'Auth0-Client': btoa(
+              JSON.stringify({
+                name: 'auth0-spa-js',
+                version: version
+              })
+            )
+          },
+          1
+        );
+      });
+
+      it('should log the user in using different default scope', async () => {
+        const auth0 = setup({
+          advancedOptions: {
+            defaultScope: 'email'
+          }
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(body.authParams.scope).toBe('openid email');
+      });
+
+      it('should log the user in using different default redirect_uri', async () => {
+        const redirect_uri = 'https://custom-redirect-uri/callback';
+
+        const auth0 = setup({
+          redirect_uri
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        console.log(mockFetch.mock.calls[0][1]);
+        expect(body.authParams.redirect_uri).toBe(redirect_uri);
+      });
+
+      it('should log the user in when overriding default redirect_uri', async () => {
+        const redirect_uri = 'https://custom-redirect-uri/callback';
+
+        const auth0 = setup({
+          redirect_uri
+        });
+
+        await loginWithPasswordless(auth0, {
+          ...defaultLoginWithPasswordlessOptions,
+          redirect_uri: 'https://my-redirect-uri/callback'
+        });
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        console.log(mockFetch.mock.calls[0][1]);
+        expect(body.authParams.redirect_uri).toBe(
+          'https://my-redirect-uri/callback'
+        );
+      });
+
+      it('should log the user in with custom params', async () => {
+        const auth0 = setup();
+
+        await loginWithPasswordless(auth0, {
+          ...defaultLoginWithPasswordlessOptions,
+          audience: 'test_audience'
+        });
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        console.log(mockFetch.mock.calls[0][1]);
+        expect(body.authParams.audience).toBe('test_audience');
+      });
+
+      it('should log the user in using offline_access when using refresh tokens', async () => {
+        const auth0 = setup({
+          useRefreshTokens: true
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(body.authParams.scope).toBe(`${TEST_SCOPES} offline_access`);
+      });
+
+      it('should log the user in and get the user', async () => {
+        const auth0 = setup({ scope: 'foo' });
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        const expectedUser = { sub: 'me' };
+
+        expect(await auth0.getUser()).toEqual(expectedUser);
+        expect(await auth0.getUser({})).toEqual(expectedUser);
+        expect(await auth0.getUser({ audience: 'default' })).toEqual(
+          expectedUser
+        );
+        expect(await auth0.getUser({ scope: 'foo' })).toEqual(expectedUser);
+        expect(await auth0.getUser({ audience: 'invalid' })).toBeUndefined();
+      });
+
+      it('should log the user in and get the user with custom scope', async () => {
+        const auth0 = setup({
+          scope: 'scope1',
+          advancedOptions: {
+            defaultScope: 'scope2'
+          }
+        });
+
+        await loginWithPasswordless(auth0, {
+          connection: TEST_CONNECTION,
+          send: 'link',
+          email: TEST_USER_EMAIL,
+          scope: 'scope3'
+        });
+
+        const expectedUser = { sub: 'me' };
+
+        expect(await auth0.getUser({ scope: 'scope1 scope2 scope3' })).toEqual(
+          expectedUser
+        );
+      });
+
+      it('should log the user in with custom auth0Client', async () => {
+        const auth0Client = { name: '__test_client__', version: '0.0.0' };
+        const auth0 = setup({ auth0Client });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        assertPost(
+          'https://auth0_domain/passwordless/start',
+          expect.anything(),
+          {
+            'Auth0-Client': btoa(JSON.stringify(auth0Client))
+          }
+        );
+      });
+
+      it('should start transaction', async () => {
+        const auth0 = setup();
+        await loginWithPasswordless(
+          auth0,
+          defaultLoginWithPasswordlessOptions,
+          { onlyStart: true }
+        );
+
+        expect(TransactionManager.prototype.create).toBeCalled();
+      });
+
+      it('uses session storage for transactions by default', async () => {
+        const auth0 = setup();
+        await loginWithPasswordless(
+          auth0,
+          defaultLoginWithPasswordlessOptions,
+          { onlyStart: true }
+        );
+
+        expect((sessionStorage.setItem as jest.Mock).mock.calls[0][0]).toBe(
+          'a0.spajs.txs'
+        );
+      });
+
+      it('uses cookie storage for transactions', async () => {
+        const auth0 = setup({ useCookiesForTransactions: true });
+
+        await loginWithPasswordless(
+          auth0,
+          defaultLoginWithPasswordlessOptions,
+          { onlyStart: true }
+        );
+
+        // Don't necessarily need to check the contents of the cookie (the storage tests are doing that),
+        // just that cookies were used when I set the correct option.
+        expect((mockCookies.set as jest.Mock).mock.calls[1][0]).toEqual(
+          'a0.spajs.txs'
+        );
+      });
+
+      it('should throw an error on start failure', async () => {
+        const auth0 = setup();
+
+        await expect(
+          loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions, {
+            start: {
+              success: false
+            }
+          })
+        ).rejects.toThrowError(
+          'HTTP error. Unable to fetch https://auth0_domain/passwordless/start'
+        );
+      });
+
+      it('should throw an error on token failure', async () => {
+        const auth0 = setup();
+
+        await expect(
+          loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions, {
+            token: {
+              success: false
+            }
+          })
+        ).rejects.toThrowError(
+          'HTTP error. Unable to fetch https://auth0_domain/oauth/token'
+        );
+      });
+
+      it('calls `tokenVerifier.verify` with the `id_token` from in the oauth/token response', async () => {
+        const auth0 = setup({
+          issuer: 'test-123.auth0.com'
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(tokenVerifier).toHaveBeenCalledWith(
+          expect.objectContaining({
+            iss: 'https://test-123.auth0.com/',
+            id_token: TEST_ID_TOKEN
+          })
+        );
+      });
+
+      it('calls `tokenVerifier.verify` with the global organization id', async () => {
+        const auth0 = setup({ organization: 'test_org_123' });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(tokenVerifier).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: 'test_org_123'
+          })
+        );
+      });
+
+      it('calls `tokenVerifier.verify` with the specific organization id', async () => {
+        const auth0 = setup({ organization: 'test_org_123' });
+
+        await loginWithPasswordless(auth0, {
+          ...defaultLoginWithPasswordlessOptions,
+          organization: 'test_org_456'
+        });
+
+        expect(tokenVerifier).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: 'test_org_456'
+          })
+        );
+      });
+
+      it('saves into cache', async () => {
+        const auth0 = setup();
+
+        jest.spyOn(auth0['cache'], 'save');
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(auth0['cache']['save']).toHaveBeenCalledWith(
+          expect.objectContaining({
+            client_id: TEST_CLIENT_ID,
+            access_token: TEST_ACCESS_TOKEN,
+            expires_in: 86400,
+            audience: 'default',
+            id_token: TEST_ID_TOKEN,
+            scope: TEST_SCOPES
+          })
+        );
+      });
+
+      it('saves `auth0.is.authenticated` key in storage', async () => {
+        const auth0 = setup();
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          '_legacy_auth0.is.authenticated',
+          'true',
+          {
+            expires: 1
+          }
+        );
+
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          'true',
+          {
+            expires: 1
+          }
+        );
+      });
+
+      it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+        const auth0 = setup({
+          sessionCheckExpiryDays: 2
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          '_legacy_auth0.is.authenticated',
+          'true',
+          {
+            expires: 2
+          }
+        );
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          'true',
+          {
+            expires: 2
+          }
+        );
+      });
+    });
+
+    describe('when using code mode', () => {
+      let defaultLoginWithPasswordlessOptions = Object.freeze<PasswordlessLoginOptions>(
+        {
+          connection: TEST_CONNECTION,
+          send: 'code',
+          email: TEST_USER_EMAIL
+        }
+      );
+
+      it('should log the user in and get the token', async () => {
+        const auth0 = setup();
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        assertPost(
+          'https://auth0_domain/passwordless/start',
+          {
+            client_id: TEST_CLIENT_ID,
+            connection: TEST_CONNECTION,
+            send: 'code',
+            email: TEST_USER_EMAIL,
+            authParams: {
+              redirect_uri: TEST_REDIRECT_URI,
+              scope: TEST_SCOPES,
+              response_type: 'code',
+              response_mode: 'query',
+              state: TEST_STATE,
+              nonce: TEST_NONCE,
+              code_challenge: TEST_CODE_CHALLENGE,
+              code_challenge_method: 'S256'
+            }
+          },
+          {
+            'Auth0-Client': btoa(
+              JSON.stringify({
+                name: 'auth0-spa-js',
+                version: version
+              })
+            )
+          }
+        );
+
+        assertPost(
+          'https://auth0_domain/oauth/token',
+          {
+            client_id: TEST_CLIENT_ID,
+            grant_type: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+            otp: TEST_OTP,
+            realm: TEST_REALM,
+            username: TEST_USER_EMAIL,
+            scope: 'openid profile email'
+          },
+          {
+            'Auth0-Client': btoa(
+              JSON.stringify({
+                name: 'auth0-spa-js',
+                version: version
+              })
+            )
+          },
+          1
+        );
+      });
+
+      it('should log the user in using offline_access when using refresh tokens', async () => {
+        const auth0 = setup({
+          useRefreshTokens: true
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        assertPost(
+          'https://auth0_domain/oauth/token',
+          {
+            client_id: TEST_CLIENT_ID,
+            grant_type: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+            otp: TEST_OTP,
+            realm: TEST_REALM,
+            username: TEST_USER_EMAIL,
+            scope: `${TEST_SCOPES} offline_access`
+          },
+          {
+            'Auth0-Client': btoa(
+              JSON.stringify({
+                name: 'auth0-spa-js',
+                version: version
+              })
+            )
+          },
+          1
+        );
+      });
+
+      it('should log the user in and get the user', async () => {
+        const auth0 = setup({ scope: 'foo' });
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        const expectedUser = { sub: 'me' };
+
+        expect(await auth0.getUser()).toEqual(expectedUser);
+        expect(await auth0.getUser({})).toEqual(expectedUser);
+        expect(await auth0.getUser({ audience: 'default' })).toEqual(
+          expectedUser
+        );
+        expect(await auth0.getUser({ scope: 'foo' })).toEqual(expectedUser);
+        expect(await auth0.getUser({ audience: 'invalid' })).toBeUndefined();
+      });
+
+      it('should not start transaction', async () => {
+        const auth0 = setup();
+        await loginWithPasswordless(
+          auth0,
+          defaultLoginWithPasswordlessOptions,
+          { onlyStart: true }
+        );
+
+        expect(TransactionManager.prototype.create).not.toBeCalled();
+      });
+
+      it('should throw an error on start failure', async () => {
+        const auth0 = setup();
+
+        await expect(
+          loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions, {
+            start: {
+              success: false
+            }
+          })
+        ).rejects.toThrowError(
+          'HTTP error. Unable to fetch https://auth0_domain/passwordless/start'
+        );
+      });
+
+      it('should throw an error on token failure', async () => {
+        const auth0 = setup();
+
+        await expect(
+          loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions, {
+            token: {
+              success: false
+            }
+          })
+        ).rejects.toThrowError(
+          'HTTP error. Unable to fetch https://auth0_domain/oauth/token'
+        );
+      });
+
+      it('calls `tokenVerifier.verify` with the `id_token` from in the oauth/token response', async () => {
+        const auth0 = setup({
+          issuer: 'test-123.auth0.com'
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+        expect(tokenVerifier).toHaveBeenCalledWith(
+          expect.objectContaining({
+            iss: 'https://test-123.auth0.com/',
+            id_token: TEST_ID_TOKEN
+          })
+        );
+      });
+
+      it('calls `tokenVerifier.verify` with the global organization id', async () => {
+        const auth0 = setup({ organization: 'test_org_123' });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(tokenVerifier).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: 'test_org_123'
+          })
+        );
+      });
+
+      it('saves into cache', async () => {
+        const auth0 = setup();
+
+        jest.spyOn(auth0['cache'], 'save');
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(auth0['cache']['save']).toHaveBeenCalledWith(
+          expect.objectContaining({
+            client_id: TEST_CLIENT_ID,
+            access_token: TEST_ACCESS_TOKEN,
+            expires_in: 86400,
+            audience: 'default',
+            id_token: TEST_ID_TOKEN,
+            scope: TEST_SCOPES
+          })
+        );
+      });
+
+      it('saves `auth0.is.authenticated` key in storage', async () => {
+        const auth0 = setup();
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          '_legacy_auth0.is.authenticated',
+          'true',
+          {
+            expires: 1
+          }
+        );
+
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          'true',
+          {
+            expires: 1
+          }
+        );
+      });
+
+      it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+        const auth0 = setup({
+          sessionCheckExpiryDays: 2
+        });
+
+        await loginWithPasswordless(auth0, defaultLoginWithPasswordlessOptions);
+
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          '_legacy_auth0.is.authenticated',
+          'true',
+          {
+            expires: 2
+          }
+        );
+        expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+          'auth0.is.authenticated',
+          'true',
+          {
+            expires: 2
+          }
+        );
+      });
+    });
+  });
+});

--- a/__tests__/Auth0Client/loginWithPasswordlessCode.test.ts
+++ b/__tests__/Auth0Client/loginWithPasswordlessCode.test.ts
@@ -1,0 +1,396 @@
+import 'fast-text-encoding';
+import * as esCookie from 'es-cookie';
+import unfetch from 'unfetch';
+import { verify } from '../../src/jwt';
+import { MessageChannel } from 'worker_threads';
+
+import { assertPostFn, loginWithPasswordlessCodeFn, setupFn } from './helpers';
+
+// @ts-ignore
+
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_AUDIENCE,
+  TEST_CLIENT_ID,
+  TEST_CODE_CHALLENGE,
+  TEST_ID_TOKEN,
+  TEST_OTP,
+  TEST_REALM,
+  TEST_REFRESH_TOKEN,
+  TEST_SCOPES,
+  TEST_USER_EMAIL
+} from '../constants';
+
+import { DEFAULT_AUTH0_CLIENT } from '../../src/constants';
+
+jest.mock('unfetch');
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = (mockWindow.fetch = <jest.Mock>unfetch);
+const mockVerify = <jest.Mock>verify;
+const tokenVerifier = require('../../src/jwt').verify;
+
+const assertPost = assertPostFn(mockFetch);
+
+const setup = setupFn(mockVerify);
+const loginWithPasswordlessCode = loginWithPasswordlessCodeFn(mockFetch);
+
+describe('Auth0Client', () => {
+  beforeEach(() => {
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+  });
+
+  describe('loginWithPasswordlessCode', () => {
+    it('should log the user in and get the user and claims', async () => {
+      const auth0 = setup({ scope: 'foo' });
+      await loginWithPasswordlessCode(auth0);
+
+      const expectedUser = { sub: 'me' };
+
+      expect(await auth0.getUser()).toEqual(expectedUser);
+      expect(await auth0.getUser({})).toEqual(expectedUser);
+      expect(await auth0.getUser({ audience: 'default' })).toEqual(
+        expectedUser
+      );
+      expect(await auth0.getUser({ scope: 'foo' })).toEqual(expectedUser);
+      expect(await auth0.getUser({ audience: 'invalid' })).toBeUndefined();
+      expect(await auth0.getIdTokenClaims()).toBeTruthy();
+      expect(await auth0.getIdTokenClaims({})).toBeTruthy();
+      expect(
+        await auth0.getIdTokenClaims({ audience: 'default' })
+      ).toBeTruthy();
+      expect(await auth0.getIdTokenClaims({ scope: 'foo' })).toBeTruthy();
+      expect(
+        await auth0.getIdTokenClaims({ audience: 'invalid' })
+      ).toBeUndefined();
+    });
+
+    it('should log the user in with custom scope', async () => {
+      const auth0 = setup({
+        scope: 'scope1',
+        advancedOptions: {
+          defaultScope: 'scope2'
+        }
+      });
+      await loginWithPasswordlessCode(auth0, {
+        otp: TEST_OTP,
+        realm: TEST_REALM,
+        username: TEST_USER_EMAIL,
+        scope: 'scope3'
+      });
+
+      const requestedScope = JSON.parse(mockFetch.mock.calls[0][1].body).scope;
+      expect(requestedScope).toContain('scope1');
+      expect(requestedScope).toContain('scope2');
+      expect(requestedScope).toContain('scope3');
+
+      const expectedUser = { sub: 'me' };
+
+      expect(await auth0.getUser({ scope: 'scope1 scope2 scope3' })).toEqual(
+        expectedUser
+      );
+    });
+
+    it('should log the user in using different default audience', async () => {
+      const auth0 = setup({
+        audience: 'not_this_one'
+      });
+      await loginWithPasswordlessCode(auth0, {
+        otp: TEST_OTP,
+        realm: TEST_REALM,
+        username: TEST_USER_EMAIL,
+        audience: TEST_AUDIENCE
+      });
+
+      const requested = JSON.parse(mockFetch.mock.calls[0][1].body).audience;
+      expect(requested).toBe(TEST_AUDIENCE);
+    });
+
+    it('should log the user in when overriding default audience', async () => {
+      const auth0 = setup({
+        audience: TEST_AUDIENCE
+      });
+      await loginWithPasswordlessCode(auth0);
+
+      const requested = JSON.parse(mockFetch.mock.calls[0][1].body).audience;
+      expect(requested).toBe(TEST_AUDIENCE);
+    });
+
+    it('should log the user in and get the token', async () => {
+      const auth0 = setup();
+
+      await loginWithPasswordlessCode(auth0);
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+          otp: TEST_OTP,
+          realm: TEST_REALM,
+          username: TEST_USER_EMAIL,
+          scope: 'openid profile email'
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        }
+      );
+    });
+
+    it('gets token with custom auth0Client', async () => {
+      const auth0Client = { name: '__test_client_name__', version: '9.9.9' };
+      const auth0 = await setup({ auth0Client });
+
+      await loginWithPasswordlessCode(auth0);
+
+      assertPost('https://auth0_domain/oauth/token', expect.anything(), {
+        'Auth0-Client': btoa(JSON.stringify(auth0Client))
+      });
+    });
+
+    it('calls `tokenVerifier.verify` with the `issuer` from in the oauth/token response', async () => {
+      const auth0 = setup({
+        issuer: 'test-123.auth0.com'
+      });
+
+      await loginWithPasswordlessCode(auth0);
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          iss: 'https://test-123.auth0.com/'
+        })
+      );
+    });
+
+    it('calls `tokenVerifier.verify` with the `leeway` from constructor', async () => {
+      const auth0 = setup({ leeway: 10 });
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          leeway: 10
+        })
+      );
+    });
+
+    it('calls `tokenVerifier.verify` with undefined `max_age` when value set in constructor is an empty string', async () => {
+      const auth0 = setup({ max_age: '' });
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_age: undefined
+        })
+      );
+    });
+
+    it('calls `tokenVerifier.verify` with the parsed `max_age` string from constructor', async () => {
+      const auth0 = setup({ max_age: '10' });
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_age: 10
+        })
+      );
+    });
+
+    it('calls `tokenVerifier.verify` with the parsed `max_age` number from constructor', async () => {
+      const auth0 = setup({ max_age: 10 });
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_age: 10
+        })
+      );
+    });
+
+    it('calls `tokenVerifier.verify` with the organization id', async () => {
+      const auth0 = setup({ organization: 'test_org_123' });
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: 'test_org_123'
+        })
+      );
+    });
+
+    it('calls `tokenVerifier.verify` with the organization id given in the login method', async () => {
+      const auth0 = setup();
+      await loginWithPasswordlessCode(auth0, {
+        otp: TEST_OTP,
+        realm: TEST_REALM,
+        username: TEST_USER_EMAIL,
+        organization: 'test_org_123'
+      });
+
+      expect(tokenVerifier).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: 'test_org_123'
+        })
+      );
+    });
+
+    it('saves into cache', async () => {
+      const auth0 = setup();
+
+      jest.spyOn(auth0['cache'], 'save');
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(auth0['cache']['save']).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_id: TEST_CLIENT_ID,
+          access_token: TEST_ACCESS_TOKEN,
+          expires_in: 86400,
+          audience: 'default',
+          id_token: TEST_ID_TOKEN,
+          scope: TEST_SCOPES
+        })
+      );
+    });
+
+    it('saves decoded token into cache', async () => {
+      const auth0 = setup();
+
+      const mockDecodedToken = {
+        claims: { sub: 'sub', aud: 'aus' },
+        user: { sub: 'sub' }
+      };
+      tokenVerifier.mockReturnValue(mockDecodedToken);
+
+      jest.spyOn(auth0['cache'], 'save');
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(auth0['cache']['save']).toHaveBeenCalledWith(
+        expect.objectContaining({
+          decodedToken: mockDecodedToken
+        })
+      );
+    });
+
+    it('should not save refresh_token in memory cache', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true
+      });
+
+      jest.spyOn(auth0['cache'], 'save');
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(auth0['cache']['save']).toHaveBeenCalled();
+      expect(auth0['cache']['save']).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh_token: TEST_REFRESH_TOKEN
+        })
+      );
+    });
+
+    it('should save refresh_token in local storage cache', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'localstorage'
+      });
+
+      jest.spyOn(auth0['cache'], 'save');
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(auth0['cache']['save']).toHaveBeenCalledWith(
+        expect.objectContaining({
+          refresh_token: TEST_REFRESH_TOKEN
+        })
+      );
+    });
+
+    it('saves `auth0.is.authenticated` key in storage', async () => {
+      const auth0 = setup();
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        '_legacy_auth0.is.authenticated',
+        'true',
+        {
+          expires: 1
+        }
+      );
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        'auth0.is.authenticated',
+        'true',
+        {
+          expires: 1
+        }
+      );
+    });
+
+    it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+      const auth0 = setup({
+        sessionCheckExpiryDays: 2
+      });
+
+      await loginWithPasswordlessCode(auth0);
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        '_legacy_auth0.is.authenticated',
+        'true',
+        {
+          expires: 2
+        }
+      );
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        'auth0.is.authenticated',
+        'true',
+        {
+          expires: 2
+        }
+      );
+    });
+
+    it('should throw an error on token failure', async () => {
+      const auth0 = setup();
+
+      await expect(
+        loginWithPasswordlessCode(
+          auth0,
+          {
+            otp: TEST_OTP,
+            realm: TEST_REALM,
+            username: TEST_USER_EMAIL
+          },
+          {
+            token: { success: false }
+          }
+        )
+      ).rejects.toThrowError(
+        'HTTP error. Unable to fetch https://auth0_domain/oauth/token'
+      );
+    });
+  });
+});

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -6,12 +6,12 @@ import {
 } from '../src/constants';
 
 import version from '../src/version';
-import { oauthToken } from '../src/api';
+import { oauthToken, passwordlessStart } from '../src/api';
 
 // @ts-ignore
 import Worker from '../src/worker/token.worker';
 import { MessageChannel } from 'worker_threads';
-import { TEST_REDIRECT_URI } from './constants';
+import { TEST_CODE_CHALLENGE, TEST_SCOPES, TEST_USER_EMAIL } from './constants';
 (<any>global).MessageChannel = MessageChannel;
 
 jest.mock('../src/worker/token.worker');
@@ -329,6 +329,301 @@ describe('oauthToken', () => {
     });
 
     expect(result.access_token).toBe('access-token');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(abortController.abort).toHaveBeenCalled();
+  });
+});
+
+describe('passwordlessStart', () => {
+  let abortController;
+  let defaultParameter = Object.freeze({
+    baseUrl: 'https://test.com',
+    client_id: 'client_idIn',
+    connection: 'email',
+    send: 'link',
+    email: TEST_USER_EMAIL,
+    auth0Client: DEFAULT_AUTH0_CLIENT,
+    authParams: {
+      redirect_uri: 'http://localhost',
+      nonce: 'nonceIn',
+      state: 'stateIn',
+      code_challenge: TEST_CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+      response_type: 'code',
+      response_mode: 'query',
+      scope: TEST_SCOPES
+    }
+  } as const);
+
+  beforeEach(() => {
+    const http = require('../src/http');
+
+    // Set up an AbortController that we can test has been called in the event of a timeout
+    abortController = new AbortController();
+    jest.spyOn(abortController, 'abort');
+    http.createAbortController = jest.fn(() => abortController);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls passwordless/start with the correct url', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({ ok: true, json: async () => true })
+    );
+    const auth0Client = {
+      name: 'auth0-spa-js',
+      version: version
+    };
+
+    await passwordlessStart({
+      baseUrl: 'https://test.com',
+      client_id: 'client_idIn',
+      connection: 'email',
+      send: 'link',
+      email: TEST_USER_EMAIL,
+      auth0Client,
+      authParams: {
+        redirect_uri: 'http://localhost',
+        nonce: 'nonceIn',
+        state: 'stateIn',
+        code_challenge: TEST_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        response_type: 'code',
+        response_mode: 'query',
+        scope: TEST_SCOPES
+      }
+    });
+
+    expect(mockFetch).toBeCalledWith('https://test.com/passwordless/start', {
+      body: `{"client_id":"client_idIn","connection":"email","send":"link","email":"${TEST_USER_EMAIL}","authParams":{"redirect_uri":"http://localhost","nonce":"nonceIn","state":"stateIn","code_challenge":"${TEST_CODE_CHALLENGE}","code_challenge_method":"S256","response_type":"code","response_mode":"query","scope":"${TEST_SCOPES}"}}`,
+      headers: {
+        'Content-type': 'application/json',
+        'Auth0-Client': btoa(JSON.stringify(auth0Client))
+      },
+      method: 'POST',
+      signal: abortController.signal
+    });
+
+    expect(mockFetch.mock.calls[0][1].signal).not.toBeUndefined();
+  });
+
+  it('calls passwordless/start with a worker with the correct url', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({ ok: true, json: async () => true })
+    );
+
+    const worker = new Worker();
+    const spy = jest.spyOn(worker, 'postMessage');
+
+    const body = {
+      client_id: 'client_idIn',
+      connection: 'email',
+      send: 'link',
+      email: TEST_USER_EMAIL,
+      authParams: {
+        redirect_uri: 'http://localhost',
+        nonce: 'nonceIn',
+        state: 'stateIn',
+        code_challenge: TEST_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        response_type: 'code',
+        response_mode: 'query',
+        audience: '__test_audience__',
+        scope: '__test_scope__'
+      }
+    };
+
+    const auth0Client = {
+      name: 'auth0-spa-js',
+      version: version
+    };
+
+    await passwordlessStart(
+      {
+        baseUrl: 'https://test.com',
+        client_id: 'client_idIn',
+        connection: 'email',
+        send: 'link',
+        email: TEST_USER_EMAIL,
+        auth0Client,
+        authParams: {
+          redirect_uri: 'http://localhost',
+          nonce: 'nonceIn',
+          state: 'stateIn',
+          code_challenge: TEST_CODE_CHALLENGE,
+          code_challenge_method: 'S256',
+          response_type: 'code',
+          response_mode: 'query',
+          audience: '__test_audience__',
+          scope: '__test_scope__'
+        }
+      },
+      worker
+    );
+
+    expect(mockFetch).toBeCalledWith('https://test.com/passwordless/start', {
+      body: JSON.stringify(body),
+      headers: {
+        'Content-type': 'application/json',
+        'Auth0-Client': btoa(JSON.stringify(auth0Client))
+      },
+      method: 'POST',
+      signal: abortController.signal
+    });
+
+    expect(mockFetch.mock.calls[0][1].signal).not.toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith(
+      {
+        fetchUrl: 'https://test.com/passwordless/start',
+        fetchOptions: {
+          body: JSON.stringify(body),
+          headers: {
+            'Content-type': 'application/json',
+            'Auth0-Client': btoa(JSON.stringify(auth0Client))
+          },
+          method: 'POST',
+          signal: new AbortController().signal
+        },
+        auth: {
+          audience: '__test_audience__',
+          scope: '__test_scope__'
+        },
+        timeout: 10000
+      },
+      expect.arrayContaining([expect.anything()])
+    );
+  });
+
+  it('handles error with error response', async () => {
+    const theError = {
+      error: 'the-error',
+      error_description: 'the-error-description'
+    };
+
+    mockFetch.mockReturnValue(
+      Promise.resolve({ ok: false, json: async () => theError })
+    );
+
+    try {
+      await passwordlessStart(defaultParameter);
+    } catch (error) {
+      expect(error.message).toBe(theError.error_description);
+      expect(error.error).toBe(theError.error);
+      expect(error.error_description).toBe(theError.error_description);
+    }
+  });
+
+  it('handles error without error response', async () => {
+    mockFetch.mockReturnValue(
+      Promise.resolve({ ok: false, json: async () => false })
+    );
+
+    try {
+      await passwordlessStart(defaultParameter);
+    } catch (error) {
+      expect(error.message).toBe(
+        `HTTP error. Unable to fetch https://test.com/passwordless/start`
+      );
+      expect(error.error).toBe('request_error');
+      expect(error.error_description).toBe(
+        `HTTP error. Unable to fetch https://test.com/passwordless/start`
+      );
+    }
+  });
+
+  it('retries the request in the event of a network failure', async () => {
+    // Fetch only fails in the case of a network issue, so should be
+    // retried here. Failure status (4xx, 5xx, etc) return a resolved Promise
+    // with the failure in the body.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+    mockFetch.mockReturnValue(Promise.reject(new Error('Network failure')));
+
+    try {
+      await passwordlessStart(defaultParameter);
+    } catch (error) {
+      expect(error.message).toBe('Network failure');
+
+      expect(mockFetch).toHaveBeenCalledTimes(DEFAULT_SILENT_TOKEN_RETRY_COUNT);
+    }
+  });
+
+  it('continues the program after failing a couple of times then succeeding', async () => {
+    // Fetch only fails in the case of a network issue, so should be
+    // retried here. Failure status (4xx, 5xx, etc) return a resolved Promise
+    // with the failure in the body.
+    // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+    mockFetch
+      .mockReturnValueOnce(Promise.reject(new Error('Network failure')))
+      .mockReturnValueOnce(Promise.reject(new Error('Network failure')))
+      .mockReturnValue(
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ email: TEST_USER_EMAIL })
+        })
+      );
+
+    const result = await passwordlessStart(defaultParameter);
+
+    expect(result.email).toBe(TEST_USER_EMAIL);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(abortController.abort).not.toHaveBeenCalled();
+  });
+
+  it('throws a fetch error when the network is down', async () => {
+    mockFetch.mockReturnValue(Promise.reject(new ProgressEvent('error')));
+
+    await expect(passwordlessStart(defaultParameter)).rejects.toMatchObject({
+      message: 'Failed to fetch'
+    });
+  });
+
+  it('surfaces a timeout error when the fetch continuously times out', async () => {
+    const createPromise = () =>
+      new Promise((resolve, _) => {
+        setTimeout(
+          () =>
+            resolve({
+              ok: true,
+              json: async () => ({ email: TEST_USER_EMAIL })
+            }),
+          500
+        );
+      });
+
+    mockFetch.mockReturnValue(createPromise());
+
+    try {
+      await passwordlessStart(defaultParameter);
+    } catch (e) {
+      expect(e.message).toBe("Timeout when executing 'fetch'");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(abortController.abort).toHaveBeenCalledTimes(3);
+    }
+  });
+
+  it('retries the request in the event of a timeout', async () => {
+    const fetchResult = {
+      ok: true,
+      json: () => Promise.resolve({ email: TEST_USER_EMAIL })
+    };
+
+    mockFetch.mockReturnValueOnce(
+      new Promise(resolve => {
+        setTimeout(() => resolve(fetchResult), 1000);
+      })
+    );
+
+    mockFetch.mockReturnValue(Promise.resolve(fetchResult));
+
+    const result = await passwordlessStart({
+      ...defaultParameter,
+      timeout: 500
+    });
+
+    expect(result.email).toBe(TEST_USER_EMAIL);
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(abortController.abort).toHaveBeenCalled();
   });

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -23,6 +23,8 @@ export const TEST_CODE = 'my_code';
 export const TEST_SCOPES = DEFAULT_SCOPE;
 export const TEST_CODE_CHALLENGE = 'TEST_CODE_CHALLENGE';
 export const TEST_CODE_VERIFIER = '123';
+export const TEST_OTP = '1234';
+export const TEST_REALM = 'email';
 export const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
 export const TEST_QUERY_PARAMS = 'query=params';
 export const TEST_ENCODED_STATE = 'encoded-state';

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -23,6 +23,7 @@ export const TEST_CODE = 'my_code';
 export const TEST_SCOPES = DEFAULT_SCOPE;
 export const TEST_CODE_CHALLENGE = 'TEST_CODE_CHALLENGE';
 export const TEST_CODE_VERIFIER = '123';
+export const TEST_CONNECTION = 'email';
 export const TEST_OTP = '1234';
 export const TEST_REALM = 'email';
 export const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,6 +17,7 @@ export async function oauthToken(
     timeout,
     audience,
     scope,
+    sendAudienceAndScope,
     auth0Client,
     ...options
   }: TokenEndpointOptions,
@@ -29,7 +30,9 @@ export async function oauthToken(
     scope,
     {
       method: 'POST',
-      body: JSON.stringify(options),
+      body: JSON.stringify(
+        sendAudienceAndScope ? { audience, scope, ...options } : options
+      ),
       headers: {
         'Content-type': 'application/json',
         'Auth0-Client': btoa(

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,7 @@
-import { TokenEndpointOptions } from './global';
+import {
+  TokenEndpointOptions,
+  PasswordlessStartEndpointOptions
+} from './global';
 import { DEFAULT_AUTH0_CLIENT } from './constants';
 import { getJSON } from './http';
 import { getMissingScope } from './scope';
@@ -52,6 +55,42 @@ export async function oauthToken(
   - Ensuring \`${missingScope}\` is returned as part of the requested token's scopes.`
     );
   }
+
+  return result;
+}
+
+export type PasswordlessStartEndpointResponse = {
+  email?: string;
+  phone_number?: string;
+  email_verified?: boolean;
+};
+
+export async function passwordlessStart(
+  {
+    baseUrl,
+    timeout,
+    auth0Client,
+    ...options
+  }: PasswordlessStartEndpointOptions,
+  worker?: Worker
+) {
+  const result = await getJSON<PasswordlessStartEndpointResponse>(
+    `${baseUrl}/passwordless/start`,
+    timeout,
+    options.authParams.audience || 'default',
+    options.authParams.scope,
+    {
+      method: 'POST',
+      body: JSON.stringify(options),
+      headers: {
+        'Content-type': 'application/json',
+        'Auth0-Client': btoa(
+          JSON.stringify(auth0Client || DEFAULT_AUTH0_CLIENT)
+        )
+      }
+    },
+    worker
+  );
 
   return result;
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -228,6 +228,23 @@ export interface PopupConfigOptions {
   popup?: any;
 }
 
+export interface PasswordlessCodeLoginOptions extends BaseLoginOptions {
+  /**
+   * Use sms or email
+   */
+  realm: 'email' | 'sms';
+
+  /**
+   * The user's phone number if realm=sms, or the user's email if realm=email
+   */
+  username: string;
+
+  /**
+   * The user's verification code
+   */
+  otp: string;
+}
+
 export interface GetUserOptions {
   /**
    * The scope that was used in the authentication request
@@ -413,6 +430,18 @@ export interface OAuthTokenOptions extends TokenEndpointOptions {
  */
 export interface RefreshTokenOptions extends TokenEndpointOptions {
   refresh_token: string;
+}
+
+/**
+ * @ignore
+ */
+export interface PasswordlessTokenOptions extends TokenEndpointOptions {
+  audience: string;
+  scope: string;
+  sendAudienceAndScope: true;
+  otp: string;
+  realm: 'email' | 'sms';
+  username: string;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -228,6 +228,36 @@ export interface PopupConfigOptions {
   popup?: any;
 }
 
+export interface PasswordlessLoginOptions extends BaseLoginOptions {
+  /**
+   * The URL where Auth0 will redirect your browser to with
+   * the authentication result. It must be whitelisted in
+   * the "Allowed Callback URLs" field in your Auth0 Application's
+   * settings.
+   */
+  redirect_uri?: string;
+
+  /**
+   * Use sms or email
+   */
+  connection: 'email';
+
+  /**
+   * Value must be either code or link.
+   */
+  send: 'code' | 'link';
+
+  /**
+   *  The user's email for delivery of a code or link via email.
+   */
+  email?: string;
+
+  /**
+   *  The user's phone number for delivery of a code or link via SMS.
+   */
+  phoneNumber?: string;
+}
+
 export interface PasswordlessCodeLoginOptions extends BaseLoginOptions {
   /**
    * Use sms or email
@@ -405,13 +435,19 @@ export interface AuthenticationResult {
 /**
  * @ignore
  */
-export interface TokenEndpointOptions {
+interface Auth0EndpointOptions {
   baseUrl: string;
   client_id: string;
-  grant_type: string;
   timeout?: number;
   auth0Client: any;
   [key: string]: any;
+}
+
+/**
+ * @ignore
+ */
+export interface TokenEndpointOptions extends Auth0EndpointOptions {
+  grant_type: string;
 }
 
 /**
@@ -442,6 +478,17 @@ export interface PasswordlessTokenOptions extends TokenEndpointOptions {
   otp: string;
   realm: 'email' | 'sms';
   username: string;
+}
+
+/**
+ * @ignore
+ */
+export interface PasswordlessStartEndpointOptions extends Auth0EndpointOptions {
+  connection: 'email' | 'sms';
+  send: 'link' | 'code';
+  email?: string;
+  phone_number?: string;
+  authParams: AuthorizeOptions;
 }
 
 /**

--- a/static/index.html
+++ b/static/index.html
@@ -40,6 +40,10 @@
               Login redirect
             </button>
 
+            <button class="btn btn-primary" @click="loginPasswordlessLink">
+              Login passwordless link
+            </button>
+
             <button class="btn btn-primary" @click="loginPasswordlessCode">
               Login passwordless code
             </button>
@@ -459,19 +463,38 @@
                 });
               });
           },
+          loginPasswordlessLink: function () {
+            var _self = this;
+            var email = prompt('Enter the passwordless e-mail address');
+            if (!email) {
+              return;
+            }
+            _self.auth0.loginWithPasswordless({
+              connection: 'email',
+              send: 'link',
+              email: email
+            });
+          },
           loginPasswordlessCode: function () {
             var _self = this;
             var email = prompt('Enter the passwordless e-mail address');
             if (!email) {
               return;
             }
-            var otp = prompt('Enter the received code');
 
             _self.auth0
-              .loginWithPasswordlessCode({
-                username: email,
-                otp: otp,
-                realm: 'email'
+              .loginWithPasswordless({
+                connection: 'email',
+                send: 'code',
+                email: email
+              })
+              .then(function () {
+                var otp = prompt('Enter the received code');
+                return _self.auth0.loginWithPasswordlessCode({
+                  username: email,
+                  otp: otp,
+                  realm: 'email'
+                });
               })
               .then(function () {
                 auth0.isAuthenticated().then(function (isAuthenticated) {

--- a/static/index.html
+++ b/static/index.html
@@ -40,6 +40,10 @@
               Login redirect
             </button>
 
+            <button class="btn btn-primary" @click="loginPasswordlessCode">
+              Login passwordless code
+            </button>
+
             <button
               class="btn btn-success"
               @click="loginHandleRedirectCallback"
@@ -447,6 +451,27 @@
             _self.auth0
               .loginWithPopup({
                 redirect_uri: window.location.origin + '/callback.html'
+              })
+              .then(function () {
+                auth0.isAuthenticated().then(function (isAuthenticated) {
+                  _self.isAuthenticated = isAuthenticated;
+                  _self.showAuth0Info();
+                });
+              });
+          },
+          loginPasswordlessCode: function () {
+            var _self = this;
+            var email = prompt('Enter the passwordless e-mail address');
+            if (!email) {
+              return;
+            }
+            var otp = prompt('Enter the received code');
+
+            _self.auth0
+              .loginWithPasswordlessCode({
+                username: email,
+                otp: otp,
+                realm: 'email'
               })
               .then(function () {
                 auth0.isAuthenticated().then(function (isAuthenticated) {


### PR DESCRIPTION
### Description

Currently, embedded passwordless login is not supported by auth0-spa-js, only by Auth0 SDK for Web (auth0.js). However, the old SDK was not really designed for SPAs, to use refresh token rotation and PKCE, you have to use the auth0-spa-js. If your application is using auth0-spa-js, it is still possible to directly call the passwordless endpoints (or use the old SDK only for these calls), but the redirect parameters won't work together with auth0-spa-js out-of-box. When third-party cookies are enabled, you can still use `getTokenSilently()`, but ITP prevents this from working in Safari. Passwordless login can be especially useful on mobile devices, but all iPhones are shipped with Safari, which makes the hacky way not suitable for the real-world usage.

This Pull Request integrates seamlessly the passwordless login functionality into auth0-spa-js.

The API has been changed by adding two new small methods:

 - `loginWithPasswordless(options: PasswordlessLoginOptions)`
  This can be used to initiate a passwordless login. When the `send` option is set to `"link"`, auth0 will send an e-mail including a link to be opened in the browser. The callback page has to call the `handleRedirectCallback()` method to complete the authentication. This flow is very similar to the `loginWithRedirect(options)` usage, except the user will click on the link in the email, instead of redirecting the browser automatically.
 - `loginWithPasswordlessCode(options: PasswordlessCodeLoginOptions)` 
   When the `loginWithPasswordless(options)` method was called with the `send` option set to `"code"`, the user will receive an e-mail including a numerical code to enter. The developer has to implement a way to prompt the user for this code. The code can be validated by calling the `loginWithPasswordless(options)` method and passing the entered code and the e-mail address or phone number of the user. When this code authentication method is used, custom `audience` and `scope` parameters have to be passed to the `loginWithPasswordlessCode` call.

The current public API left unchanged, only new methods added as described above.

Internally, first part of the `buildAuthorizeUrl` implementation has been extracted into a new private `_buildAuthorizeParams` method. This builds the parameters, but not serializes them into an URL. Thanks to this, the implementation of `loginWithPasswordless` can reuse the same logic without code duplication. The public behavior of `buildAuthorizeUrl` is not changed, works exactly like before, and this is still ensured with unchanged unit and integration tests.

### References

https://auth0.com/docs/libraries/auth0-single-page-app-sdk/migrate-from-auth0-js-to-the-auth0-single-page-app-sdk

#413

### Testing

All the new methods and functions have been unit tested with 100% coverage. The static HTML page for manual and integration tests has been updated to include buttons for the new function.

There is no new integration test, because the `brucke.auth0.com` tenant has disabled the `email` connection. I would happily write the new end-to-end tests, but the tenant configuration has to be updated, which I don't have access to. Then I can either use a free web-based disposable email service, or the tenant needs an e-mail provider configured which can expose an API to see the content of the sent mails.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
