### PR TITLE
Upgrade Node version for Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   }
 
   tools {
-    nodejs '14.16.0'
+    nodejs '14.16.1'
   }
 
   options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   }
 
   tools {
-    nodejs '12.9.1'
+    nodejs '14.16.0'
   }
 
   options {

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -7,7 +7,11 @@ policy.add(
   new Prompt(
     { name: 'noop', requestable: false },
     new Check('foo', 'bar', ctx => {
-      if (ctx.query?.scope?.includes('offline_access')) {
+      if (
+        ctx.query &&
+        ctx.query.scope &&
+        ctx.query.scope.includes('offline_access')
+      ) {
         ctx.oidc.params.scope = `${ctx.oidc.params.scope} offline_access`;
       }
       return Check.NO_NEED_TO_PROMPT;

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -7,11 +7,7 @@ policy.add(
   new Prompt(
     { name: 'noop', requestable: false },
     new Check('foo', 'bar', ctx => {
-      if (
-        ctx.query &&
-        ctx.query.scope &&
-        ctx.query.scope.includes('offline_access')
-      ) {
+      if (ctx.query?.scope?.includes('offline_access')) {
         ctx.oidc.params.scope = `${ctx.oidc.params.scope} offline_access`;
       }
       return Check.NO_NEED_TO_PROMPT;


### PR DESCRIPTION
Avoid optional chaining as our Jenkins still uses node 12.