### PR TITLE
Use correct context for BrowserStack in Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,8 @@ workflows:
       - browserstack:
           requires:
             - build
+          context:
+            - browserstack-env
       - test_gatsby:
           requires:
             - build

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -43,7 +43,7 @@ npm run test:watch
 
 ### Integration tests
 
-Integration tests can be run through [Cypress](https://www.cypress.io/) to perform integration testing using the SDK and Auth0. You will need to supply the password for the user used in the integration tests using an environment variable.
+Integration tests can be run through [Cypress](https://www.cypress.io/) to perform integration testing using the SDK and Auth0.
 
 To run these, use:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,13 +48,13 @@ Integration tests can be run through [Cypress](https://www.cypress.io/) to perfo
 To run these, use:
 
 ```
-CYPRESS_INTEGRATION_PASSWORD=<password> npm run test:integration
+npm run test:integration
 ```
 
 To perform these tests interactively and watch the output, use:
 
 ```
-CYPRESS_INTEGRATION_PASSWORD=<password> npm run test:watch:integration
+npm run test:watch:integration
 ```
 
 ### Test coverage


### PR DESCRIPTION
Currently in our build we rely on environment variables that are part of the project. This PR updates the Circle config to use a predefined org-level context with the correct credentials in it.

Also fixed the readme for running integration tests locally.
