### PR TITLE
Updated minor syntax, to allow for TypeScript compiler to be happier

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -51,6 +51,7 @@ import {
   RedirectLoginResult,
   GetTokenSilentlyOptions,
   GetTokenWithPopupOptions,
+  IdToken,
   LogoutOptions,
   RefreshTokenOptions,
   OAuthTokenOptions,
@@ -422,7 +423,7 @@ export default class Auth0Client {
    * @typeparam TUser The type to return, has to extend {@link User}. Defaults to {@link User} when omitted.
    * @param options
    */
-  public async getUser<TUser extends User = User>(
+  public async getUser<TUser extends User>(
     options: GetUserOptions = {}
   ): Promise<TUser | undefined> {
     const audience = options.audience || this.options.audience || 'default';
@@ -827,8 +828,8 @@ export default class Auth0Client {
       nonceIn,
       code_challenge,
       options.redirect_uri ||
-        this.options.redirect_uri ||
-        window.location.origin
+      this.options.redirect_uri ||
+      window.location.origin
     );
 
     const url = this._authorizeUrl({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -420,7 +420,7 @@ export default class Auth0Client {
    * (the SDK stores a corresponding ID Token with every Access Token, and uses the
    * scope and audience to look up the ID Token)
    *
-   * @typeparam TUser The type to return, has to extend {@link User}. Defaults to {@link User} when omitted.
+   * @typeparam TUser The type to return, has to extend {@link User}. 
    * @param options
    */
   public async getUser<TUser extends User>(
@@ -828,8 +828,8 @@ export default class Auth0Client {
       nonceIn,
       code_challenge,
       options.redirect_uri ||
-        this.options.redirect_uri ||
-        window.location.origin
+      this.options.redirect_uri ||
+      window.location.origin
     );
 
     const url = this._authorizeUrl({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -828,8 +828,8 @@ export default class Auth0Client {
       nonceIn,
       code_challenge,
       options.redirect_uri ||
-      this.options.redirect_uri ||
-      window.location.origin
+        this.options.redirect_uri ||
+        window.location.origin
     );
 
     const url = this._authorizeUrl({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -51,13 +51,13 @@ import {
   RedirectLoginResult,
   GetTokenSilentlyOptions,
   GetTokenWithPopupOptions,
-  IdToken,
   LogoutOptions,
   RefreshTokenOptions,
   OAuthTokenOptions,
   CacheLocation,
   LogoutUrlOptions,
-  User
+  User,
+  IdToken
 } from './global';
 
 // @ts-ignore
@@ -453,7 +453,7 @@ export default class Auth0Client {
    *
    * @param options
    */
-  public async getIdTokenClaims(options: GetIdTokenClaimsOptions = {}) {
+  public async getIdTokenClaims(options: GetIdTokenClaimsOptions = {}): Promise<IdToken> {
     const audience = options.audience || this.options.audience || 'default';
     const scope = getUniqueScopes(this.defaultScope, this.scope, options.scope);
 


### PR DESCRIPTION
### Description
Have logged an issue, and then investigated within source code ;
https://github.com/auth0/auth0-spa-js/issues/713

Fix #1 :  to return a specific type, Promise<IdToken>, which then includes a reference in IMPORTS - to avoid an 'include' statement within TYPINGS

Fix #2 : no need for additional reference (= USER) - this causes a 'missing comma' error in TypeScript compiler (!?!)

### Testing

No functionality change, simply to provide for more succinct and precise code - when compiling with TypeScript 2.2.2
(This is needed for a SharePoint SPFX webpart being created)

### Checklist

- [ X ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
(No changed functionality)

- [ X ] All active GitHub checks for tests, formatting, and security are passing
- [ X ] The correct base branch is being used, if not `master`
