### PR TITLE
Add screen_hint parameter to BaseLoginOptions

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -37,6 +37,15 @@ export interface BaseLoginOptions {
   id_token_hint?: string;
 
   /**
+   * Provides a hint to Auth0 as to what flow should be displayed.
+   * The default behavior is to show a login page but you can override
+   * this by passing 'signup' to show the signup page instead.
+   *
+   * This only affects the New Universal Login Experience.
+   */
+  screen_hint?: string;
+
+  /**
    * The user's email address or other identifier. When your app knows
    * which user is trying to authenticate, you can provide this parameter
    * to pre-fill the email box or select the right session for sign-in.


### PR DESCRIPTION
### Description

The global options doesn't indicate you can pass a `screen_hint` such as `signup` to default to the signup page (rather than the login page).

### References

screen_hint is documented at https://auth0.com/docs/universal-login/new-experience#signup

### Testing

This change just adds it to the typescript definition as all the args are already passed to auth0 today so no imperative code is needed to enable it. This PR just stops TypeScript from being unhappy.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
