### PR TITLE
[SDK-2290] Add support for Organizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
       - run:
           name: Install SPA JS
           command: |
+            pwd
             yarn add "../spa-js"
             echo -e "$AUTH0_CONTENT" > src/auth0.js;
             echo -e "$IMPORT_STATEMENT"|cat - src/main.js > /tmp/out && mv /tmp/out src/main.js;

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Note that Organizations is currently only available to customers on our Enterpri
 
 #### Log in to an organization
 
-Log into an organization by specifying the `organization` parameter when setting up the client:
+Log in to an organization by specifying the `organization` parameter when setting up the client:
 
 ```js
 createAuth0Client({

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ client.loginWithPopup({
 
 ### Accept user invitations
 
-Accept a user invitation through the SDK by creating a route within your application that can handle the invitation route, and log the user in by passing the `organization` and `invitation` parameters from this URL. You can either use `loginWithRedirect` or `loginWithPopup` as needed.
+Accept a user invitation through the SDK by creating a route within your application that can handle the user invitation URL, and log the user in by passing the `organization` and `invitation` parameters from this URL. You can either use `loginWithRedirect` or `loginWithPopup` as needed.
 
 ```js
 const params = new URLSearchParams(invitationUrl);

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Using Organizations, you can:
 
 Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
 
-#### Usage
+#### Log in to an organization
 
 Log into an organization by specifying the `organization` parameter when setting up the client:
 
