### PR TITLE
Release 1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Change Log
 
+## [v1.19.1](https://github.com/auth0/auth0-spa-js/tree/v1.19.1) (2021-10-14)
+
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.19.0...v1.19.1)
+
+Republished version `1.19.0`, which got published during a period npm was suffering downtime issues, resulting in `1.19.0` being released but not installable for end users. Users should install `1.19.1` instead.
+
 ## [v1.19.0](https://github.com/auth0/auth0-spa-js/tree/v1.19.0) (2021-10-11)
+
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.18.0...v1.19.0)
 
 **Added**
+
 - [SDK-2794] Return token response in getTokenSilently [\#803](https://github.com/auth0/auth0-spa-js/pull/803) ([stevehobbsdev](https://github.com/stevehobbsdev))
 - [SDK-2793] Ability to define a custom now provider [\#802](https://github.com/auth0/auth0-spa-js/pull/802) ([frederikprijck](https://github.com/frederikprijck))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.19.0';
+export default '1.19.1';


### PR DESCRIPTION
Republished version `1.19.0`, which got published during a period npm was suffering downtime issues, resulting in `1.19.0` being released but not installable for end users. Users should install `1.19.1` instead.