### PR TITLE
Automatically publish package to NPM on version change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   # @dev:d1b8cd7 - this release will dissappear in ~3 months
-  ship: lbalmaceda/node-publisher@dev:e838acf
+  ship: lbalmaceda/node-publisher@dev:18698a7
 parameters:
   docker_image:
     type: string
@@ -197,6 +197,7 @@ workflows:
       - ship/node-publish:
           context:
             - publish-npm
+            - publish-gh
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  # @dev:d1b8cd7 - this release will dissappear in ~3 months
+  # @dev:18698a7 - this release will dissappear in ~3 months
   ship: lbalmaceda/node-publisher@dev:18698a7
 parameters:
   docker_image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  # @dev:d1b8cd7 - this release will dissappear in ~3 months
+  auth0-publisher: lbalmaceda/node-publisher@dev:d1b8cd7
 parameters:
   docker_image:
     type: string
@@ -191,3 +194,16 @@ workflows:
       - test_angular:
           requires:
             - build
+      - auth0-publisher/publish:
+          context:
+            - publish-npm
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - browserstack
+            - test_gatsby
+            - test_react
+            - test_vue
+            - test_angular

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
-  # @dev:18698a7 - this release will dissappear in ~3 months
-  ship: lbalmaceda/node-publisher@dev:18698a7
+  ship: auth0/ship@0.1.0
 parameters:
   docker_image:
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   # @dev:d1b8cd7 - this release will dissappear in ~3 months
-  auth0-publisher: lbalmaceda/node-publisher@dev:d1b8cd7
+  ship: lbalmaceda/node-publisher@dev:e838acf
 parameters:
   docker_image:
     type: string
@@ -194,7 +194,7 @@ workflows:
       - test_angular:
           requires:
             - build
-      - auth0-publisher/publish:
+      - ship/node-publish:
           context:
             - publish-npm
           filters:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "serve:coverage": "serve coverage/lcov-report -n",
     "serve:stats": "serve bundle-stats -n",
     "print-bundle-size": "node ./scripts/print-bundle-size",
-    "prepack": "npm run build && npm run test && node ./scripts/prepack",
+    "prepack": "npm run build && node ./scripts/prepack",
     "release": "node ./scripts/release",
     "release:clean": "node ./scripts/cleanup",
     "publish:cdn": "ccu --trace"


### PR DESCRIPTION

### Description

This PR adds the usage of an experimental orb (currently in development) that will take care of publishing a new release to npm if the version changes. If the npm token is not available, the job will fail with missing authentication.

The job only runs when the merge commit comes from selected Auth0 members and is performed against the default branch.


### References
See `SDK-2726`

### Testing

Local run:
![image](https://user-images.githubusercontent.com/3900123/129894129-b0bb9814-2da3-4566-8e4c-9501f2e844e6.png)


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
