### PR TITLE
[SDK-2794] Return token response in getTokenSilently

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1638,7 +1638,7 @@ describe('Auth0Client', () => {
       windowSpy.mockRestore();
     });
 
-    it('returns the full token response when returnMode = "verbose"', async () => {
+    it('returns the full token response when "detailedResponse: true"', async () => {
       const auth0 = setup();
 
       await loginWithRedirect(auth0);
@@ -1658,7 +1658,7 @@ describe('Auth0Client', () => {
 
       const response = await auth0.getTokenSilently({
         ignoreCache: true,
-        verboseResponse: true
+        detailedResponse: true
       });
 
       // No refresh_token included here, or oauthTokenScope
@@ -1669,7 +1669,7 @@ describe('Auth0Client', () => {
       });
     });
 
-    it('returns the full token response with scopes when returnMode = "verbose"', async () => {
+    it('returns the full token response with scopes when "detailedResponse: true"', async () => {
       const auth0 = setup();
 
       await loginWithRedirect(auth0);
@@ -1686,7 +1686,7 @@ describe('Auth0Client', () => {
 
       const response = await auth0.getTokenSilently({
         ignoreCache: true,
-        verboseResponse: true
+        detailedResponse: true
       });
 
       // No refresh_token included here, or oauthTokenScope
@@ -1698,7 +1698,7 @@ describe('Auth0Client', () => {
       });
     });
 
-    it('returns the full response when returnMode = "verbose" and using cache', async () => {
+    it('returns the full response when "detailedReponse: true" and using cache', async () => {
       const auth0 = setup();
 
       await loginWithRedirect(auth0);
@@ -1710,7 +1710,7 @@ describe('Auth0Client', () => {
         });
 
       const response = await auth0.getTokenSilently({
-        verboseResponse: true
+        detailedResponse: true
       });
 
       // No refresh_token included here, or oauthTokenScope
@@ -1723,7 +1723,7 @@ describe('Auth0Client', () => {
       expect(runIframeSpy).not.toHaveBeenCalled();
     });
 
-    it('returns the full response with scopes when returnMode = "verbose" and using cache', async () => {
+    it('returns the full response with scopes when "detailedResponse: true" and using cache', async () => {
       const auth0 = setup({
         scope: 'read:messages write:messages'
       });
@@ -1768,7 +1768,7 @@ describe('Auth0Client', () => {
       // Get a full response from the cache - should return
       // oauthTokenScope in the scope property
       const response = await auth0.getTokenSilently({
-        verboseResponse: true,
+        detailedResponse: true,
         scope: 'read:messages'
       });
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1608,13 +1608,6 @@ describe('Auth0Client', () => {
       mockFetch.mockReset();
       jest.spyOn(auth0, 'logout');
 
-      const utilSpy = jest.spyOn(utils, 'runIframe').mockRejectedValue(
-        GenericError.fromPayload({
-          error: 'login_required',
-          error_description: 'login_required'
-        })
-      );
-
       await expect(
         auth0.getTokenSilently({ ignoreCache: true })
       ).rejects.toThrow('login_required');

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -728,15 +728,27 @@ export default class Auth0Client {
     }
   }
 
+  /**
+   * Fetches a new access token and returns the response from the /oauth/token endpoint, omitting the refresh token.
+   *
+   * @param options
+   */
   public async getTokenSilently(
     options: GetTokenSilentlyOptions & { verboseResponse: true }
   ): Promise<GetTokenSilentlyVerboseResponse>;
 
+  /**
+   * Fetches a new access token and returns it.
+   *
+   * @param options
+   */
   public async getTokenSilently(
     options?: GetTokenSilentlyOptions
   ): Promise<string>;
 
   /**
+   * Fetches a new access token, and either returns just the access token (the default) or the response from the /oauth/token endpoint, depending on the `verboseResponse` option.
+   *
    * ```js
    * const token = await auth0.getTokenSilently(options);
    * ```

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -732,7 +732,7 @@ export default class Auth0Client {
    * @param options
    */
   public async getTokenSilently(
-    options: GetTokenSilentlyOptions & { verboseResponse: true }
+    options: GetTokenSilentlyOptions & { detailedResponse: true }
   ): Promise<GetTokenSilentlyVerboseResponse>;
 
   /**
@@ -745,7 +745,7 @@ export default class Auth0Client {
   ): Promise<string>;
 
   /**
-   * Fetches a new access token, and either returns just the access token (the default) or the response from the /oauth/token endpoint, depending on the `verboseResponse` option.
+   * Fetches a new access token, and either returns just the access token (the default) or the response from the /oauth/token endpoint, depending on the `detailedResponse` option.
    *
    * ```js
    * const token = await auth0.getTokenSilently(options);
@@ -808,7 +808,7 @@ export default class Auth0Client {
       );
 
       if (entry && entry.access_token) {
-        if (options.verboseResponse) {
+        if (options.detailedResponse) {
           const { id_token, access_token, oauthTokenScope, expires_in } = entry;
 
           return {
@@ -857,9 +857,13 @@ export default class Auth0Client {
           daysUntilExpire: this.sessionCheckExpiryDays
         });
 
-        if (options.verboseResponse) {
-          const { id_token, access_token, oauthTokenScope, expires_in } =
-            authResult;
+        if (options.detailedResponse) {
+          const {
+            id_token,
+            access_token,
+            oauthTokenScope,
+            expires_in
+          } = authResult;
 
           return {
             id_token,
@@ -1134,8 +1138,13 @@ export default class Auth0Client {
 
     let tokenResult: TokenEndpointResponse;
 
-    const { scope, audience, ignoreCache, timeoutInSeconds, ...customOptions } =
-      options;
+    const {
+      scope,
+      audience,
+      ignoreCache,
+      timeoutInSeconds,
+      ...customOptions
+    } = options;
 
     const timeout =
       typeof options.timeoutInSeconds === 'number'

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -670,8 +670,7 @@ export default class Auth0Client {
       decodedToken,
       audience: transaction.audience,
       scope: transaction.scope,
-      client_id: this.options.client_id,
-      ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null)
+      client_id: this.options.client_id
     });
 
     this.cookieStorage.save(this.isAuthenticatedCookieName, true, {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -22,8 +22,7 @@ import {
   ICache,
   LocalStorageCache,
   CacheKey,
-  CacheManager,
-  CacheEntry
+  CacheManager
 } from './cache';
 
 import TransactionManager from './transaction-manager';

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,15 +1,7 @@
-import { TokenEndpointOptions } from './global';
+import { TokenEndpointOptions, TokenEndpointResponse } from './global';
 import { DEFAULT_AUTH0_CLIENT } from './constants';
 import { getJSON } from './http';
 import { createQueryParams } from './utils';
-
-export type TokenEndpointResponse = {
-  id_token: string;
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number;
-  scope?: string;
-};
 
 export async function oauthToken(
   {

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -68,6 +68,7 @@ export type CacheEntry = {
   scope: string;
   client_id: string;
   refresh_token?: string;
+  oauthTokenScope?: string;
 };
 
 export type WrappedCacheEntry = {

--- a/src/global.ts
+++ b/src/global.ts
@@ -338,6 +338,8 @@ export interface GetTokenSilentlyOptions {
    */
   timeoutInSeconds?: number;
 
+  verboseResponse?: boolean;
+
   /**
    * If you need to send custom parameters to the Authorization Server,
    * make sure to use the original parameter name.
@@ -452,6 +454,17 @@ export interface TokenEndpointOptions {
 /**
  * @ignore
  */
+export type TokenEndpointResponse = {
+  id_token: string;
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+};
+
+/**
+ * @ignore
+ */
 export interface OAuthTokenOptions extends TokenEndpointOptions {
   code_verifier: string;
   code: string;
@@ -558,3 +571,8 @@ export type FetchOptions = {
   body?: string;
   signal?: AbortSignal;
 };
+
+export type GetTokenSilentlyVerboseResponse = Omit<
+  Partial<TokenEndpointResponse>,
+  'refresh_token'
+>;

--- a/src/global.ts
+++ b/src/global.ts
@@ -344,7 +344,7 @@ export interface GetTokenSilentlyOptions {
    *
    * The default is `false`.
    */
-  verboseResponse?: boolean;
+  detailedResponse?: boolean;
 
   /**
    * If you need to send custom parameters to the Authorization Server,

--- a/src/global.ts
+++ b/src/global.ts
@@ -338,6 +338,12 @@ export interface GetTokenSilentlyOptions {
    */
   timeoutInSeconds?: number;
 
+  /**
+   * If true, the full response from the /oauth/token endpoint (or the cache, if the cache was used) is returned
+   * (minus `refresh_token` if one was issued). Otherwise, just the access token is returned.
+   *
+   * The default is `false`.
+   */
   verboseResponse?: boolean;
 
   /**


### PR DESCRIPTION
### Description

This PR adds a new option that allows the developer to get access to the response from the /oauth/token endpoint rather than just the access token when calling `getTokenSilently`.

```js
await auth0.getTokenSilently({ detailedResponse: true });
```

The response is returned with a couple of caveats:

- `refresh_token` is removed
- `scope` returns the scope as returned by `/oauth/token` and does not try to populate it based on the `Auth0Client` configuration

In the case where there was a cache hit and `ignoreCache` is `false`, the properties that would appear in the token endpoint response are extracted (minus `refresh_token`) and the scope is taken from a new cache property `oauthTokenScope`, which stores the scope as returned by `/oauth/token`.

However, this will continue to return `undefined` until the user performs an operation that causes the token endpoint to return different scopes to what was asked, and we don't yet allow the developer to de-scope an access token, so I'm not sure this is a real issue.

### References

Closes #715

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
