### PR TITLE
Update circle tests to use latest available cypress image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 parameters:
   docker_image:
     type: string
-    default: cypress/browsers:node14.7.0-chrome84
+    default: cypress/browsers:node14.16.0-chrome90-ff88
 jobs:
   build:
     docker:


### PR DESCRIPTION
As our integration tests now install Angular 12, we need to use Node > 14.15.0, so I upgraded to the latest available cypress image