### PR TITLE
[SDK-2692] Remember organization ID for silent authentication

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1381,6 +1381,29 @@ describe('Auth0Client', () => {
       );
     });
 
+    it('stores the org_id in a hint cookie if returned in the ID token claims', async () => {
+      const auth0 = setup({}, { org_id: TEST_ORG_ID });
+
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+
+      await getTokenSilently(auth0);
+
+      expect(esCookie.set).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`,
+        JSON.stringify(TEST_ORG_ID),
+        {}
+      );
+
+      expect(esCookie.set).toHaveBeenCalledWith(
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+        JSON.stringify(TEST_ORG_ID),
+        {}
+      );
+    });
+
     it('removes organization hint cookie if no org claim was returned in the ID token', async () => {
       const auth0 = setup({});
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -10,7 +10,11 @@ import * as api from '../../src/api';
 
 import { expectToHaveBeenCalledWithAuth0ClientParam } from '../helpers';
 
-import { GET_TOKEN_SILENTLY_LOCK_KEY, TEST_AUDIENCE } from '../constants';
+import {
+  GET_TOKEN_SILENTLY_LOCK_KEY,
+  TEST_AUDIENCE,
+  TEST_ORG_ID
+} from '../constants';
 
 // @ts-ignore
 import { acquireLockSpy } from 'browser-tabs-lock';
@@ -1376,6 +1380,31 @@ describe('Auth0Client', () => {
         }
       );
     });
+
+    // it('removes organization hint cookie if no org claim was returned in the ID token', async () => {
+    //   const auth0 = setup({ organization: TEST_CLIENT_ID });
+
+    //   jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+    //     access_token: TEST_ACCESS_TOKEN,
+    //     state: TEST_STATE
+    //   });
+
+    //   await getTokenSilently(auth0);
+
+    //   expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+    //     `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+    //     TEST_ORG_ID,
+    //     {
+    //     }
+    //   );
+
+    //   expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+    //     `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+    //     TEST_ORG_ID,
+    //     {
+    //     }
+    //   );
+    // });
 
     it('opens iframe with correct urls and timeout from client options', async () => {
       const auth0 = setup({ authorizeTimeoutInSeconds: 1 });

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1381,30 +1381,20 @@ describe('Auth0Client', () => {
       );
     });
 
-    // it('removes organization hint cookie if no org claim was returned in the ID token', async () => {
-    //   const auth0 = setup({ organization: TEST_CLIENT_ID });
+    it('removes organization hint cookie if no org claim was returned in the ID token', async () => {
+      const auth0 = setup({});
 
-    //   jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
-    //     access_token: TEST_ACCESS_TOKEN,
-    //     state: TEST_STATE
-    //   });
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
 
-    //   await getTokenSilently(auth0);
+      await getTokenSilently(auth0);
 
-    //   expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-    //     `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
-    //     TEST_ORG_ID,
-    //     {
-    //     }
-    //   );
-
-    //   expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-    //     `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
-    //     TEST_ORG_ID,
-    //     {
-    //     }
-    //   );
-    // });
+      expect(esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`
+      );
+    });
 
     it('opens iframe with correct urls and timeout from client options', async () => {
       const auth0 = setup({ authorizeTimeoutInSeconds: 1 });

--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -150,7 +150,9 @@ export const loginWithRedirectFn = (mockWindow, mockFetch) => {
       customCallbackUrl
     } = processDefaultLoginWithRedirectOptions(testConfig);
     await auth0.loginWithRedirect(options);
+
     const redirectMethod = options?.redirectMethod || 'assign';
+
     expect(mockWindow.location[redirectMethod]).toHaveBeenCalled();
 
     if (error && errorDescription) {

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -597,7 +597,7 @@ describe('Auth0Client', () => {
     });
 
     it('saves organization hint cookie in storage', async () => {
-      const auth0 = setup({ organization: TEST_ORG_ID });
+      const auth0 = setup({}, { org_id: TEST_ORG_ID });
 
       await loginWithPopup(auth0);
 

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -23,6 +23,7 @@ import {
   TEST_DOMAIN,
   TEST_ID_TOKEN,
   TEST_NONCE,
+  TEST_ORG_ID,
   TEST_REDIRECT_URI,
   TEST_REFRESH_TOKEN,
   TEST_SCOPES,
@@ -592,6 +593,24 @@ describe('Auth0Client', () => {
         {
           expires: 1
         }
+      );
+    });
+
+    it('saves organization hint cookie in storage', async () => {
+      const auth0 = setup({ organization: TEST_ORG_ID });
+
+      await loginWithPopup(auth0);
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+        TEST_ORG_ID,
+        {}
+      );
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`,
+        TEST_ORG_ID,
+        {}
       );
     });
 

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -614,6 +614,20 @@ describe('Auth0Client', () => {
       );
     });
 
+    it('removes the organization hint cookie if no org_id claim was returned in the ID token', async () => {
+      const auth0 = setup();
+
+      await loginWithPopup(auth0);
+
+      expect(<jest.Mock>esCookie.remove).toHaveBeenCalledWith(
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`
+      );
+
+      expect(<jest.Mock>esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`
+      );
+    });
+
     it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
       const auth0 = setup({
         sessionCheckExpiryDays: 2

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -603,13 +603,13 @@ describe('Auth0Client', () => {
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
-        TEST_ORG_ID,
+        JSON.stringify(TEST_ORG_ID),
         {}
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `auth0.${TEST_CLIENT_ID}.organization_hint`,
-        TEST_ORG_ID,
+        JSON.stringify(TEST_ORG_ID),
         {}
       );
     });

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -347,7 +347,7 @@ describe('Auth0Client', () => {
     });
 
     it('stores the organization ID in a hint cookie', async () => {
-      const auth0 = setup({ organization: TEST_ORG_ID });
+      const auth0 = setup({}, { org_id: TEST_ORG_ID });
 
       await loginWithRedirect(auth0);
 
@@ -361,6 +361,20 @@ describe('Auth0Client', () => {
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
         TEST_ORG_ID,
         {}
+      );
+    });
+
+    it('removes the org hint cookie if no org_id claim in the ID token', async () => {
+      const auth0 = setup({});
+
+      await loginWithRedirect(auth0);
+
+      expect(<jest.Mock>esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`
+      );
+
+      expect(<jest.Mock>esCookie.remove).toHaveBeenCalledWith(
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`
       );
     });
 

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -345,6 +345,24 @@ describe('Auth0Client', () => {
       );
     });
 
+    it('stores the organization ID in a hint cookie', async () => {
+      const auth0 = setup({ organization: 'test_org_123' });
+
+      await loginWithRedirect(auth0);
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`,
+        'test_org_123',
+        {}
+      );
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+        'test_org_123',
+        {}
+      );
+    });
+
     it('calls `tokenVerifier.verify` with the specific organization id', async () => {
       const auth0 = setup({ organization: 'test_org_123' });
 

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -353,13 +353,13 @@ describe('Auth0Client', () => {
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `auth0.${TEST_CLIENT_ID}.organization_hint`,
-        TEST_ORG_ID,
+        JSON.stringify(TEST_ORG_ID),
         {}
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
-        TEST_ORG_ID,
+        JSON.stringify(TEST_ORG_ID),
         {}
       );
     });

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -29,6 +29,7 @@ import {
   TEST_DOMAIN,
   TEST_ID_TOKEN,
   TEST_NONCE,
+  TEST_ORG_ID,
   TEST_REDIRECT_URI,
   TEST_SCOPES,
   TEST_STATE
@@ -346,19 +347,19 @@ describe('Auth0Client', () => {
     });
 
     it('stores the organization ID in a hint cookie', async () => {
-      const auth0 = setup({ organization: 'test_org_123' });
+      const auth0 = setup({ organization: TEST_ORG_ID });
 
       await loginWithRedirect(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `auth0.${TEST_CLIENT_ID}.organization_hint`,
-        'test_org_123',
+        TEST_ORG_ID,
         {}
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
-        'test_org_123',
+        TEST_ORG_ID,
         {}
       );
     });

--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -83,6 +83,15 @@ describe('Auth0Client', () => {
       expect(esCookie.remove).toHaveBeenCalledWith('auth0.is.authenticated');
     });
 
+    it('removes the organization hint cookie from storage', async () => {
+      const auth0 = setup();
+      auth0.logout();
+
+      expect(esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`
+      );
+    });
+
     it('calls `window.location.assign` with the correct url', async () => {
       const auth0 = setup();
 
@@ -132,6 +141,16 @@ describe('Auth0Client', () => {
       auth0.logout({ localOnly: true });
 
       expect(esCookie.remove).toHaveBeenCalledWith('auth0.is.authenticated');
+    });
+
+    it('removes the organization hint cookie from storage when `options.localOnly` is true', async () => {
+      const auth0 = setup();
+
+      auth0.logout({ localOnly: true });
+
+      expect(esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`
+      );
     });
 
     it('skips `window.location.assign` when `options.localOnly` is true', async () => {

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,4 +1,5 @@
 import * as esCookie from 'es-cookie';
+import { MockedObject } from 'ts-jest/dist/utils/testing';
 import { mocked } from 'ts-jest/utils';
 import { CookieStorage, CookieStorageWithLegacySameSite } from '../src/storage';
 
@@ -10,15 +11,19 @@ describe('CookieStorage', () => {
   beforeEach(() => {
     cookieMock = mocked(esCookie);
   });
+
   it('saves object', () => {
     const key = 'key';
     const value = { some: 'value' };
     const options = { daysUntilExpire: 1 };
+
     CookieStorage.save(key, value, options);
+
     expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {
       expires: options.daysUntilExpire
     });
   });
+
   it('saves object with secure flag and samesite=none when on https', () => {
     const key = 'key';
     const value = { some: 'value' };
@@ -34,6 +39,7 @@ describe('CookieStorage', () => {
     });
     window.location = originalLocation;
   });
+
   it('returns undefined when there is no object', () => {
     const Cookie = cookieMock;
     const key = 'key';
@@ -44,6 +50,7 @@ describe('CookieStorage', () => {
     const outputValue = CookieStorage.get(key);
     expect(outputValue).toBeUndefined();
   });
+
   it('gets object', () => {
     const Cookie = cookieMock;
     const key = 'key';
@@ -55,6 +62,7 @@ describe('CookieStorage', () => {
     const outputValue = CookieStorage.get(key);
     expect(outputValue).toMatchObject(value);
   });
+
   it('removes object', () => {
     const Cookie = cookieMock;
     const key = 'key';
@@ -69,14 +77,18 @@ describe('CookieStorageWithLegacySameSite', () => {
   beforeEach(() => {
     cookieMock = mocked(esCookie);
   });
+
   it('saves object', () => {
     const key = 'key';
     const value = { some: 'value' };
     const options = { daysUntilExpire: 1 };
+
     CookieStorageWithLegacySameSite.save(key, value, options);
+
     expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {
       expires: options.daysUntilExpire
     });
+
     expect(cookieMock.set).toHaveBeenCalledWith(
       `_legacy_${key}`,
       JSON.stringify(value),
@@ -85,19 +97,23 @@ describe('CookieStorageWithLegacySameSite', () => {
       }
     );
   });
+
   it('saves object with secure flag and samesite=none and legacy with no samesite when on https', () => {
     const key = 'key';
     const value = { some: 'value' };
     const options = { daysUntilExpire: 1 };
     const originalLocation = window.location;
+
     delete window.location;
     window.location = { ...originalLocation, protocol: 'https:' };
     CookieStorageWithLegacySameSite.save(key, value, options);
+
     expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {
       expires: options.daysUntilExpire,
       secure: true,
       sameSite: 'none'
     });
+
     expect(cookieMock.set).toHaveBeenCalledWith(
       `_legacy_${key}`,
       JSON.stringify(value),
@@ -106,38 +122,53 @@ describe('CookieStorageWithLegacySameSite', () => {
         secure: true
       }
     );
+
     window.location = originalLocation;
   });
+
   it('returns undefined when there is no object', () => {
     const Cookie = cookieMock;
     const key = 'key';
+
     Cookie.get = k => undefined;
+
     const outputValue = CookieStorageWithLegacySameSite.get(key);
+
     expect(outputValue).toBeUndefined();
   });
+
   it('returns modern samesite cookie when available', () => {
     const Cookie = cookieMock;
     const key = 'key';
+
     Cookie.get = k => {
       if (k === key) return JSON.stringify({ foo: 1 });
       return JSON.stringify({ bar: 2 });
     };
+
     const outputValue = CookieStorageWithLegacySameSite.get(key);
+
     expect(outputValue).toEqual({ foo: 1 });
   });
+
   it('falls back to legacy cookie when modern cookie is unavailable', () => {
     const Cookie = cookieMock;
     const key = 'key';
+
     Cookie.get = k => {
       if (k === key) return false;
       return JSON.stringify({ bar: 2 });
     };
+
     const outputValue = CookieStorageWithLegacySameSite.get(key);
+
     expect(outputValue).toEqual({ bar: 2 });
   });
+
   it('removes objects', () => {
     const Cookie = cookieMock;
     const key = 'key';
+
     CookieStorageWithLegacySameSite.remove(key);
     expect(Cookie.remove).toHaveBeenCalledWith(key);
     expect(Cookie.remove).toHaveBeenCalledWith(`_legacy_${key}`);

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -62,12 +62,12 @@ describe('getTokenSilently', () => {
       it('can get the access token after refreshing the page', () => {
         whenReady();
 
-        cy.toggleSwitch('local-storage');
+        cy.setSwitch('local-storage', true);
         cy.login();
         cy.reload();
         cy.getTokenSilently();
-
         cy.getAccessTokens().should('have.length', 1);
+
         cy.window().then(win => {
           expect(
             win.localStorage.getItem(
@@ -96,9 +96,9 @@ describe('getTokenSilently', () => {
     it('retrieves an access token using a refresh token', () => {
       whenReady();
 
-      cy.toggleSwitch('local-storage');
-      cy.toggleSwitch('use-cache');
-      cy.toggleSwitch('refresh-tokens');
+      cy.setSwitch('local-storage', true);
+      cy.setSwitch('use-cache', false);
+      cy.setSwitch('refresh-tokens', true);
 
       cy.login();
 
@@ -123,9 +123,9 @@ describe('getTokenSilently', () => {
     it('retrieves an access token for another audience using a refresh token', () => {
       whenReady();
 
-      cy.toggleSwitch('local-storage');
-      cy.toggleSwitch('use-cache');
-      cy.toggleSwitch('refresh-tokens');
+      cy.setSwitch('local-storage', true);
+      cy.setSwitch('use-cache', false);
+      cy.setSwitch('refresh-tokens', true);
       cy.login();
 
       cy.intercept({

--- a/cypress/integration/loginWithRedirect.js
+++ b/cypress/integration/loginWithRedirect.js
@@ -22,15 +22,12 @@ describe('loginWithRedirect', function () {
 
   it('can perform the login flow with cookie transactions', () => {
     whenReady();
-
-    cy.toggleSwitch('cookie-txns');
+    cy.setSwitch('cookie-txns', true);
 
     const tomorrowInSeconds = Math.floor(Date.now() / 1000) + 86400;
 
     cy.loginNoCallback();
-
     cy.url().should(url => shouldInclude(url, 'http://127.0.0.1:3000'));
-
     whenReady();
 
     cy.getCookie('a0.spajs.txs')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -51,9 +51,21 @@ Cypress.Commands.add('logout', () => {
   });
 });
 
-Cypress.Commands.add('toggleSwitch', name =>
-  cy.get(`[data-cy=switch-${name}]`).click()
-);
+Cypress.Commands.add('setSwitch', (name, value) => {
+  // Can only use `check` or `uncheck` on an actual checkbox, but the switch
+  // value we're given is for the label. Get the `for` attribute to find the actual
+  // checkbox and return that instead.
+  const checkbox = () =>
+    cy
+      .get(`[data-cy=switch-${name}]`)
+      .then($label => cy.get(`#${$label.attr('for')}`));
+
+  // These are forced because of the way the checkboxes on the playground are rendered
+  // (they're covered by some UI to make them look pretty)
+  !!value === true
+    ? checkbox().check({ force: true })
+    : checkbox().uncheck({ force: true });
+});
 
 Cypress.Commands.add('setScope', scope =>
   cy.get(`[data-cy=scope]`).clear().type(scope)

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -53,7 +53,6 @@ const config = {
     return {
       accountId: id,
       claims(use, scope, claims) {
-        console.log(claims);
         return {
           sub: id,
           ...(claims?.org_id ? { org_id: claims.org_id.values[0] } : null)

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -1,8 +1,8 @@
 import { Provider, interactionPolicy } from 'oidc-provider';
 
 const { base, Prompt, Check } = interactionPolicy;
-
 const policy = base();
+
 policy.add(
   new Prompt(
     { name: 'noop', requestable: false },
@@ -20,11 +20,14 @@ const config = {
   clients: [
     {
       client_id: 'testing',
-      redirect_uris: ['http://127.0.0.1:3000'],
+      redirect_uris: ['http://127.0.0.1:3000', 'http://localhost:3000'],
       token_endpoint_auth_method: 'none',
       grant_types: ['authorization_code', 'refresh_token']
     }
   ],
+  claims: {
+    org_id: null
+  },
   routes: {
     authorization: '/authorize', // lgtm [js/hardcoded-credentials]
     token: '/oauth/token',
@@ -37,11 +40,26 @@ const config = {
   features: {
     webMessageResponseMode: {
       enabled: true
+    },
+    claimsParameter: {
+      enabled: true
     }
   },
   rotateRefreshToken: true,
   interactions: {
     policy
+  },
+  findAccount(ctx, id) {
+    return {
+      accountId: id,
+      claims(use, scope, claims) {
+        console.log(claims);
+        return {
+          sub: id,
+          ...(claims?.org_id ? { org_id: claims.org_id.values[0] } : null)
+        };
+      }
+    };
   }
 };
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -937,6 +937,12 @@ export default class Auth0Client {
         window.location.origin
     );
 
+    const orgIdHint = this.cookieStorage.get<string>(this.orgHintCookieName);
+
+    if (orgIdHint && !params.organization) {
+      params.organization = orgIdHint;
+    }
+
     const url = this._authorizeUrl({
       ...params,
       prompt: 'none',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -340,7 +340,6 @@ export default class Auth0Client {
    *
    * @param options
    */
-
   public async buildAuthorizeUrl(
     options: RedirectLoginOptions = {}
   ): Promise<string> {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -478,6 +478,8 @@ export default class Auth0Client {
         this.orgHintCookieName,
         decodedToken.claims.org_id
       );
+    } else {
+      this.cookieStorage.remove(this.orgHintCookieName);
     }
   }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -467,6 +467,13 @@ export default class Auth0Client {
     this.cookieStorage.save(COOKIE_IS_AUTHENTICATED_HINT, true, {
       daysUntilExpire: this.sessionCheckExpiryDays
     });
+
+    if (organizationId) {
+      this.cookieStorage.save(
+        buildOrganizationHintCookieName(this.options.client_id),
+        organizationId
+      );
+    }
   }
 
   /**

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -38,7 +38,7 @@ export const CookieStorage = {
     }
 
     if (options?.daysUntilExpire) {
-      cookieAttributes.expires = options?.daysUntilExpire;
+      cookieAttributes.expires = options.daysUntilExpire;
     }
 
     Cookies.set(key, JSON.stringify(value), cookieAttributes);
@@ -77,7 +77,7 @@ export const CookieStorageWithLegacySameSite = {
     }
 
     if (options?.daysUntilExpire) {
-      cookieAttributes.expires = options?.daysUntilExpire;
+      cookieAttributes.expires = options.daysUntilExpire;
     }
 
     Cookies.set(
@@ -99,6 +99,7 @@ export const CookieStorageWithLegacySameSite = {
  */
 export const SessionStorage = {
   get<T extends Object>(key: string) {
+    /* istanbul ignore next */
     if (typeof sessionStorage === 'undefined') {
       return;
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -27,14 +27,22 @@ export const CookieStorage = {
 
   save(key: string, value: any, options?: ClientStorageOptions): void {
     let cookieAttributes: Cookies.CookieAttributes = {};
+
     if ('https:' === window.location.protocol) {
       cookieAttributes = {
         secure: true,
         sameSite: 'none'
       };
     }
-    cookieAttributes.expires = options.daysUntilExpire;
-    Cookies.set(key, JSON.stringify(value), cookieAttributes);
+
+    if (options?.daysUntilExpire) {
+      cookieAttributes.expires = options?.daysUntilExpire;
+    }
+
+    const serialized =
+      typeof value === 'string' ? value : JSON.stringify(value);
+
+    Cookies.set(key, serialized, cookieAttributes);
   },
 
   remove(key: string) {
@@ -62,15 +70,20 @@ export const CookieStorageWithLegacySameSite = {
 
   save(key: string, value: any, options?: ClientStorageOptions): void {
     let cookieAttributes: Cookies.CookieAttributes = {};
+
     if ('https:' === window.location.protocol) {
       cookieAttributes = { secure: true };
     }
-    cookieAttributes.expires = options.daysUntilExpire;
-    Cookies.set(
-      `${LEGACY_PREFIX}${key}`,
-      JSON.stringify(value),
-      cookieAttributes
-    );
+
+    if (options?.daysUntilExpire) {
+      cookieAttributes.expires = options?.daysUntilExpire;
+    }
+
+    const serialized =
+      typeof value === 'string' ? value : JSON.stringify(value);
+
+    Cookies.set(`${LEGACY_PREFIX}${key}`, serialized, cookieAttributes);
+
     CookieStorage.save(key, value, options);
   },
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -19,9 +19,11 @@ export type ClientStorage = {
 export const CookieStorage = {
   get<T extends Object>(key: string) {
     const value = Cookies.get(key);
+
     if (typeof value === 'undefined') {
       return;
     }
+
     return <T>JSON.parse(value);
   },
 
@@ -39,10 +41,7 @@ export const CookieStorage = {
       cookieAttributes.expires = options?.daysUntilExpire;
     }
 
-    const serialized =
-      typeof value === 'string' ? value : JSON.stringify(value);
-
-    Cookies.set(key, serialized, cookieAttributes);
+    Cookies.set(key, JSON.stringify(value), cookieAttributes);
   },
 
   remove(key: string) {
@@ -61,11 +60,13 @@ const LEGACY_PREFIX = '_legacy_';
  */
 export const CookieStorageWithLegacySameSite = {
   get<T extends Object>(key: string) {
-    const value = CookieStorage.get(key);
+    const value = CookieStorage.get<T>(key);
+
     if (value) {
       return value;
     }
-    return CookieStorage.get(`${LEGACY_PREFIX}${key}`);
+
+    return CookieStorage.get<T>(`${LEGACY_PREFIX}${key}`);
   },
 
   save(key: string, value: any, options?: ClientStorageOptions): void {
@@ -79,11 +80,11 @@ export const CookieStorageWithLegacySameSite = {
       cookieAttributes.expires = options?.daysUntilExpire;
     }
 
-    const serialized =
-      typeof value === 'string' ? value : JSON.stringify(value);
-
-    Cookies.set(`${LEGACY_PREFIX}${key}`, serialized, cookieAttributes);
-
+    Cookies.set(
+      `${LEGACY_PREFIX}${key}`,
+      JSON.stringify(value),
+      cookieAttributes
+    );
     CookieStorage.save(key, value, options);
   },
 
@@ -101,10 +102,13 @@ export const SessionStorage = {
     if (typeof sessionStorage === 'undefined') {
       return;
     }
+
     const value = sessionStorage.getItem(key);
+
     if (typeof value === 'undefined') {
       return;
     }
+
     return <T>JSON.parse(value);
   },
 

--- a/static/index.html
+++ b/static/index.html
@@ -676,11 +676,11 @@
                 ignoreCache: !_self.useCache
               })
               .then(function (token) {
+                access_tokens.push(token);
                 _self.error = null;
 
                 auth0.isAuthenticated().then(function (isAuthenticated) {
                   _self.isAuthenticated = isAuthenticated;
-                  _self.showAuth0Info();
                 });
               })
               .catch(function (e) {

--- a/static/index.html
+++ b/static/index.html
@@ -224,6 +224,17 @@
             class="form-control"
             id="organization"
           />
+          <div class="form-check mt-3">
+            <input
+              type="checkbox"
+              class="form-check-input"
+              id="org-login-check"
+              v-model="useOrgAtLogin"
+            />
+            <label for="org-login-check" class="form-check-label"
+              >Apply only at loginWithRedirect</label
+            >
+          </div>
         </div>
 
         <div class="btn-group mb-5">
@@ -350,6 +361,12 @@
               >
             </div>
           </div>
+
+          <div class="col-md-12">
+            <h3 class="mb-3">Client Options</h3>
+
+            <pre><code>{{ clientOptions }}</code></pre>
+          </div>
         </div>
       </form>
     </div>
@@ -410,6 +427,8 @@
             audience: data.audience || defaultAudience,
             organization: data.organization || defaultOrganization,
             useFormData: data.useFormData || false,
+            useOrgAtLogin: data.useOrgAtLogin || false,
+            clientOptions: '',
             audienceScopes: [
               {
                 audience: data.audience || defaultAudience,
@@ -487,13 +506,15 @@
               clientOptions.audience = _self.audience;
             }
 
-            if (_self.organization) {
+            if (_self.organization && !_self.useOrgAtLogin) {
               clientOptions.organization = _self.organization;
             }
 
             if (_self.useCustomStorage) {
               clientOptions.cache = sessionStorageCache;
             }
+
+            _self.clientOptions = JSON.stringify(clientOptions, null, 2);
 
             var _init = function (auth0) {
               _self.auth0 = auth0;
@@ -527,7 +548,8 @@
                 useCache: this.useCache,
                 audience: this.audience,
                 organization: this.organization,
-                useFormData: this.useFormData
+                useFormData: this.useFormData,
+                useOrgAtLogin: this.useOrgAtLogin
               })
             );
 
@@ -545,6 +567,7 @@
             this.useCookiesForTransactions = false;
             this.organization = defaultOrganization;
             this.useFormData = false;
+            this.useOrgAtLogin = false;
             this.saveForm();
           },
           showAuth0Info: function () {
@@ -587,6 +610,7 @@
               .then(function () {
                 return auth0.isAuthenticated().then(function (isAuthenticated) {
                   _self.isAuthenticated = isAuthenticated;
+                  _self.showAuth0Info();
                 });
               })
               .catch(function (e) {
@@ -620,7 +644,7 @@
             var _self = this;
             var options = { scope: _self.audienceScopes[0].scope };
 
-            if (_self.organization) {
+            if (_self.organization && _self.useOrgAtLogin) {
               options.organization = _self.organization;
             }
 
@@ -652,11 +676,11 @@
                 ignoreCache: !_self.useCache
               })
               .then(function (token) {
-                access_tokens.push(token);
                 _self.error = null;
 
                 auth0.isAuthenticated().then(function (isAuthenticated) {
                   _self.isAuthenticated = isAuthenticated;
+                  _self.showAuth0Info();
                 });
               })
               .catch(function (e) {

--- a/static/index.html
+++ b/static/index.html
@@ -523,6 +523,16 @@
 
             _self.clientOptions = JSON.stringify(clientOptions, null, 2);
 
+            if (_self.organization) {
+              const claims = {
+                id_token: {
+                  org_id: { values: [_self.organization] }
+                }
+              };
+
+              clientOptions.claims = JSON.stringify(claims);
+            }
+
             var _init = function (auth0) {
               _self.auth0 = auth0;
               window.auth0 = auth0; // Cypress integration tests support

--- a/static/index.html
+++ b/static/index.html
@@ -665,14 +665,6 @@
               if (_self.useOrgAtLogin) {
                 options.organization = _self.organization;
               }
-
-              const claims = {
-                id_token: {
-                  org_id: { values: [_self.organization] }
-                }
-              };
-
-              options.claims = JSON.stringify(claims);
             }
 
             this.auth0.loginWithRedirect(options);

--- a/static/index.html
+++ b/static/index.html
@@ -223,6 +223,7 @@
             v-model="organization"
             class="form-control"
             id="organization"
+            data-cy="organizationId"
           />
           <div class="form-check mt-3">
             <input
@@ -230,6 +231,7 @@
               class="form-check-input"
               id="org-login-check"
               v-model="useOrgAtLogin"
+              data-cy="useOrgAtLogin"
             />
             <label for="org-login-check" class="form-check-label"
               >Apply only at loginWithRedirect</label
@@ -238,7 +240,12 @@
         </div>
 
         <div class="btn-group mb-5">
-          <button @click="saveForm" class="btn btn-primary" id="save-config">
+          <button
+            @click="saveForm"
+            class="btn btn-primary"
+            id="save-config"
+            data-cy="saveSettings"
+          >
             Save
           </button>
 
@@ -644,8 +651,18 @@
             var _self = this;
             var options = { scope: _self.audienceScopes[0].scope };
 
-            if (_self.organization && _self.useOrgAtLogin) {
-              options.organization = _self.organization;
+            if (_self.organization) {
+              if (_self.useOrgAtLogin) {
+                options.organization = _self.organization;
+              }
+
+              const claims = {
+                id_token: {
+                  org_id: { values: [_self.organization] }
+                }
+              };
+
+              options.claims = JSON.stringify(claims);
             }
 
             this.auth0.loginWithRedirect(options);


### PR DESCRIPTION
Key changes:

* If an `org_id` claim is returned in the ID token, the SDK stores it in a new cookie to act as a "hint" for silent authentication
* When doing `getTokenSilently` with iframe + `prompt=none`, if the hint cookie is available and no value for `organization` was given in the options, the value from the cookie is read and sent to the authorization request
* If the hint cookie is available and `organization` is present in the options, the options value takes precedence
* The cookie is removed on logout
* The cookie is removed if there is no `org_id` claim in the ID token

I also evolved the playground a bit so that you can toggle the organization ID being passed through constructor options or directly to `loginWithRedirect`. I also added JSON output at the bottom so that the options being used to initialize the SDK are visible.
