### PR TITLE
remove jest.runOnlyPendingTimers

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -336,7 +336,6 @@ describe('utils', () => {
        * then rolling back to real timers
        */
       setTimeout(() => {
-        jest.runOnlyPendingTimers();
         jest.advanceTimersByTime(seconds * 1000);
       }, 10);
 
@@ -361,7 +360,6 @@ describe('utils', () => {
        * then rolling back to real timers
        */
       setTimeout(() => {
-        jest.runOnlyPendingTimers();
         jest.advanceTimersByTime(DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS * 1000);
       }, 10);
 
@@ -383,7 +381,6 @@ describe('utils', () => {
        * then rolling back to real timers
        */
       setTimeout(() => {
-        jest.runOnlyPendingTimers();
         jest.advanceTimersByTime(DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS * 1000);
       }, 10);
 


### PR DESCRIPTION
This PR is a small test correction of the utils test file.

`jest.advanceTimersByTime` should be enough and the correct way to test that the Popup timed out after x seconds, successfully.

By using `jest.runOnlyPendingTimers` in conjunction with `jest.advanceTimersByTime` this would always be truthy even if the timer advance is below `config.timeoutInSeconds`.

If you run `jest.runOnlyPendingTimers()` it will not take into account `jest.advanceTimersByTime`, since `jest.runOnlyPendingTimers` executes all macro-tasks that are currently pending. So remove it and just advance the timers by x seconds.

## Showcase

Before, it will succeed (even if we advance only for 5 secs): 
```
const seconds = 10;
const advanceInSeconds = 5;
setTimeout(() => {
    jest.runOnlyPendingTimers();
     jest.advanceTimersByTime(advanceInSeconds * 1000);
 }, 10);
```

After, it will correctly fail, since it will timeout 5 secs later.
```
const seconds = 10;
const advanceInSeconds = 5;
setTimeout(() => {
     jest.advanceTimersByTime(advanceInSeconds * 1000);
 }, 10);
```

Correct way: Test that the timeout happens exactly after `seconds` seconds.
If `advanceInSeconds === seconds`  the tests pass.
