### PR TITLE
GetTokenSilentlyVerboseResponse no longer uses partial TokenEndpointResponse type

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -593,6 +593,6 @@ export type FetchOptions = {
 };
 
 export type GetTokenSilentlyVerboseResponse = Omit<
-  Partial<TokenEndpointResponse>,
+  TokenEndpointResponse,
   'refresh_token'
 >;


### PR DESCRIPTION
`GetTokenSilentlyVerboseResponse` doesn't require a partial `TokenEndpointResponse`, as it should really just be the same as `TokenEndpointResponse` but without the refresh token. However, this change eases some upstream challenges in SDKs like `auth0-angular` and `auth0-react`.

We don't believe this to be a breaking change.
