### PR TITLE
Fix invitations usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,12 +282,13 @@ client.loginWithPopup({
 });
 ```
 
-### Accept user invitations
+#### Accept user invitations
 
 Accept a user invitation through the SDK by creating a route within your application that can handle the user invitation URL, and log the user in by passing the `organization` and `invitation` parameters from this URL. You can either use `loginWithRedirect` or `loginWithPopup` as needed.
 
 ```js
-const params = new URLSearchParams(invitationUrl);
+const url = new URL(invitationUrl);
+const params = new URLSearchParams(url.search);
 const organization = params.get('organization');
 const invitation = params.get('invitation');
 


### PR DESCRIPTION
### Description

This PR fixes the usage example for organizations in the readme. Namely:

* Should have used a level 4 heading
* The example for user invitations is wrong; you can't pass a full URL into `URLSearchParams` without it behaving weirdly when you try and get parameters. It just wants the "search" part of a URL.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
