### PR TITLE
[SDK-2759] Re-scoping cookies and transactions to client ID

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "args": ["${fileBasenameNoExtension}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true
+      "disableOptimisticBPs": true,
+      "skipFiles": ["<node_internals>/**"]
     },
     {
       "type": "node",
@@ -22,7 +23,8 @@
       "args": ["--runInBand"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true
+      "disableOptimisticBPs": true,
+      "skipFiles": ["<node_internals>/**"]
     },
     {
       "type": "node",

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1337,7 +1337,7 @@ describe('Auth0Client', () => {
       await getTokenSilently(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        '_legacy_auth0.is.authenticated',
+        `_legacy_auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 1
@@ -1345,7 +1345,7 @@ describe('Auth0Client', () => {
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        'auth0.is.authenticated',
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 1
@@ -1366,14 +1366,15 @@ describe('Auth0Client', () => {
       await getTokenSilently(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        '_legacy_auth0.is.authenticated',
+        `_legacy_auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 2
         }
       );
+
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        'auth0.is.authenticated',
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 2

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -580,7 +580,7 @@ describe('Auth0Client', () => {
       await loginWithPopup(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        '_legacy_auth0.is.authenticated',
+        `_legacy_auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 1
@@ -588,7 +588,7 @@ describe('Auth0Client', () => {
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        'auth0.is.authenticated',
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 1
@@ -636,14 +636,14 @@ describe('Auth0Client', () => {
       await loginWithPopup(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        '_legacy_auth0.is.authenticated',
+        `_legacy_auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 2
         }
       );
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        'auth0.is.authenticated',
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 2

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -290,7 +290,7 @@ describe('Auth0Client', () => {
       await auth0.loginWithRedirect();
 
       expect((sessionStorage.setItem as jest.Mock).mock.calls[0][0]).toBe(
-        'a0.spajs.txs'
+        `a0.spajs.txs.${TEST_CLIENT_ID}`
       );
     });
 
@@ -302,7 +302,7 @@ describe('Auth0Client', () => {
       // Don't necessarily need to check the contents of the cookie (the storage tests are doing that),
       // just that cookies were used when I set the correct option.
       expect((mockCookies.set as jest.Mock).mock.calls[1][0]).toEqual(
-        'a0.spajs.txs'
+        `a0.spajs.txs.${TEST_CLIENT_ID}`
       );
     });
 

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -415,7 +415,7 @@ describe('Auth0Client', () => {
       await loginWithRedirect(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        '_legacy_auth0.is.authenticated',
+        `_legacy_auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 1
@@ -423,7 +423,7 @@ describe('Auth0Client', () => {
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        'auth0.is.authenticated',
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 1
@@ -431,7 +431,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('saves `auth0.is.authenticated` key in storage for an extended period', async () => {
+    it('saves authenticated cookie key in storage for an extended period', async () => {
       const auth0 = setup({
         sessionCheckExpiryDays: 2
       });
@@ -439,14 +439,14 @@ describe('Auth0Client', () => {
       await loginWithRedirect(auth0);
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        '_legacy_auth0.is.authenticated',
+        `_legacy_auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 2
         }
       );
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
-        'auth0.is.authenticated',
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`,
         'true',
         {
           expires: 2

--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -72,11 +72,13 @@ describe('Auth0Client', () => {
   });
 
   describe('logout()', () => {
-    it('removes `auth0.is.authenticated` key from storage', async () => {
+    it('removes authenticated cookie from storage', async () => {
       const auth0 = setup();
       auth0.logout();
 
-      expect(esCookie.remove).toHaveBeenCalledWith('auth0.is.authenticated');
+      expect(esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`
+      );
     });
 
     it('removes the organization hint cookie from storage', async () => {
@@ -132,12 +134,14 @@ describe('Auth0Client', () => {
       expect(auth0['cacheManager']['clearSync']).toHaveBeenCalled();
     });
 
-    it('removes `auth0.is.authenticated` key from storage when `options.localOnly` is true', async () => {
+    it('removes authenticated cookie from storage when `options.localOnly` is true', async () => {
       const auth0 = setup();
 
       auth0.logout({ localOnly: true });
 
-      expect(esCookie.remove).toHaveBeenCalledWith('auth0.is.authenticated');
+      expect(esCookie.remove).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.is.authenticated`
+      );
     });
 
     it('removes the organization hint cookie from storage when `options.localOnly` is true', async () => {

--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -5,15 +5,11 @@ import { verify } from '../../src/jwt';
 import { MessageChannel } from 'worker_threads';
 import * as utils from '../../src/utils';
 import * as scope from '../../src/scope';
-
 import { expectToHaveBeenCalledWithAuth0ClientParam } from '../helpers';
-
 import { TEST_AUTH0_CLIENT_QUERY_STRING } from '../constants';
 
 // @ts-ignore
-
-import { loginWithPopupFn, loginWithRedirectFn, setupFn } from './helpers';
-
+import { loginWithRedirectFn, setupFn } from './helpers';
 import { TEST_CLIENT_ID, TEST_CODE_CHALLENGE, TEST_DOMAIN } from '../constants';
 import { InMemoryAsyncCacheNoKeys } from '../cache/shared';
 
@@ -126,6 +122,7 @@ describe('Auth0Client', () => {
 
     it('clears the cache', async () => {
       const auth0 = setup();
+
       jest
         .spyOn(auth0['cacheManager'], 'clearSync')
         .mockReturnValueOnce(undefined);

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -370,5 +370,67 @@ cacheFactories.forEach(cacheFactory => {
         entry3
       );
     });
+
+    it('clears all keys from the cache (sync)', async () => {
+      const manager = new CacheManager(new LocalStorageCache());
+      const entry1 = { ...defaultData };
+      const entry2 = { ...defaultData, scope: 'scope-1' };
+      const entry3 = { ...defaultData, client_id: 'some-other-client' };
+
+      await manager.set(entry1);
+      await manager.set(entry2);
+      await manager.set(entry3);
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
+        entry1
+      );
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
+        entry2
+      );
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+        entry3
+      );
+
+      manager.clearSync();
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
+      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toBeFalsy();
+    });
+
+    it('clears only the keys relating to a specific client ID from the cache (sync)', async () => {
+      const manager = new CacheManager(new LocalStorageCache());
+      const entry1 = { ...defaultData };
+      const entry2 = { ...defaultData, scope: 'scope-1' };
+      const entry3 = { ...defaultData, client_id: 'some-other-client' };
+
+      await manager.set(entry1);
+      await manager.set(entry2);
+      await manager.set(entry3);
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
+        entry1
+      );
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
+        entry2
+      );
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+        entry3
+      );
+
+      manager.clearSync(TEST_CLIENT_ID);
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
+      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
+
+      // Should not be removed as it has a different client ID from the manager instance
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+        entry3
+      );
+    });
   });
 });

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -3,6 +3,7 @@ import {
   InMemoryCache,
   LocalStorageCache
 } from '../../src/cache';
+import { CacheKeyManifest } from '../../src/cache/key-manifest';
 
 import {
   CacheEntry,
@@ -62,14 +63,18 @@ cacheFactories.forEach(cacheFactory => {
   describe(`CacheManager using ${cacheFactory.name}`, () => {
     let manager: CacheManager;
     let cache: ICache;
-    let withKeyManifest: boolean;
+    let keyManifest: CacheKeyManifest;
 
     beforeEach(() => {
       cache = cacheFactory.new();
-      manager = new CacheManager(cache, TEST_CLIENT_ID);
-      withKeyManifest = !!!cache.allKeys;
 
-      if (withKeyManifest) {
+      keyManifest = !!!cache.allKeys
+        ? new CacheKeyManifest(cache, TEST_CLIENT_ID)
+        : undefined;
+
+      manager = new CacheManager(cache, keyManifest);
+
+      if (keyManifest) {
         ['get', 'add', 'clear'].forEach((method: any) =>
           jest.spyOn(manager['keyManifest'], method)
         );
@@ -128,7 +133,7 @@ cacheFactories.forEach(cacheFactory => {
       expect(await manager.get(key)).toStrictEqual(data);
     });
 
-    if (withKeyManifest) {
+    if (keyManifest) {
       it('should update the key manifest when the key has only been added to the underlying cache', async () => {
         const manifestKey = `${CACHE_KEY_PREFIX}::${defaultData.client_id}`;
 
@@ -265,7 +270,7 @@ cacheFactories.forEach(cacheFactory => {
       expect(result).toBeFalsy();
 
       // And that the data has been removed from the key manifest
-      if (withKeyManifest) {
+      if (keyManifest) {
         expect(cacheRemoveSpy).toHaveBeenCalledWith(
           `@@auth0spajs@@::${data.client_id}`
         );
@@ -301,19 +306,21 @@ cacheFactories.forEach(cacheFactory => {
       expect(result).toBeFalsy();
 
       // And that the data has been removed from the key manifest
-      if (withKeyManifest) {
+      if (keyManifest) {
         expect(cacheRemoveSpy).toHaveBeenCalledWith(
           `@@auth0spajs@@::${data.client_id}`
         );
       }
     });
 
-    it('clears the cache', async () => {
+    it('clears all keys from the cache', async () => {
       const entry1 = { ...defaultData };
       const entry2 = { ...defaultData, scope: 'scope-1' };
+      const entry3 = { ...defaultData, client_id: 'some-other-client' };
 
       await manager.set(entry1);
       await manager.set(entry2);
+      await manager.set(entry3);
 
       expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
         entry1
@@ -323,9 +330,45 @@ cacheFactories.forEach(cacheFactory => {
         entry2
       );
 
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+        entry3
+      );
+
       await manager.clear();
       expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
       expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toBeFalsy();
+    });
+
+    it('clears only the keys relating to a specific client ID from the cache', async () => {
+      const entry1 = { ...defaultData };
+      const entry2 = { ...defaultData, scope: 'scope-1' };
+      const entry3 = { ...defaultData, client_id: 'some-other-client' };
+
+      await manager.set(entry1);
+      await manager.set(entry2);
+      await manager.set(entry3);
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
+        entry1
+      );
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
+        entry2
+      );
+
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+        entry3
+      );
+
+      await manager.clear(TEST_CLIENT_ID);
+      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
+      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
+
+      // Should not be removed as it has a different client ID from the manager instance
+      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+        entry3
+      );
     });
   });
 });

--- a/__tests__/transaction-manager.test.ts
+++ b/__tests__/transaction-manager.test.ts
@@ -1,8 +1,9 @@
 import TransactionManager from '../src/transaction-manager';
 import { SessionStorage } from '../src/storage';
+import { TEST_CLIENT_ID } from './constants';
 import { mocked } from 'ts-jest/utils';
 
-const TRANSACTION_KEY = 'a0.spajs.txs';
+const TRANSACTION_KEY_PREFIX = 'a0.spajs.txs';
 
 const transaction = {
   nonce: 'nonceIn',
@@ -15,6 +16,9 @@ const transaction = {
 
 const transactionJson = JSON.stringify(transaction);
 
+const transactionKey = (clientId = TEST_CLIENT_ID) =>
+  `${TRANSACTION_KEY_PREFIX}.${clientId}`;
+
 describe('transaction manager', () => {
   let tm: TransactionManager;
 
@@ -24,15 +28,14 @@ describe('transaction manager', () => {
 
   describe('constructor', () => {
     it('loads transactions from storage (per key)', () => {
-      tm = new TransactionManager(SessionStorage);
-
-      expect(sessionStorage.getItem).toHaveBeenCalledWith(TRANSACTION_KEY);
+      tm = new TransactionManager(SessionStorage, TEST_CLIENT_ID);
+      expect(sessionStorage.getItem).toHaveBeenCalledWith(transactionKey());
     });
   });
 
   describe('with empty transactions', () => {
     beforeEach(() => {
-      tm = new TransactionManager(SessionStorage);
+      tm = new TransactionManager(SessionStorage, TEST_CLIENT_ID);
     });
 
     it('`create` creates the transaction', () => {
@@ -45,7 +48,7 @@ describe('transaction manager', () => {
       tm.create(transaction);
 
       expect(sessionStorage.setItem).toHaveBeenCalledWith(
-        TRANSACTION_KEY,
+        transactionKey(),
         transactionJson
       );
     });
@@ -67,12 +70,14 @@ describe('transaction manager', () => {
 
     it('`remove` removes transaction from storage', () => {
       tm.create(transaction);
+
       expect(sessionStorage.setItem).toHaveBeenCalledWith(
-        TRANSACTION_KEY,
+        transactionKey(),
         transactionJson
       );
+
       tm.remove();
-      expect(sessionStorage.removeItem).toHaveBeenCalledWith(TRANSACTION_KEY);
+      expect(sessionStorage.removeItem).toHaveBeenCalledWith(transactionKey());
     });
   });
 });

--- a/cypress/integration/loginWithRedirect.js
+++ b/cypress/integration/loginWithRedirect.js
@@ -1,4 +1,4 @@
-import { whenReady, shouldInclude, tolerance } from '../support/utils';
+import { whenReady, shouldInclude, tolerance, get } from '../support/utils';
 
 describe('loginWithRedirect', function () {
   beforeEach(cy.resetTests);
@@ -11,10 +11,16 @@ describe('loginWithRedirect', function () {
       cy.url().should(url => shouldInclude(url, 'http://127.0.0.1:3000'));
 
       whenReady().then(win => {
-        expect(win.sessionStorage.getItem('a0.spajs.txs')).to.exist;
+        get('client-id').then($clientIdBox => {
+          expect(
+            win.sessionStorage.getItem(`a0.spajs.txs.${$clientIdBox.val()}`)
+          ).to.exist;
 
-        cy.handleRedirectCallback().then(() => {
-          expect(win.sessionStorage.getItem('a0.spajs.txs')).to.not.exist;
+          cy.handleRedirectCallback().then(() => {
+            expect(
+              win.sessionStorage.getItem(`a0.spajs.txs.${$clientIdBox.val()}`)
+            ).to.not.exist;
+          });
         });
       });
     });
@@ -30,16 +36,18 @@ describe('loginWithRedirect', function () {
     cy.url().should(url => shouldInclude(url, 'http://127.0.0.1:3000'));
     whenReady();
 
-    cy.getCookie('a0.spajs.txs')
-      .should('exist')
-      .should(cookie => {
-        // Check that the cookie value is at least within a second of what we expect, to make
-        // the test a little less brittle.
-        expect(tolerance(cookie.expiry, tomorrowInSeconds, 1)).to.be.true;
-      });
+    get('client-id').then($clientIdBox => {
+      cy.getCookie(`a0.spajs.txs.${$clientIdBox.val()}`)
+        .should('exist')
+        .should(cookie => {
+          // Check that the cookie value is at least within a second of what we expect, to make
+          // the test a little less brittle.
+          expect(tolerance(cookie.expiry, tomorrowInSeconds, 1)).to.be.true;
+        });
 
-    cy.handleRedirectCallback().then(() => {
-      cy.getCookie('a0.spajs.txs').should('not.exist');
+      cy.handleRedirectCallback().then(() => {
+        cy.getCookie(`a0.spajs.txs.${$clientIdBox.val()}`).should('not.exist');
+      });
     });
   });
 });

--- a/cypress/integration/multiple_clients.js
+++ b/cypress/integration/multiple_clients.js
@@ -1,0 +1,44 @@
+import { whenReady, shouldInclude, tolerance, get } from '../support/utils';
+
+const login = instanceId => {
+  get(`client-login-${instanceId}`).click();
+  cy.get('.login-card input[name=login]').clear().type('test');
+  cy.get('.login-card input[name=password]').clear().type('test');
+
+  cy.get('.login-submit').click();
+  // Need to click one more time to give consent.
+  // It is actually a different button with the same class.
+  cy.get('.login-submit').click();
+};
+
+describe('using multiple clients in the app', () => {
+  beforeEach(() => {
+    cy.server();
+    cy.visit('http://127.0.0.1:3000/multiple_clients.html');
+    get('client-logout-1').click();
+    cy.window().then(win => win.localStorage.clear());
+    cy.visit('http://127.0.0.1:3000/multiple_clients.html');
+  });
+
+  afterEach(cy.fixCookies);
+
+  it('can log into just one client', () => {
+    whenReady();
+
+    // Get a token for the exact client we log into and no more
+    login(1);
+    get('client-access-token-1').should('not.be.empty');
+    get('client-access-token-2').should('be.empty');
+    get('client-access-token-3').should('be.empty');
+
+    // Logging into a second client should not work
+    get('client-token-2').click();
+
+    shouldInclude(get('client-error-2'), 'requested scopes not granted');
+
+    // Verify check session
+    cy.reload();
+    whenReady();
+    get('client-access-token-1').should('not.be.empty');
+  });
+});

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -5,6 +5,9 @@ module.exports.shouldBe = (expected, actual) => expect(actual).to.eq(expected);
 module.exports.shouldInclude = (expected, actual) =>
   expect(actual).to.include(actual);
 
+// Gets an element using its `data-cy` attribute name
+module.exports.get = attrId => cy.get(`[data-cy=${attrId}]`);
+
 module.exports.shouldNotBe = (expected, actual) =>
   expect(actual).to.not.eq(expected);
 

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -23,6 +23,33 @@ const config = {
       redirect_uris: ['http://127.0.0.1:3000', 'http://localhost:3000'],
       token_endpoint_auth_method: 'none',
       grant_types: ['authorization_code', 'refresh_token']
+    },
+    {
+      client_id: 'multi-client-1',
+      redirect_uris: [
+        'http://127.0.0.1:3000/multiple_clients.html',
+        'http://localhost:3000/multiple_clients.html'
+      ],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token']
+    },
+    {
+      client_id: 'multi-client-2',
+      redirect_uris: [
+        'http://127.0.0.1:3000/multiple_clients.html',
+        'http://localhost:3000/multiple_clients.html'
+      ],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token']
+    },
+    {
+      client_id: 'multi-client-3',
+      redirect_uris: [
+        'http://127.0.0.1:3000/multiple_clients.html',
+        'http://localhost:3000/multiple_clients.html'
+      ],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token']
     }
   ],
   claims: {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -218,7 +218,12 @@ export default class Auth0Client {
       : SessionStorage;
 
     this.scope = this.options.scope;
-    this.transactionManager = new TransactionManager(transactionStorage);
+
+    this.transactionManager = new TransactionManager(
+      transactionStorage,
+      this.options.client_id
+    );
+
     this.cacheManager = new CacheManager(cache, this.options.client_id);
     this.domainUrl = getDomain(this.options.domain);
     this.tokenIssuer = getTokenIssuer(this.options.issuer, this.domainUrl);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -84,7 +84,6 @@ const lock = new Lock();
  * @ignore
  */
 const GET_TOKEN_SILENTLY_LOCK_KEY = 'auth0.lock.getTokenSilently';
-const COOKIE_IS_AUTHENTICATED_HINT = 'auth0.is.authenticated';
 
 /**
  * @ignore

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -944,15 +944,10 @@ export default class Auth0Client {
       window.location.assign(url);
     };
 
-    let clientId;
-    if (options.client_id !== null) {
-      clientId = options.client_id || this.options.client_id;
-    }
-
     if (this.options.cache) {
-      return this.cacheManager.clear(clientId).then(() => postCacheClear());
+      return this.cacheManager.clear().then(() => postCacheClear());
     } else {
-      this.cacheManager.clearSync(clientId);
+      this.cacheManager.clearSync();
       postCacheClear();
     }
   }

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -75,11 +75,12 @@ export class CacheManager {
     /* istanbul ignore next */
     if (!keys) return;
 
-    keys
+    await keys
       .filter(key => (clientId ? key.includes(clientId) : true))
-      .forEach(async key => {
+      .reduce(async (memo, key) => {
+        await memo;
         await this.cache.remove(key);
-      });
+      }, Promise.resolve());
 
     await this.keyManifest?.clear();
   }

--- a/src/cache/key-manifest.ts
+++ b/src/cache/key-manifest.ts
@@ -9,7 +9,7 @@ export class CacheKeyManifest {
   private readonly manifestKey: string;
 
   constructor(private cache: ICache, private clientId: string) {
-    this.manifestKey = this.createManifestKeyFrom(clientId);
+    this.manifestKey = this.createManifestKeyFrom(this.clientId);
   }
 
   async add(key: string): Promise<void> {

--- a/src/transaction-manager.ts
+++ b/src/transaction-manager.ts
@@ -1,6 +1,6 @@
 import { ClientStorage } from './storage';
 
-const TRANSACTION_STORAGE_KEY = 'a0.spajs.txs';
+const TRANSACTION_STORAGE_KEY_PREFIX = 'a0.spajs.txs';
 
 interface Transaction {
   nonce: string;
@@ -14,15 +14,17 @@ interface Transaction {
 
 export default class TransactionManager {
   private transaction: Transaction;
+  private storageKey: string;
 
-  constructor(private storage: ClientStorage) {
-    this.transaction = this.storage.get(TRANSACTION_STORAGE_KEY);
+  constructor(private storage: ClientStorage, private clientId: string) {
+    this.storageKey = `${TRANSACTION_STORAGE_KEY_PREFIX}.${clientId}`;
+    this.transaction = this.storage.get(this.storageKey);
   }
 
   public create(transaction: Transaction) {
     this.transaction = transaction;
 
-    this.storage.save(TRANSACTION_STORAGE_KEY, transaction, {
+    this.storage.save(this.storageKey, transaction, {
       daysUntilExpire: 1
     });
   }
@@ -33,6 +35,6 @@ export default class TransactionManager {
 
   public remove() {
     delete this.transaction;
-    this.storage.remove(TRANSACTION_STORAGE_KEY);
+    this.storage.remove(this.storageKey);
   }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -203,6 +203,7 @@
             class="form-control"
             id="client_id"
             v-model="clientId"
+            data-cy="client-id"
           />
         </div>
 

--- a/static/multiple_clients.html
+++ b/static/multiple_clients.html
@@ -12,7 +12,7 @@
   <body>
     <div id="app" class="container mx-auto p-5">
       <header class="mb-10">
-        <h1 class="text-4xl">Multiple Client Test</h1>
+        <h1 class="text-4xl mb-2">Multiple Client Test</h1>
         <p>
           <a
             href="http://localhost:3000/multiple_clients.html"
@@ -61,27 +61,31 @@
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
     <script src="/auth0-spa-js.development.js"></script>
     <script>
-      const commonOptions = {
-        redirect_uri: `${window.location.origin}/multiple_clients.html`,
-        cacheLocation: 'localstorage',
-        useFormData: true
-      };
-
       new Vue({
         el: '#app',
         data() {
+          const useAuth0 = false;
+
+          const commonOptions = {
+            redirect_uri: `${window.location.origin}/multiple_clients.html`,
+            cacheLocation: 'localstorage',
+            useFormData: true,
+            domain: useAuth0 ? 'brucke.auth0.com' : 'http://127.0.0.1:3000'
+          };
+
           return {
             clients: [
               {
                 name: 'Client 1',
                 get description() {
-                  return `Using ${this.options.domain} and iframe with prompt=none`;
+                  return `Using ${commonOptions.domain} and iframe with prompt=none`;
                 },
                 id: 1,
                 options: {
                   ...commonOptions,
-                  domain: 'brucke.auth0.com',
-                  client_id: 'IRLdsf27vEPiV5NNQjlNK7fwgmRuwyJY'
+                  client_id: useAuth0
+                    ? 'IRLdsf27vEPiV5NNQjlNK7fwgmRuwyJY'
+                    : 'multi-client-1'
                 },
                 id_token: '',
                 access_token: '',
@@ -95,8 +99,9 @@
                 id: 2,
                 options: {
                   ...commonOptions,
-                  domain: 'brucke.auth0.com',
-                  client_id: 'Q4TgHIYRcUBh2xe6l049ZR7X5JAeLzwI',
+                  client_id: useAuth0
+                    ? 'Q4TgHIYRcUBh2xe6l049ZR7X5JAeLzwI'
+                    : 'multi-client-2',
                   useRefreshTokens: true
                 },
                 id_token: '',
@@ -111,8 +116,9 @@
                 id: 3,
                 options: {
                   ...commonOptions,
-                  domain: 'brucke.auth0.com',
-                  client_id: 'Y7VQRCOOVeU7b0Y36cLA5OS4fUbIJfwV',
+                  client_id: useAuth0
+                    ? 'Y7VQRCOOVeU7b0Y36cLA5OS4fUbIJfwV'
+                    : 'multi-client-3',
                   useCookiesForTransactions: true
                 },
                 id_token: '',
@@ -130,7 +136,7 @@
             }
           };
 
-          this.clients.map(async client => {
+          this.clients.map(client => {
             client.auth0 = new Auth0Client(client.options);
           });
 

--- a/static/multiple_clients.html
+++ b/static/multiple_clients.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="app" class="container mx-auto p-5">
+      <header class="mb-10">
+        <h1 class="text-4xl">Multiple Client Test</h1>
+        <p>
+          <a
+            href="http://localhost:3000/multiple_clients.html"
+            class="text-gray-400 underline"
+            >Reset URL</a
+          >
+        </p>
+      </header>
+
+      <div x-data="clientData">
+        <div class="mb-5" v-for="client in clients" :key="client.id">
+          <h2 v-text="client.name" class="text-2xl"></h2>
+          <p class="text-gray-400 mb-5" v-text="client.description"></p>
+          <button
+            type="submit"
+            class="p-2 rounded bg-blue-700 text-white"
+            @click="loginWith(client)"
+          >
+            Log in
+          </button>
+          <button
+            class="p-2 rounded bg-red-700 text-white"
+            @click="getTokenWith(client)"
+          >
+            Get Token
+          </button>
+          <button
+            class="p-2 rounded bg-gray-700 text-white"
+            @click="logoutOf(client)"
+          >
+            Log out
+          </button>
+          <div class="mt-5">
+            <div>
+              <p v-text="client.access_token"></p>
+            </div>
+            <template v-if="client.error !== null">
+              <p class="text-red-500" v-text="client.error"></p>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+    <script src="/auth0-spa-js.development.js"></script>
+    <script>
+      const commonOptions = {
+        redirect_uri: `${window.location.origin}/multiple_clients.html`,
+        cacheLocation: 'localstorage',
+        useFormData: true
+      };
+
+      new Vue({
+        el: '#app',
+        data() {
+          return {
+            clients: [
+              {
+                name: 'Client 1',
+                get description() {
+                  return `Using ${this.options.domain} and iframe with prompt=none`;
+                },
+                id: 1,
+                options: {
+                  ...commonOptions,
+                  domain: 'brucke.auth0.com',
+                  client_id: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp'
+                },
+                id_token: '',
+                access_token: '',
+                error: null
+              },
+              {
+                name: 'Client 2',
+                get description() {
+                  return `Using ${this.options.domain} and refresh tokens`;
+                },
+                id: 2,
+                options: {
+                  ...commonOptions,
+                  domain: 'elkdanger.eu.auth0.com',
+                  client_id: 'TgqxTDJFG2G3H5TjqvIEEVL5i6IcZGye',
+                  useRefreshTokens: true
+                },
+                id_token: '',
+                access_token: '',
+                error: null
+              }
+            ]
+          };
+        },
+        async created() {
+          const authFn = async client => {
+            if (await client.auth0.isAuthenticated()) {
+              client.id_token = (await client.auth0.getIdTokenClaims()).__raw;
+              client.access_token = await client.auth0.getTokenSilently();
+            }
+          };
+
+          this.clients.map(async client => {
+            client.auth0 = new Auth0Client(client.options);
+          });
+
+          if (
+            window.location.search.includes('code=') &&
+            window.location.search.includes('state=')
+          ) {
+            const id = localStorage.getItem('login_id');
+
+            if (id) {
+              const client = this.clients.find(c => c.id === parseInt(id));
+
+              if (client) {
+                console.log('Handling callback');
+                await client.auth0.handleRedirectCallback();
+                history.pushState({}, null, '/multiple_clients.html');
+                await authFn(client);
+              }
+            }
+          }
+
+          this.clients.map(async client => {
+            client.auth0 = new Auth0Client(client.options);
+            await client.auth0.checkSession();
+            await authFn(client);
+          });
+        },
+        methods: {
+          loginWith(client) {
+            localStorage.setItem('login_id', client.id);
+            client.auth0.loginWithRedirect();
+          },
+          async getTokenWith(client) {
+            try {
+              client.access_token = await client.auth0.getTokenSilently({
+                ignoreCache: true
+              });
+              client.error = null;
+            } catch (e) {
+              client.error = e.error_description;
+            }
+          },
+          logoutOf(client) {
+            client.auth0.logout({
+              returnTo: `${window.location.origin}/multiple_clients.html`,
+              client_id: client.options.client_id
+            });
+          }
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/static/multiple_clients.html
+++ b/static/multiple_clients.html
@@ -11,6 +11,10 @@
   </head>
   <body>
     <div id="app" class="container mx-auto p-5">
+      <div v-if="!loading" style="visibility: hidden">
+        <span id="loaded">loaded</span>
+      </div>
+
       <header class="mb-10">
         <h1 class="text-4xl mb-2">Multiple Client Test</h1>
         <p>
@@ -31,27 +35,37 @@
             type="submit"
             class="p-2 rounded bg-blue-700 text-white"
             @click="loginWith(client)"
+            :data-cy="`client-login-${client.id}`"
           >
             Log in
           </button>
           <button
             class="p-2 rounded bg-red-700 text-white"
+            :data-cy="`client-token-${client.id}`"
             @click="getTokenWith(client)"
           >
             Get Token
           </button>
           <button
             class="p-2 rounded bg-gray-700 text-white"
+            :data-cy="`client-logout-${client.id}`"
             @click="logoutOf(client)"
           >
             Log out
           </button>
           <div class="mt-5">
             <div>
-              <p v-text="client.access_token"></p>
+              <p
+                v-text="client.access_token"
+                :data-cy="`client-access-token-${client.id}`"
+              ></p>
             </div>
             <template v-if="client.error !== null">
-              <p class="text-red-500" v-text="client.error"></p>
+              <p
+                class="text-red-500"
+                v-text="client.error"
+                :data-cy="`client-error-${client.id}`"
+              ></p>
             </template>
           </div>
         </div>
@@ -70,10 +84,12 @@
             redirect_uri: `${window.location.origin}/multiple_clients.html`,
             cacheLocation: 'localstorage',
             useFormData: true,
-            domain: useAuth0 ? 'brucke.auth0.com' : 'http://127.0.0.1:3000'
+            domain: useAuth0 ? 'brucke.auth0.com' : window.location.origin,
+            tokenIssuer: window.location.origin
           };
 
           return {
+            loading: true,
             clients: [
               {
                 name: 'Client 1',
@@ -158,11 +174,14 @@
             }
           }
 
-          this.clients.map(async client => {
-            client.auth0 = new Auth0Client(client.options);
-            await client.auth0.checkSession();
-            await authFn(client);
-          });
+          await Promise.all(
+            this.clients.map(async client => {
+              await client.auth0.checkSession();
+              await authFn(client);
+            })
+          );
+
+          this.loading = false;
         },
         methods: {
           loginWith(client) {

--- a/static/multiple_clients.html
+++ b/static/multiple_clients.html
@@ -168,6 +168,7 @@
               client.access_token = await client.auth0.getTokenSilently({
                 ignoreCache: true
               });
+
               client.error = null;
             } catch (e) {
               client.error = e.error_description;

--- a/static/multiple_clients.html
+++ b/static/multiple_clients.html
@@ -25,7 +25,8 @@
       <div x-data="clientData">
         <div class="mb-5" v-for="client in clients" :key="client.id">
           <h2 v-text="client.name" class="text-2xl"></h2>
-          <p class="text-gray-400 mb-5" v-text="client.description"></p>
+          <p class="text-gray-400" v-text="client.description"></p>
+          <p class="text-gray-400 mb-5" v-text="client.options.client_id"></p>
           <button
             type="submit"
             class="p-2 rounded bg-blue-700 text-white"
@@ -80,7 +81,7 @@
                 options: {
                   ...commonOptions,
                   domain: 'brucke.auth0.com',
-                  client_id: 'wLSIP47wM39wKdDmOj6Zb5eSEw3JVhVp'
+                  client_id: 'IRLdsf27vEPiV5NNQjlNK7fwgmRuwyJY'
                 },
                 id_token: '',
                 access_token: '',
@@ -94,9 +95,25 @@
                 id: 2,
                 options: {
                   ...commonOptions,
-                  domain: 'elkdanger.eu.auth0.com',
-                  client_id: 'TgqxTDJFG2G3H5TjqvIEEVL5i6IcZGye',
+                  domain: 'brucke.auth0.com',
+                  client_id: 'Q4TgHIYRcUBh2xe6l049ZR7X5JAeLzwI',
                   useRefreshTokens: true
+                },
+                id_token: '',
+                access_token: '',
+                error: null
+              },
+              {
+                name: 'Client 3',
+                get description() {
+                  return `Using ${this.options.domain} and cookies for transactions`;
+                },
+                id: 3,
+                options: {
+                  ...commonOptions,
+                  domain: 'brucke.auth0.com',
+                  client_id: 'Y7VQRCOOVeU7b0Y36cLA5OS4fUbIJfwV',
+                  useCookiesForTransactions: true
                 },
                 id_token: '',
                 access_token: '',


### PR DESCRIPTION
### Description

This PR makes some tweaks to the way cookies are handled with the intention of supporting using multiple instances of the client within the same app. Tweaks have also been made to the cache manager so that only cache items for a particular client ID can be cleared.

Mostly this involves scoping of:

- transaction cookie
- `is.authenticated` cookie for `checkSession`. This is automatically migrated if the old cookie is found on the system

I've added an E2E test that tries to cover this scenario as well as a new playground page that the tests run against.

### References

SDK-2759

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