@@ -280,6 +280,23 @@ client.loginWithRedirect({
 client.loginWithPopup({
   organization: '<MY_ORG_ID>'
 });
+```
+
+### Accept user invitations
+
+Accept a user invitation through the SDK by creating a route within your application that can handle the invitation route, and log the user in by passing the `organization` and `invitation` parameters from this URL. You can either use `loginWithRedirect` or `loginWithPopup` as needed.
+
+```js
+const params = new URLSearchParams(invitationUrl);
+const organization = params.get('organization');
+const invitation = params.get('invitation');
+
+if (organization && invitation) {
+  client.loginWithRedirect({
+    organization,
+    invitation
+  });
+}
 ```
 
 ### Advanced options

--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ You can redirect users back to your app after logging out. This URL must appear 
 ```js
 auth0.logout({
   returnTo: 'https://your.custom.url.example.com/'
-})
+});
 ```
-
 
 ### Data caching options
 
@@ -237,6 +236,51 @@ In all cases where a refresh token is not available, the SDK falls back to the l
 If the fallback mechanism fails, a `login_required` error will be thrown and could be handled in order to put the user back through the authentication process.
 
 **Note**: This fallback mechanism does still require access to the Auth0 session cookie, so if third-party cookies are being blocked then this fallback will not work and the user must re-authenticate in order to get a new refresh token.
+
+### Organizations (Closed Beta)
+
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+
+Using Organizations, you can:
+
+- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+
+- Manage their membership in a variety of ways, including user invitation.
+
+- Configure branded, federated login flows for each organization.
+
+- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+
+- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+#### Usage
+
+Log into an organization by specifying the `organization` parameter when setting up the client:
+
+```js
+createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  client_id: '<AUTH0_CLIENT_ID>',
+  redirect_uri: '<MY_CALLBACK_URL>',
+  organization: '<MY_ORG_ID>'
+});
+```
+
+You can also specify the organization when logging in:
+
+```js
+// Using a redirect
+client.loginWithRedirect({
+  organization: '<MY_ORG_ID>'
+});
+
+// Using a popup window
+client.loginWithPopup({
+  organization: '<MY_ORG_ID>'
+});
+```
 
 ### Advanced options
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -67,7 +67,7 @@ export interface BaseLoginOptions {
   connection?: string;
   
   /**
-   * Log users in to a specific organization (Organizations is currently a Closed Beta).
+   * The Id of an organization to log in to (Organizations is currently a Closed Beta).
    *
    * This will specify an `organization` parameter in your user's login request and will add a step to validate
    * the `org_id` claim in your user's ID Token.

--- a/src/global.ts
+++ b/src/global.ts
@@ -9,6 +9,7 @@ export interface BaseLoginOptions {
    * - `'wap'`: displays the UI with a "feature phone" type interface
    */
   display?: 'page' | 'popup' | 'touch' | 'wap';
+
   /**
    * - `'none'`: do not prompt user for login or consent on reauthentication
    * - `'login'`: prompt user for reauthentication
@@ -16,21 +17,25 @@ export interface BaseLoginOptions {
    * - `'select_account'`: prompt user to select an account
    */
   prompt?: 'none' | 'login' | 'consent' | 'select_account';
+
   /**
    * Maximum allowable elasped time (in seconds) since authentication.
    * If the last time the user authenticated is greater than this value,
    * the user must be reauthenticated.
    */
   max_age?: string | number;
+
   /**
    * The space-separated list of language tags, ordered by preference.
    * For example: `'fr-CA fr en'`.
    */
   ui_locales?: string;
+
   /**
    * Previously issued ID Token.
    */
   id_token_hint?: string;
+
   /**
    * The user's email address or other identifier. When your app knows
    * which user is trying to authenticate, you can provide this parameter
@@ -39,13 +44,16 @@ export interface BaseLoginOptions {
    * This currently only affects the classic Lock experience.
    */
   login_hint?: string;
+
   acr_values?: string;
+
   /**
    * The default scope to be used on authentication requests.
    * The defaultScope defined in the Auth0Client is included
    * along with this scope
    */
   scope?: string;
+
   /**
    * The default audience to be used for requesting API access.
    */
@@ -56,6 +64,16 @@ export interface BaseLoginOptions {
    * the Login Widget.
    */
   connection?: string;
+
+  /**
+   * The Id of the organization to log in to.
+   */
+  organization?: string;
+
+  /**
+   * The Id of an invitation to accept. This is available from the URL that is given when participating in a user invitation flow.
+   */
+  invitation?: string;
 
   /**
    * If you need to send custom parameters to the Authorization Server,

--- a/src/global.ts
+++ b/src/global.ts
@@ -64,12 +64,13 @@ export interface BaseLoginOptions {
    * the Login Widget.
    */
   connection?: string;
-
   /**
-   * The Id of the organization to log in to.
+   * Log users in to a specific organization (Organizations is currently a Closed Beta).
+   *
+   * This will specify an `organization` parameter in your user's login request and will add a step to validate
+   * the `org_id` claim in your user's ID Token.
    */
   organization?: string;
-
   /**
    * The Id of an invitation to accept. This is available from the URL that is given when participating in a user invitation flow.
    */

--- a/src/global.ts
+++ b/src/global.ts
@@ -53,17 +53,19 @@ export interface BaseLoginOptions {
    * along with this scope
    */
   scope?: string;
-
+  
   /**
    * The default audience to be used for requesting API access.
    */
   audience?: string;
+  
   /**
    * The name of the connection configured for your application.
    * If null, it will redirect to the Auth0 Login Page and show
    * the Login Widget.
    */
   connection?: string;
+  
   /**
    * Log users in to a specific organization (Organizations is currently a Closed Beta).
    *
@@ -71,11 +73,12 @@ export interface BaseLoginOptions {
    * the `org_id` claim in your user's ID Token.
    */
   organization?: string;
+  
   /**
-   * The Id of an invitation to accept. This is available from the URL that is given when participating in a user invitation flow.
+   * The Id of an invitation to accept. This is available from the user invitation URL that is given when participating in a user invitation flow.
    */
   invitation?: string;
-
+  
   /**
    * If you need to send custom parameters to the Authorization Server,
    * make sure to use the original parameter name.

--- a/static/index.html
+++ b/static/index.html
@@ -191,6 +191,16 @@
           />
         </div>
 
+        <div class="form-group">
+          <label for="organization">Organization</label>
+          <input
+            type="text"
+            v-model="organization"
+            class="form-control"
+            id="organization"
+          />
+        </div>
+
         <div class="btn-group mb-5">
           <button @click="saveForm" class="btn btn-primary">Save</button>
 
@@ -288,6 +298,7 @@
       var defaultDomain = 'brucke.auth0.com';
       var defaultClientId = 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp';
       var defaultAudience = '';
+      var defaultOrganization = '';
 
       var GenericError = createAuth0Client.GenericError;
 
@@ -303,7 +314,6 @@
         el: '#app',
         data: function () {
           var savedData = localStorage.getItem('spa-playground-data');
-
           var data = savedData ? JSON.parse(savedData) : {};
 
           return {
@@ -320,6 +330,7 @@
             domain: data.domain || defaultDomain,
             clientId: data.clientId || defaultClientId,
             audience: data.audience || defaultAudience,
+            organization: data.organization || defaultOrganization,
             audienceScopes: [
               {
                 audience: data.audience || defaultAudience,
@@ -376,10 +387,17 @@
               client_id: _self.clientId,
               cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory',
               useRefreshTokens: _self.useRefreshTokens,
-              audience: _self.audience,
               useCookiesForTransactions: _self.useCookiesForTransactions,
               redirect_uri: window.location.origin
             };
+
+            if (_self.audience) {
+              clientOptions.audience = _self.audience;
+            }
+
+            if (_self.organization) {
+              clientOptions.organization = _self.organization;
+            }
 
             var _init = function (auth0) {
               _self.auth0 = auth0;
@@ -412,7 +430,8 @@
                 useConstructor: this.useConstructor,
                 useCookiesForTransactions: this.useCookiesForTransactions,
                 useCache: this.useCache,
-                audience: this.audience
+                audience: this.audience,
+                organization: this.organization
               })
             );
           },
@@ -425,6 +444,7 @@
             this.audience = defaultAudience;
             this.useConstructor = false;
             this.useCookiesForTransactions = false;
+            this.organization = defaultOrganization;
             this.saveForm();
           },
           showAuth0Info: function () {
@@ -446,23 +466,30 @@
           loginPopup: function () {
             var _self = this;
 
-            _self.auth0
-              .loginWithPopup({
-                redirect_uri: window.location.origin + '/callback.html'
-              })
-              .then(function () {
-                auth0.isAuthenticated().then(function (isAuthenticated) {
-                  _self.isAuthenticated = isAuthenticated;
-                  _self.showAuth0Info();
-                });
+            var options = {
+              redirect_uri: window.location.origin + '/callback.html'
+            };
+
+            if (_self.organization) {
+              options.organization = _self.organization;
+            }
+
+            _self.auth0.loginWithPopup(options).then(function () {
+              auth0.isAuthenticated().then(function (isAuthenticated) {
+                _self.isAuthenticated = isAuthenticated;
+                _self.showAuth0Info();
               });
+            });
           },
           loginRedirect: function () {
             var _self = this;
+            var options = { scope: _self.audienceScopes[0].scope };
 
-            this.auth0.loginWithRedirect({
-              scope: _self.audienceScopes[0].scope
-            });
+            if (_self.organization) {
+              options.organization = _self.organization;
+            }
+
+            this.auth0.loginWithRedirect(options);
           },
           loginHandleRedirectCallback: function () {
             var _self = this;

--- a/static/index.html
+++ b/static/index.html
@@ -48,6 +48,14 @@
             >
               Login redirect callback
             </button>
+
+            <button
+              class="btn btn-dark"
+              id="handle_invite_url"
+              @click="loginHandleInvitationUrl"
+            >
+              Handle User Invitation
+            </button>
           </div>
 
           <div class="btn-group mb-3">
@@ -557,6 +565,24 @@
               client_id: null,
               returnTo: window.location.origin
             });
+          },
+          loginHandleInvitationUrl: function () {
+            var url = prompt('Your invitation URL');
+
+            if (url) {
+              const inviteMatches = url.match(/invitation=([a-zA-Z0-9_]+)/);
+
+              if (inviteMatches) {
+                var orgMatches = url.match(/organization=([a-zA-Z0-9_]+)/);
+
+                if (orgMatches) {
+                  this.auth0.loginWithRedirect({
+                    organization: orgMatches[1],
+                    invitation: inviteMatches[1]
+                  });
+                }
+              }
+            }
           }
         }
       });


### PR DESCRIPTION
This PR adds more complete support for Organizations, which is currently in a closed beta stage.

* Adds auth endpoint properties `organization` and `invitation` to the global types
* Adds information into the readme as to how to configure the SDK to support organizations and accepting user invitations
* Updates the playground app to try out organizations and user invitations with a compatible tenant + application

ID token validation was already added in [a previous PR](https://github.com/auth0/auth0-spa-js/pull/631).

