### PR TITLE
Revert [SDK-2183] Add warning when requested scopes differ from retrieved scopes

### DIFF
--- a/__tests__/scope.test.ts
+++ b/__tests__/scope.test.ts
@@ -1,4 +1,4 @@
-import { getMissingScope, getUniqueScopes } from '../src/scope';
+import { getUniqueScopes } from '../src/scope';
 
 describe('getUniqueScopes', () => {
   it('removes duplicates', () => {
@@ -13,15 +13,5 @@ describe('getUniqueScopes', () => {
     expect(
       getUniqueScopes('openid profile', ' ', undefined, 'email', '', null)
     ).toBe('openid profile email');
-  });
-});
-
-describe('getMissingScopes', () => {
-  it('returns missing scopes', () => {
-    expect(getMissingScope('openid test test2', 'openid')).toBe('test test2');
-  });
-
-  it('returns an empty string if nothing missing', () => {
-    expect(getMissingScope(' openid test', 'openid test')).toBe('');
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,6 @@
 import { TokenEndpointOptions } from './global';
 import { DEFAULT_AUTH0_CLIENT } from './constants';
 import { getJSON } from './http';
-import { getMissingScope } from './scope';
 
 export type TokenEndpointResponse = {
   id_token: string;
@@ -22,7 +21,7 @@ export async function oauthToken(
   }: TokenEndpointOptions,
   worker?: Worker
 ) {
-  const result = await getJSON<TokenEndpointResponse>(
+  return await getJSON<TokenEndpointResponse>(
     `${baseUrl}/oauth/token`,
     timeout,
     audience || 'default',
@@ -39,16 +38,4 @@ export async function oauthToken(
     },
     worker
   );
-
-  const missingScope = getMissingScope(scope, result.scope);
-  if (missingScope.length) {
-    console.warn(
-      `The requested scopes (${scope}) are different from the scopes of the retrieved token (${result.scope}). This could mean that your access token may not include all the scopes that you expect. It is advised to resolve this by either:
-  
-  - Removing \`${missingScope}\` from the scope when requesting a new token.
-  - Ensuring \`${missingScope}\` is returned as part of the requested token's scopes.`
-    );
-  }
-
-  return result;
 }

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -9,18 +9,3 @@ const dedupe = (arr: string[]) => Array.from(new Set(arr));
 export const getUniqueScopes = (...scopes: string[]) => {
   return dedupe(scopes.join(' ').trim().split(/\s+/)).join(' ');
 };
-
-/**
- * @ignore
- */
-export const getMissingScope = (
-  originalScope: string = '',
-  comparingScope: string = ''
-) => {
-  const originalScopes = originalScope.split(/\s+/);
-  const comparingScopes = comparingScope.split(/\s+/);
-
-  return originalScopes
-    .filter(scope => !comparingScopes.includes(scope))
-    .join(' ');
-};


### PR DESCRIPTION
This PR revert the console warning that was added as part of https://github.com/auth0/auth0-spa-js/pull/665 based on feedback received in https://github.com/auth0/auth0-spa-js/issues/709.

The user reporting that issue shows that having a difference in requested vs retrieved scopes can be expected and results in unwanted console warnings.

Note: I didnt use an actual revert commit as that PR include unrelated changes to the test scripts that we want to keep.