### PR TITLE
Revert 'Ensure getTokenWithPopup uses the cache '

### DIFF
--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -2,7 +2,6 @@ import {
   Auth0ClientOptions,
   AuthenticationResult,
   GetTokenSilentlyOptions,
-  GetTokenWithPopupOptions,
   IdToken,
   PopupConfigOptions,
   PopupLoginOptions,
@@ -360,73 +359,5 @@ export const getTokenSilentlyFn = (mockWindow, mockFetch) => {
     );
 
     return await auth0.getTokenSilently(options);
-  };
-};
-
-const processDefaultGetTokenWithPopupOptions = config => {
-  const defaultResponseOptions = {
-    success: true,
-    response: {}
-  };
-  const defaultAuthorizeResponseOptions = {
-    response: authorizationResponse
-  };
-
-  const token = {
-    ...defaultResponseOptions,
-    ...(config.token || {})
-  };
-
-  const authorize = {
-    ...defaultAuthorizeResponseOptions,
-    ...(config.authorize || {})
-  };
-
-  const delay = config.delay || 0;
-
-  return {
-    token,
-    authorize,
-    delay
-  };
-};
-
-export const getTokenWithPopupFn = (mockWindow, mockFetch) => {
-  return async (
-    auth0,
-    options: GetTokenWithPopupOptions = undefined,
-    testConfig: {
-      token?: {
-        success?: boolean;
-        response?: any;
-      };
-    } = {
-      token: {}
-    }
-  ) => {
-    const {
-      token,
-      authorize: { response },
-      delay
-    } = processDefaultGetTokenWithPopupOptions(testConfig);
-
-    setupMessageEventLister(mockWindow, response, delay);
-
-    mockFetch.mockResolvedValueOnce(
-      fetchResponse(
-        token.success,
-        Object.assign(
-          {
-            id_token: TEST_ID_TOKEN,
-            refresh_token: TEST_REFRESH_TOKEN,
-            access_token: TEST_ACCESS_TOKEN,
-            expires_in: 86400
-          },
-          token.response
-        )
-      )
-    );
-
-    return await auth0.getTokenWithPopup(options);
   };
 };


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR reverts the feature that adds cache support for `getTokenWithPopup`. We are reverting this for two reasons:

- As the name suggests, it's expected to be an interactive operation and so should show a popup by default. Those wanting to get a token silently should use `getTokenSilently`.
- It's a change in behaviour for those using `getTokenWithPopup` from what they expect using the library today. We could change behaviour so that `ignoreCache` is `true` by default but this creates a behaviour inconsistent with how `getTokenSilently` works

This revert creates no impact for customers today as the feature has not yet been published in a release.

### References

Original PR and issue: #801

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
