### PR TITLE
[SDK-2793] Ability to define a custom now provider

### DIFF
--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -383,7 +383,7 @@ cacheFactories.forEach(cacheFactory => {
         }
       };
 
-      const provider = jest.fn().mockResolvedValue(now);
+      const provider = jest.fn().mockReturnValue(now);
       const manager = new CacheManager(cache, keyManifest, provider);
 
       await manager.set(data);
@@ -489,7 +489,7 @@ cacheFactories.forEach(cacheFactory => {
         expires_in: dayInSeconds * 120
       };
 
-      const provider = jest.fn().mockResolvedValue(now);
+      const provider = jest.fn().mockReturnValue(now);
       const manager = new CacheManager(cache, keyManifest, provider);
 
       await manager.set(data);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -187,7 +187,7 @@ export default class Auth0Client {
   private sessionCheckExpiryDays: number;
   private orgHintCookieName: string;
   private isAuthenticatedCookieName: string;
-  private nowProvider: () => Promise<number>;
+  private nowProvider: () => number | Promise<number>;
 
   cacheLocation: CacheLocation;
   private worker: Worker;

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -15,7 +15,7 @@ export class CacheManager {
   constructor(
     private cache: ICache,
     private keyManifest?: CacheKeyManifest,
-    private nowProvider?: () => Promise<number>
+    private nowProvider?: () => number | Promise<number>
   ) {
     this.nowProvider = this.nowProvider || DEFAULT_NOW_PROVIDER;
   }

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_NOW_PROVIDER } from '../constants';
 import { CacheKeyManifest } from './key-manifest';
 
 import {
@@ -11,7 +12,13 @@ import {
 const DEFAULT_EXPIRY_ADJUSTMENT_SECONDS = 0;
 
 export class CacheManager {
-  constructor(private cache: ICache, private keyManifest?: CacheKeyManifest) {}
+  constructor(
+    private cache: ICache,
+    private keyManifest?: CacheKeyManifest,
+    private nowProvider?: () => Promise<number>
+  ) {
+    this.nowProvider = this.nowProvider || DEFAULT_NOW_PROVIDER;
+  }
 
   async get(
     cacheKey: CacheKey,
@@ -35,7 +42,8 @@ export class CacheManager {
       return;
     }
 
-    const nowSeconds = Math.floor(Date.now() / 1000);
+    const now = await this.nowProvider();
+    const nowSeconds = Math.floor(now / 1000);
 
     if (wrappedEntry.expiresAt - expiryAdjustmentSeconds < nowSeconds) {
       if (wrappedEntry.body.refresh_token) {
@@ -63,7 +71,7 @@ export class CacheManager {
       audience: entry.audience
     });
 
-    const wrappedEntry = this.wrapCacheEntry(entry);
+    const wrappedEntry = await this.wrapCacheEntry(entry);
 
     await this.cache.set(cacheKey.toKey(), wrappedEntry);
     await this.keyManifest?.add(cacheKey.toKey());
@@ -101,8 +109,9 @@ export class CacheManager {
       });
   }
 
-  private wrapCacheEntry(entry: CacheEntry): WrappedCacheEntry {
-    const expiresInTime = Math.floor(Date.now() / 1000) + entry.expires_in;
+  private async wrapCacheEntry(entry: CacheEntry): Promise<WrappedCacheEntry> {
+    const now = await this.nowProvider();
+    const expiresInTime = Math.floor(now / 1000) + entry.expires_in;
 
     const expirySeconds = Math.min(
       expiresInTime,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,3 +76,6 @@ export const DEFAULT_AUTH0_CLIENT = {
   name: 'auth0-spa-js',
   version: version
 };
+
+export const DEFAULT_NOW_PROVIDER = () =>
+  new Promise<number>(resolve => resolve(Date.now()));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,5 +77,4 @@ export const DEFAULT_AUTH0_CLIENT = {
   version: version
 };
 
-export const DEFAULT_NOW_PROVIDER = () =>
-  new Promise<number>(resolve => resolve(Date.now()));
+export const DEFAULT_NOW_PROVIDER = () => Date.now();

--- a/src/global.ts
+++ b/src/global.ts
@@ -214,8 +214,9 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   useFormData?: boolean;
 
   /**
-   * Allows you to modify the current time used throughout the SDK.
-   * The value returned will be used as the current time when validating the token expirations.
+   * Modify the value used as the current time during the token validation.
+   *
+   * **Note**: Using this improperly can potentially compromise the token validation.
    */
   nowProvider?: () => Promise<number>;
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -218,7 +218,7 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    *
    * **Note**: Using this improperly can potentially compromise the token validation.
    */
-  nowProvider?: () => Promise<number>;
+  nowProvider?: () => Promise<number> | number;
 }
 
 /**

--- a/src/global.ts
+++ b/src/global.ts
@@ -212,6 +212,12 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * continue to work as intended.
    */
   useFormData?: boolean;
+
+  /**
+   * Allows you to modify the current time used throughout the SDK.
+   * The value returned will be used as the current time when validating the token expirations.
+   */
+  nowProvider?: () => Promise<number>;
 }
 
 /**
@@ -478,6 +484,7 @@ export interface JWTVerifyOptions {
   leeway?: number;
   max_age?: number;
   organizationId?: string;
+  now?: number;
 }
 
 /**

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -159,7 +159,7 @@ export const verify = (options: JWTVerifyOptions) => {
   }
 
   const leeway = options.leeway || 60;
-  const now = new Date(Date.now());
+  const now = new Date(options.now || Date.now());
   const expDate = new Date(0);
   const nbfDate = new Date(0);
   const authTimeDate = new Date(0);


### PR DESCRIPTION
### Description

Adds a custom `nowProvider`, allowing developers to register a function returning a promise, indicating the current time (in milliseconds) used to validate the token expirations:

```ts
const client = new Auth0Client({
  nowProvider: () => Promise.resolve(Date.now())
});
```
This allows to integrate a time-server where needed:
```ts
async function getCurrentTime() {
  const response = await fetch('URL_HERE');
  const data = await response.json();
  return data.now;
}
const client = new Auth0Client({
  nowProvider: () => getCurrentTime()
});
```


### References
Closes #650


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
