### PR TITLE
Explicitly specify the NPM registry for the Vue build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - run: mv dist spa-js
       - run:
           name: Create App
-          command: npx -p @vue/cli vue create my-app -d -m yarn --useTaobaoRegistry=false < /dev/null
+          command: npx -p @vue/cli vue create my-app -d -m yarn -r http://registry.npmjs.org/ < /dev/null
       - run:
           name: Install SPA JS
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,12 +121,11 @@ jobs:
       - run: mv dist spa-js
       - run:
           name: Create App
-          command: npx -p @vue/cli vue create my-app -d -m yarn < /dev/null
+          command: npx -p @vue/cli vue create my-app -d -m yarn --useTaobaoRegistry=false < /dev/null
       - run:
           name: Install SPA JS
           command: |
             yarn add "../spa-js"
-            ls -lah
             touch src/auth0.js
             echo -e "$AUTH0_CONTENT" > src/auth0.js;
             echo -e "$IMPORT_STATEMENT"|cat - src/main.js > /tmp/out && mv /tmp/out src/main.js;


### PR DESCRIPTION
This is an attemp to fix the Vue CI build, which randomly fails.

It looks like the reason Vue builds are randomly failing is because the
Vue CLI prompts the terminal to ask whether to use the Taobao registry
instead as the package install is taking too long. Of course, in a CI
build this prompt never gets answered, presumably times out and then we
never see it because we output the CLI command to `/dev/null`.

This attempts to fix it by explicitly specifying the default NPM registry so that the prompt is not used.

See https://cli.vuejs.org/guide/creating-a-project.html#vue-create
