### PR TITLE
Add Popup cancelled event

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -320,7 +320,14 @@ export default class Auth0Client {
 
   /**
    * ```js
-   * await auth0.loginWithPopup(options);
+   * try {
+   *  await auth0.loginWithPopup(options);
+   * } catch(e) {
+   *  if (e instanceof PopupCancelledError) {
+   *    // Popup was closed before login completed
+   *  }
+   * }
+   *
    * ```
    *
    * Opens a popup with the `/authorize` URL using the parameters

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -58,3 +58,11 @@ export class PopupTimeoutError extends TimeoutError {
     Object.setPrototypeOf(this, PopupTimeoutError.prototype);
   }
 }
+
+export class PopupCancelledError extends GenericError {
+  constructor(public popup: Window) {
+    super('cancelled', 'Popup closed');
+    //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, PopupCancelledError.prototype);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,5 +27,6 @@ export {
   GenericError,
   AuthenticationError,
   TimeoutError,
-  PopupTimeoutError
+  PopupTimeoutError,
+  PopupCancelledError
 } from './errors';

--- a/static/index.html
+++ b/static/index.html
@@ -482,12 +482,17 @@
               options.organization = _self.organization;
             }
 
-            _self.auth0.loginWithPopup(options).then(function () {
-              auth0.isAuthenticated().then(function (isAuthenticated) {
-                _self.isAuthenticated = isAuthenticated;
-                _self.showAuth0Info();
+            _self.auth0
+              .loginWithPopup(options)
+              .then(function () {
+                auth0.isAuthenticated().then(function (isAuthenticated) {
+                  _self.isAuthenticated = isAuthenticated;
+                  _self.showAuth0Info();
+                });
+              })
+              .catch(err => {
+                _self.error = err;
               });
-            });
           },
           loginRedirect: function () {
             var _self = this;
@@ -553,6 +558,9 @@
               .getTokenWithPopup({ audience: audience, scope: scope })
               .then(function (token) {
                 access_tokens.push(token);
+              })
+              .catch(err => {
+                _self.error = err;
               });
           },
           logout: function () {


### PR DESCRIPTION
### Description

Add support for PopupCancelledError

``` js
  try {
       await auth0.loginWithPopup(options);
    } catch(e) {
      if (e instanceof PopupCancelledError) {
          // Popup was closed before login completed
       }
    }
```
🥼  Extra enhancements:

- Replace deprecated **jest.runTimersToTime** with **jest.advanceTimersByTime**
- Replace **jest.runAllTimers** with **jest.runOnlyPendingTimers**

### References

Feature request via [https://github.com/auth0/auth0-spa-js/issues/599](https://github.com/auth0/auth0-spa-js/issues/599)

### Testing

1. Run the Auth0 SPA JS Playground (npm start)
2. Click Login popup
3. Close the Popup

You should see 

<img width="354" alt="error" src="https://user-images.githubusercontent.com/4001529/114947075-14c53300-9e12-11eb-9828-1300e14e042a.png">

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
