### PR TITLE
[SDK-2795] Ensure getTokenWithPopup uses the cache

### DIFF
--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -276,6 +276,22 @@ describe('Auth0Client', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it('refreshes the token when ignoreCache set to true', async () => {
+      const auth0 = setup();
+      await loginWithPopup(auth0, undefined, undefined, {
+        token: {
+          response: { expires_in: 70 }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      const token = await getTokenWithPopup(auth0, { ignoreCache: true });
+
+      expect(token).toBe(TEST_ACCESS_TOKEN);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it('uses the cache when expires_in > constant leeway & refresh tokens are used', async () => {
       const auth0 = setup({
         useRefreshTokens: true

--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -305,8 +305,9 @@ describe('Auth0Client', () => {
 
       mockFetch.mockReset();
 
-      await getTokenWithPopup(auth0);
+      const token = await getTokenWithPopup(auth0);
 
+      expect(token).toBe(TEST_ACCESS_TOKEN);
       expect(mockFetch).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -10,6 +10,8 @@ import * as scope from '../../src/scope';
 import {
   assertPostFn,
   fetchResponse,
+  getTokenWithPopupFn,
+  loginWithPopupFn,
   setupFn,
   setupMessageEventLister
 } from './helpers';
@@ -38,6 +40,8 @@ const mockWindow = <any>global;
 const mockFetch = (mockWindow.fetch = <jest.Mock>unfetch);
 const mockVerify = <jest.Mock>verify;
 const assertPost = assertPostFn(mockFetch);
+const loginWithPopup = loginWithPopupFn(mockWindow, mockFetch);
+const getTokenWithPopup = getTokenWithPopupFn(mockWindow, mockFetch);
 
 jest
   .spyOn(utils, 'bufferToBase64UrlEncoded')
@@ -104,6 +108,22 @@ describe('Auth0Client', () => {
 
       return auth0;
     };
+
+    it('uses the cache when expires_in > constant leeway', async () => {
+      const auth0 = setup();
+      await loginWithPopup(auth0, undefined, undefined, {
+        token: {
+          response: { expires_in: 70 }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      const token = await auth0.getTokenWithPopup();
+
+      expect(token).toBe(TEST_ACCESS_TOKEN);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
 
     it('calls `loginWithPopup` with the correct default options', async () => {
       const auth0 = await localSetup();
@@ -214,6 +234,64 @@ describe('Auth0Client', () => {
       await auth0.getTokenWithPopup({}, config);
 
       expect(config.popup.location.href).toMatch(/global-audience/);
+    });
+
+    it('refreshes the token when no cache available', async () => {
+      const auth0 = setup();
+      const token = await getTokenWithPopup(auth0);
+
+      expect(token).toBe(TEST_ACCESS_TOKEN);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('refreshes the token when cache available without access token', async () => {
+      const auth0 = setup();
+      await loginWithPopup(auth0, undefined, undefined, {
+        token: {
+          response: { expires_in: 70, access_token: null }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      const token = await getTokenWithPopup(auth0);
+
+      expect(token).toBe(TEST_ACCESS_TOKEN);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('refreshes the token when expires_in < constant leeway', async () => {
+      const auth0 = setup();
+      await loginWithPopup(auth0, undefined, undefined, {
+        token: {
+          response: { expires_in: 50 }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      const token = await getTokenWithPopup(auth0);
+
+      expect(token).toBe(TEST_ACCESS_TOKEN);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the cache when expires_in > constant leeway & refresh tokens are used', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true
+      });
+
+      await loginWithPopup(auth0, undefined, undefined, {
+        token: {
+          response: { expires_in: 70 }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      await getTokenWithPopup(auth0);
+
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -2,6 +2,7 @@ import {
   Auth0ClientOptions,
   AuthenticationResult,
   GetTokenSilentlyOptions,
+  GetTokenWithPopupOptions,
   IdToken,
   PopupConfigOptions,
   PopupLoginOptions,
@@ -359,5 +360,73 @@ export const getTokenSilentlyFn = (mockWindow, mockFetch) => {
     );
 
     return await auth0.getTokenSilently(options);
+  };
+};
+
+const processDefaultGetTokenWithPopupOptions = config => {
+  const defaultResponseOptions = {
+    success: true,
+    response: {}
+  };
+  const defaultAuthorizeResponseOptions = {
+    response: authorizationResponse
+  };
+
+  const token = {
+    ...defaultResponseOptions,
+    ...(config.token || {})
+  };
+
+  const authorize = {
+    ...defaultAuthorizeResponseOptions,
+    ...(config.authorize || {})
+  };
+
+  const delay = config.delay || 0;
+
+  return {
+    token,
+    authorize,
+    delay
+  };
+};
+
+export const getTokenWithPopupFn = (mockWindow, mockFetch) => {
+  return async (
+    auth0,
+    options: GetTokenWithPopupOptions = undefined,
+    testConfig: {
+      token?: {
+        success?: boolean;
+        response?: any;
+      };
+    } = {
+      token: {}
+    }
+  ) => {
+    const {
+      token,
+      authorize: { response },
+      delay
+    } = processDefaultGetTokenWithPopupOptions(testConfig);
+
+    setupMessageEventLister(mockWindow, response, delay);
+
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse(
+        token.success,
+        Object.assign(
+          {
+            id_token: TEST_ID_TOKEN,
+            refresh_token: TEST_REFRESH_TOKEN,
+            access_token: TEST_ACCESS_TOKEN,
+            expires_in: 86400
+          },
+          token.response
+        )
+      )
+    );
+
+    return await auth0.getTokenWithPopup(options);
   };
 };

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -763,23 +763,14 @@ export default class Auth0Client {
   private async _getTokenSilently(options: GetTokenSilentlyOptions = {}) {
     const { ignoreCache, ...getTokenOptions } = options;
 
-    const getAccessTokenFromCache = async () => {
-      const cache = await this.cacheManager.get(
-        new CacheKey({
-          scope: getTokenOptions.scope,
-          audience: getTokenOptions.audience || 'default',
-          client_id: this.options.client_id
-        }),
-        60 // get a new token if within 60 seconds of expiring
-      );
-
-      return cache && cache.access_token;
-    };
-
     // Check the cache before acquiring the lock to avoid the latency of
     // `lock.acquireLock` when the cache is populated.
     if (!ignoreCache) {
-      const accessToken = await getAccessTokenFromCache();
+      const accessToken = await this._getAccessTokenFromCache({
+        scope: getTokenOptions.scope,
+        audience: getTokenOptions.audience || 'default',
+        client_id: this.options.client_id
+      });
 
       if (accessToken) {
         return accessToken;
@@ -796,7 +787,11 @@ export default class Auth0Client {
         // Check the cache a second time, because it may have been populated
         // by a previous call while this call was waiting to acquire the lock.
         if (!ignoreCache) {
-          const accessToken = await getAccessTokenFromCache();
+          const accessToken = await this._getAccessTokenFromCache({
+            scope: getTokenOptions.scope,
+            audience: getTokenOptions.audience || 'default',
+            client_id: this.options.client_id
+          });
 
           if (accessToken) {
             return accessToken;
@@ -841,30 +836,37 @@ export default class Auth0Client {
     options: GetTokenWithPopupOptions = {},
     config: PopupConfigOptions = {}
   ) {
-    options.audience = options.audience || this.options.audience;
+    const { ignoreCache, ...getTokenOptions } = {
+      audience: this.options.audience,
+      ignoreCache: false,
+      ...options,
+      scope: getUniqueScopes(this.defaultScope, this.scope, options.scope)
+    };
 
-    options.scope = getUniqueScopes(
-      this.defaultScope,
-      this.scope,
-      options.scope
-    );
+    if (!ignoreCache) {
+      const accessToken = await this._getAccessTokenFromCache({
+        scope: getTokenOptions.scope,
+        audience: getTokenOptions.audience || 'default',
+        client_id: this.options.client_id
+      });
+
+      if (accessToken) {
+        return accessToken;
+      }
+    }
 
     config = {
       ...DEFAULT_POPUP_CONFIG_OPTIONS,
       ...config
     };
 
-    await this.loginWithPopup(options, config);
+    await this.loginWithPopup(getTokenOptions, config);
 
-    const cache = await this.cacheManager.get(
-      new CacheKey({
-        scope: options.scope,
-        audience: options.audience || 'default',
-        client_id: this.options.client_id
-      })
-    );
-
-    return cache.access_token;
+    return await this._getAccessTokenFromCache({
+      scope: getTokenOptions.scope,
+      audience: getTokenOptions.audience || 'default',
+      client_id: this.options.client_id
+    });
   }
 
   /**
@@ -1130,5 +1132,26 @@ export default class Auth0Client {
       scope: options.scope,
       audience: options.audience || 'default'
     };
+  }
+
+  private async _getAccessTokenFromCache({
+    scope,
+    audience,
+    client_id
+  }: {
+    scope: string;
+    audience: string;
+    client_id: string;
+  }) {
+    const cache = await this.cacheManager.get(
+      new CacheKey({
+        scope,
+        audience,
+        client_id
+      }),
+      60 // get a new token if within 60 seconds of expiring
+    );
+
+    return cache && cache.access_token;
   }
 }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -837,11 +837,13 @@ export default class Auth0Client {
     config: PopupConfigOptions = {}
   ) {
     const { ignoreCache, ...getTokenOptions } = {
-      audience: this.options.audience,
       ignoreCache: false,
       ...options,
       scope: getUniqueScopes(this.defaultScope, this.scope, options.scope)
     };
+
+    getTokenOptions.audience =
+      getTokenOptions.audience || this.options.audience;
 
     if (!ignoreCache) {
       const accessToken = await this._getAccessTokenFromCache({

--- a/src/global.ts
+++ b/src/global.ts
@@ -345,7 +345,13 @@ export interface GetTokenSilentlyOptions {
   [key: string]: any;
 }
 
-export interface GetTokenWithPopupOptions extends PopupLoginOptions {}
+export interface GetTokenWithPopupOptions extends PopupLoginOptions {
+  /**
+   * When `true`, ignores the cache and always sends a
+   * request to Auth0.
+   */
+  ignoreCache?: boolean;
+}
 
 export interface LogoutUrlOptions {
   /**


### PR DESCRIPTION
### Description

Ensures the `getTokenWithPopup` reads the token from the cache if available, unless `ignoreCache` is set to true. This ensures we can avoid triggering a popup when we already have a token available in our cache..

### References

Closes #710

### Testing

Call getTokenWithPopup multiple times, no popup should be shown once a token is available in the cache.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
