### PR TITLE
Fix popup blocker showing for loginWithPopup in Firefox & Safari

### DIFF
--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -231,7 +231,10 @@ export const setupMessageEventLister = (
   });
 
   mockWindow.open.mockReturnValue({
-    close: () => {}
+    close: () => {},
+    location: {
+      href: ''
+    }
   });
 };
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -268,7 +268,7 @@ describe('utils', () => {
               jest.runAllTimers();
             }, 10);
             jest.useFakeTimers();
-            await expect(runPopup(url, { popup })).rejects.toMatchObject(
+            await expect(runPopup({ popup })).rejects.toMatchObject(
               TIMEOUT_ERROR
             );
             jest.useRealTimers();
@@ -287,7 +287,7 @@ describe('utils', () => {
 
       const { popup, url } = setup(message);
 
-      await expect(runPopup(url, { popup })).resolves.toMatchObject(
+      await expect(runPopup({ popup })).resolves.toMatchObject(
         message.data.response
       );
 
@@ -308,7 +308,7 @@ describe('utils', () => {
 
       const { popup, url } = setup(message);
 
-      await expect(runPopup(url, { popup })).rejects.toMatchObject({
+      await expect(runPopup({ popup })).rejects.toMatchObject({
         ...message.data.response,
         message: 'error_description'
       });
@@ -334,7 +334,7 @@ describe('utils', () => {
       jest.useFakeTimers();
 
       await expect(
-        runPopup(url, {
+        runPopup({
           timeoutInSeconds: seconds,
           popup
         })
@@ -357,34 +357,9 @@ describe('utils', () => {
 
       jest.useFakeTimers();
 
-      await expect(runPopup(url, { popup })).rejects.toMatchObject(
-        TIMEOUT_ERROR
-      );
+      await expect(runPopup({ popup })).rejects.toMatchObject(TIMEOUT_ERROR);
 
       jest.useRealTimers();
-    });
-
-    it('creates and uses a popup window if none was given', async () => {
-      const message = {
-        data: {
-          type: 'authorization_response',
-          response: { id_token: 'id_token' }
-        }
-      };
-
-      const { popup, url } = setup(message);
-      const oldOpenFn = window.open;
-
-      window.open = <any>jest.fn(() => popup);
-
-      await expect(runPopup(url, {})).resolves.toMatchObject(
-        message.data.response
-      );
-
-      expect(popup.location.href).toBe(url);
-      expect(popup.close).toHaveBeenCalled();
-
-      window.open = oldOpenFn;
     });
   });
   describe('runIframe', () => {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -9,7 +9,8 @@ import {
   runIframe,
   sha256,
   bufferToBase64UrlEncoded,
-  validateCrypto
+  validateCrypto,
+  openPopup
 } from './utils';
 
 import { oauthToken, TokenEndpointResponse } from './api';
@@ -338,6 +339,16 @@ export default class Auth0Client {
     options: PopupLoginOptions = {},
     config: PopupConfigOptions = {}
   ) {
+    let popup = config.popup;
+
+    if (!popup) {
+      popup = openPopup('');
+    }
+
+    if (!popup) {
+      throw new Error('Could not open popup');
+    }
+
     const { ...authorizeOptions } = options;
     const stateIn = encode(createRandomString());
     const nonceIn = encode(createRandomString());
@@ -358,13 +369,18 @@ export default class Auth0Client {
       response_mode: 'web_message'
     });
 
-    const codeResult = await runPopup(url, {
-      ...config,
-      timeoutInSeconds:
-        config.timeoutInSeconds ||
-        this.options.authorizeTimeoutInSeconds ||
-        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
-    });
+    popup.location.href = url;
+
+    const codeResult = await runPopup(
+      {
+        ...config,
+        timeoutInSeconds:
+          config.timeoutInSeconds ||
+          this.options.authorizeTimeoutInSeconds ||
+          DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
+      },
+      popup
+    );
 
     if (stateIn !== codeResult.state) {
       throw new Error('Invalid state');
@@ -420,7 +436,7 @@ export default class Auth0Client {
    * (the SDK stores a corresponding ID Token with every Access Token, and uses the
    * scope and audience to look up the ID Token)
    *
-   * @typeparam TUser The type to return, has to extend {@link User}. 
+   * @typeparam TUser The type to return, has to extend {@link User}.
    * @param options
    */
   public async getUser<TUser extends User>(
@@ -453,7 +469,9 @@ export default class Auth0Client {
    *
    * @param options
    */
-  public async getIdTokenClaims(options: GetIdTokenClaimsOptions = {}): Promise<IdToken> {
+  public async getIdTokenClaims(
+    options: GetIdTokenClaimsOptions = {}
+  ): Promise<IdToken> {
     const audience = options.audience || this.options.audience || 'default';
     const scope = getUniqueScopes(this.defaultScope, this.scope, options.scope);
 
@@ -829,8 +847,8 @@ export default class Auth0Client {
       nonceIn,
       code_challenge,
       options.redirect_uri ||
-      this.options.redirect_uri ||
-      window.location.origin
+        this.options.redirect_uri ||
+        window.location.origin
     );
 
     const url = this._authorizeUrl({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -342,14 +342,8 @@ export default class Auth0Client {
     options = options || {};
     config = config || {};
 
-    let popup = config.popup;
-
-    if (!popup) {
-      popup = openPopup('');
-    }
-
-    if (!popup) {
-      throw new Error('Could not open popup');
+    if (!config.popup) {
+      config.popup = openPopup('');
     }
 
     const { ...authorizeOptions } = options;
@@ -372,18 +366,15 @@ export default class Auth0Client {
       response_mode: 'web_message'
     });
 
-    popup.location.href = url;
+    config.popup.location.href = url;
 
-    const codeResult = await runPopup(
-      {
-        ...config,
-        timeoutInSeconds:
-          config.timeoutInSeconds ||
-          this.options.authorizeTimeoutInSeconds ||
-          DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
-      },
-      popup
-    );
+    const codeResult = await runPopup({
+      ...config,
+      timeoutInSeconds:
+        config.timeoutInSeconds ||
+        this.options.authorizeTimeoutInSeconds ||
+        DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS
+    });
 
     if (stateIn !== codeResult.state) {
       throw new Error('Invalid state');

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -336,9 +336,12 @@ export default class Auth0Client {
    * @param config
    */
   public async loginWithPopup(
-    options: PopupLoginOptions = {},
-    config: PopupConfigOptions = {}
+    options?: PopupLoginOptions,
+    config?: PopupConfigOptions
   ) {
+    options = options || {};
+    config = config || {};
+
     let popup = config.popup;
 
     if (!popup) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,12 +93,12 @@ export const openPopup = (url: string) => {
   );
 };
 
-export const runPopup = (config: PopupConfigOptions, popup: any) => {
+export const runPopup = (config: PopupConfigOptions) => {
   return new Promise<AuthenticationResult>((resolve, reject) => {
     let popupEventListener: EventListenerOrEventListenerObject;
 
     const timeoutId = setTimeout(() => {
-      reject(new PopupTimeoutError(popup));
+      reject(new PopupTimeoutError(config.popup));
       window.removeEventListener('message', popupEventListener, false);
     }, (config.timeoutInSeconds || DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS) * 1000);
 
@@ -109,7 +109,7 @@ export const runPopup = (config: PopupConfigOptions, popup: any) => {
 
       clearTimeout(timeoutId);
       window.removeEventListener('message', popupEventListener, false);
-      popup.close();
+      config.popup.close();
 
       if (e.data.response.error) {
         return reject(GenericError.fromPayload(e.data.response));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export const runIframe = (
   });
 };
 
-const openPopup = (url: string) => {
+export const openPopup = (url: string) => {
   const width = 400;
   const height = 600;
   const left = window.screenX + (window.innerWidth - width) / 2;
@@ -93,19 +93,7 @@ const openPopup = (url: string) => {
   );
 };
 
-export const runPopup = (authorizeUrl: string, config: PopupConfigOptions) => {
-  let popup = config.popup;
-
-  if (popup) {
-    popup.location.href = authorizeUrl;
-  } else {
-    popup = openPopup(authorizeUrl);
-  }
-
-  if (!popup) {
-    throw new Error('Could not open popup');
-  }
-
+export const runPopup = (config: PopupConfigOptions, popup: any) => {
   return new Promise<AuthenticationResult>((resolve, reject) => {
     let popupEventListener: EventListenerOrEventListenerObject;
 


### PR DESCRIPTION
This PR moves the creation of the popup window in `loginWithPopup` outside of an async context, so that browsers like Firefox and Safari don't attempt to block the popup as it will now come directly from a user interaction event.

It achieves this by moving popup creation into `loginWithPopup` itself instead of inside `runPopup`.

This PR also fixes an issue where calling `loginWithPopup(null)` would cause the method to crash when it tried to access `options.organization`. It does this by making the parameters optional, instead of providing default values (which are now assigned inside the method).

Fixes #726
Fixes #728
