### PR TITLE
Use more info needed instead of waiting for customer

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,7 @@ daysUntilClose: 7
 
 # Only issues or pull requests with all of these labels are considered by StaleBot. Defaults to `[]` (disabled)
 onlyLabels:
-  - 'waiting for customer'
+  - 'more info needed'
 
 # Ignore issues in projects
 exemptProjects: true


### PR DESCRIPTION
This repo has no `waiting for customer` label