### PR TITLE
Add HTML comments around issue templates to improve formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,27 +4,28 @@ about: Suggest an idea or a feature for this project
 title: ''
 labels: feature request
 assignees: ''
-
 ---
 
+<!--
 **Please do not report security vulnerabilities here**. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
 
 **Thank you in advance for helping us to improve this library!** Your attention to detail here is greatly appreciated and will help us respond as quickly as possible. For general support or usage questions, use the [Auth0 Community](https://community.auth0.com/) or [Auth0 Support](https://support.auth0.com/). Finally, to avoid duplicates, please search existing Issues before submitting one here.
 
 By submitting an Issue to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+-->
 
 ### Describe the problem you'd like to have solved
 
-> A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ### Describe the ideal solution
 
-> A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen -->
 
 ## Alternatives and current work-arounds
 
-> A clear and concise description of any alternatives you've considered or any work-arounds that are currently in place.
+<!-- A clear and concise description of any alternatives you've considered or any work-arounds that are currently in place.-->
 
 ### Additional context
 
-> Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -6,31 +6,36 @@ labels: bug report
 assignees: ''
 ---
 
+<!--
 **Please do not report security vulnerabilities here**. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
 
 **Thank you in advance for helping us to improve this library!** Please read through the template below and answer all relevant questions. Your additional work here is greatly appreciated and will help us respond as quickly as possible. For general support or usage questions, use the [Auth0 Community](https://community.auth0.com/) or [Auth0 Support](https://support.auth0.com/). Finally, to avoid duplicates, please search existing Issues before submitting one here.
 
 By submitting an Issue to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md).
+-->
 
 ### Describe the problem
 
-> Provide a clear and concise description of the issue
+<!-- Provide a clear and concise description of the issue -->
 
 ### What was the expected behavior?
 
-> Tell us about the behavior you expected to see
+<!-- Tell us about the behavior you expected to see -->
 
 ### Reproduction
 
+<!--
 > Detail the steps taken to reproduce this error, and whether this issue can be reproduced consistently or if it is intermittent.
 > **Note**: If clear, reproducable steps or the smallest sample app demonstrating misbehavior cannot be provided, we may not be able to follow up on this bug report.
 
 - Step 1..
 - Step 2..
 - ...
+-->
 
 **Can the behavior be reproduced using the [SPA SDK Playground](https://github.com/auth0/auth0-spa-js/blob/master/DEVELOPMENT.md#the-sdk-playground)?**
 
+<!--
 If so, provide steps:
 
 > Where applicable, please include:
@@ -39,10 +44,13 @@ If so, provide steps:
 > - Log files (redact/remove sensitive information)
 > - Application settings (redact/remove sensitive information)
 > - Screenshots
+-->
 
 ### Environment
 
+<!--
 > Please provide the following:
+-->
 
 - **Version of `auth0-spa-js` used:**
 - **Which browsers have you tested in?**


### PR DESCRIPTION
Oftentimes issues are raised and all the default text is still in there.
This will hopefully continue to prompt the person raising the issue for
information, but none of that boilerplate should make it to the actual
issue, making them easier to read.
