### PR TITLE
Release v1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v1.19.2](https://github.com/auth0/auth0-spa-js/tree/v1.19.2) (2021-10-18)
+
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.19.1...v1.19.2)
+
+This release fixes an anomoly with a new type we exposed in [\#803](https://github.com/auth0/auth0-spa-js/pull/820), where it was incorrectly wrapped with `Partial`. We don't expect this change to introduce any issues, but if you are affected please [raise it on our issue tracker](https://github.com/auth0/auth0-spa-js/issues).
+
+**Fixed**
+
+- GetTokenSilentlyVerboseResponse no longer uses partial TokenEndpointResponse type [\#820](https://github.com/auth0/auth0-spa-js/pull/820) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [v1.19.1](https://github.com/auth0/auth0-spa-js/tree/v1.19.1) (2021-10-14)
 
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.19.0...v1.19.1)

--- a/docs/classes/auth0client.html
+++ b/docs/classes/auth0client.html
@@ -2834,7 +2834,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L205">src/Auth0Client.ts:205</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L205">src/Auth0Client.ts:205</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2856,7 +2856,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L204">src/Auth0Client.ts:204</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L204">src/Auth0Client.ts:204</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2873,7 +2873,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L390">src/Auth0Client.ts:390</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L390">src/Auth0Client.ts:390</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2907,7 +2907,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L947">src/Auth0Client.ts:947</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L947">src/Auth0Client.ts:947</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2939,7 +2939,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L714">src/Auth0Client.ts:714</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L714">src/Auth0Client.ts:714</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2979,7 +2979,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L580">src/Auth0Client.ts:580</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L580">src/Auth0Client.ts:580</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3015,7 +3015,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L742">src/Auth0Client.ts:742</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L742">src/Auth0Client.ts:742</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3054,7 +3054,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L751">src/Auth0Client.ts:751</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L751">src/Auth0Client.ts:751</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3102,7 +3102,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L895">src/Auth0Client.ts:895</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L895">src/Auth0Client.ts:895</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3140,7 +3140,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L550">src/Auth0Client.ts:550</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L550">src/Auth0Client.ts:550</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3185,7 +3185,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L620">src/Auth0Client.ts:620</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L620">src/Auth0Client.ts:620</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3216,7 +3216,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L934">src/Auth0Client.ts:934</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L934">src/Auth0Client.ts:934</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3241,7 +3241,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L449">src/Auth0Client.ts:449</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L449">src/Auth0Client.ts:449</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3288,7 +3288,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L608">src/Auth0Client.ts:608</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L608">src/Auth0Client.ts:608</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3322,7 +3322,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/Auth0Client.ts#L979">src/Auth0Client.ts:979</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/Auth0Client.ts#L979">src/Auth0Client.ts:979</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/authenticationerror.html
+++ b/docs/classes/authenticationerror.html
@@ -2821,7 +2821,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L31">src/errors.ts:31</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L31">src/errors.ts:31</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2852,7 +2852,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L37">src/errors.ts:37</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L37">src/errors.ts:37</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2863,7 +2863,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2874,7 +2874,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L36">src/errors.ts:36</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L36">src/errors.ts:36</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2935,7 +2935,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cachekey.html
+++ b/docs/classes/cachekey.html
@@ -2803,7 +2803,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2828,7 +2828,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2838,7 +2838,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L12">src/cache/shared.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L12">src/cache/shared.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2848,7 +2848,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L16">src/cache/shared.ts:16</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L16">src/cache/shared.ts:16</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2858,7 +2858,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L13">src/cache/shared.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L13">src/cache/shared.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2875,7 +2875,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L26">src/cache/shared.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L26">src/cache/shared.ts:26</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2898,7 +2898,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L46">src/cache/shared.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L46">src/cache/shared.ts:46</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2930,7 +2930,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L35">src/cache/shared.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L35">src/cache/shared.ts:35</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/cachekeymanifest.html
+++ b/docs/classes/cachekeymanifest.html
@@ -2786,7 +2786,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/key-manifest.ts#L9">src/cache/key-manifest.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/key-manifest.ts#L9">src/cache/key-manifest.ts:9</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2815,7 +2815,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/key-manifest.ts#L15">src/cache/key-manifest.ts:15</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/key-manifest.ts#L15">src/cache/key-manifest.ts:15</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2838,7 +2838,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/key-manifest.ts#L46">src/cache/key-manifest.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/key-manifest.ts#L46">src/cache/key-manifest.ts:46</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2855,7 +2855,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/key-manifest.ts#L42">src/cache/key-manifest.ts:42</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/key-manifest.ts#L42">src/cache/key-manifest.ts:42</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><a href="../globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2872,7 +2872,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/key-manifest.ts#L27">src/cache/key-manifest.ts:27</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/key-manifest.ts#L27">src/cache/key-manifest.ts:27</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cachemanager.html
+++ b/docs/classes/cachemanager.html
@@ -2786,7 +2786,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L14">src/cache/cache-manager.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L14">src/cache/cache-manager.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2830,7 +2830,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L80">src/cache/cache-manager.ts:80</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L80">src/cache/cache-manager.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2853,7 +2853,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L99">src/cache/cache-manager.ts:99</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L99">src/cache/cache-manager.ts:99</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2881,7 +2881,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L23">src/cache/cache-manager.ts:23</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L23">src/cache/cache-manager.ts:23</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2907,7 +2907,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L67">src/cache/cache-manager.ts:67</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L67">src/cache/cache-manager.ts:67</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/genericerror.html
+++ b/docs/classes/genericerror.html
@@ -2829,7 +2829,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L9">src/errors.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L9">src/errors.ts:9</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2854,7 +2854,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2864,7 +2864,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error_<wbr>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2925,7 +2925,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/inmemorycache.html
+++ b/docs/classes/inmemorycache.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">enclosed<wbr>Cache<span class="tsd-signature-symbol">:</span> <a href="../interfaces/icache.html" class="tsd-signature-type">ICache</a><span class="tsd-signature-symbol"> = (function () {let cache: Record&lt;string, unknown&gt; &#x3D; {};return {set&lt;T &#x3D; Cacheable&gt;(key: string, entry: T) {cache[key] &#x3D; entry;},get&lt;T &#x3D; Cacheable&gt;(key: string) {const cacheEntry &#x3D; cache[key] as T;if (!cacheEntry) {return;}return cacheEntry;},remove(key: string) {delete cache[key];},allKeys(): string[] {return Object.keys(cache);}};})()</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-memory.ts#L4">src/cache/cache-memory.ts:4</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-memory.ts#L4">src/cache/cache-memory.ts:4</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/classes/localstoragecache.html
+++ b/docs/classes/localstoragecache.html
@@ -2784,7 +2784,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#allkeys">allKeys</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-localstorage.ts#L26">src/cache/cache-localstorage.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-localstorage.ts#L26">src/cache/cache-localstorage.ts:26</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -2802,7 +2802,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#get">get</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-localstorage.ts#L8">src/cache/cache-localstorage.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-localstorage.ts#L8">src/cache/cache-localstorage.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2832,7 +2832,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#remove">remove</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-localstorage.ts#L22">src/cache/cache-localstorage.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-localstorage.ts#L22">src/cache/cache-localstorage.ts:22</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2856,7 +2856,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#set">set</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-localstorage.ts#L4">src/cache/cache-localstorage.ts:4</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-localstorage.ts#L4">src/cache/cache-localstorage.ts:4</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/mfarequirederror.html
+++ b/docs/classes/mfarequirederror.html
@@ -2816,7 +2816,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L82">src/errors.ts:82</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L82">src/errors.ts:82</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2845,7 +2845,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2856,7 +2856,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2877,7 +2877,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">mfa_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L87">src/errors.ts:87</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L87">src/errors.ts:87</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popupcancellederror.html
+++ b/docs/classes/popupcancellederror.html
@@ -2809,7 +2809,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L70">src/errors.ts:70</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L70">src/errors.ts:70</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2832,7 +2832,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2843,7 +2843,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2875,7 +2875,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L72">src/errors.ts:72</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L72">src/errors.ts:72</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2904,7 +2904,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popuptimeouterror.html
+++ b/docs/classes/popuptimeouterror.html
@@ -2816,7 +2816,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="timeouterror.html">TimeoutError</a>.<a href="timeouterror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L61">src/errors.ts:61</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L61">src/errors.ts:61</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2839,7 +2839,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2850,7 +2850,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2882,7 +2882,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L63">src/errors.ts:63</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L63">src/errors.ts:63</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2911,7 +2911,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/timeouterror.html
+++ b/docs/classes/timeouterror.html
@@ -2818,7 +2818,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L49">src/errors.ts:49</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L49">src/errors.ts:49</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="timeouterror.html" class="tsd-signature-type">TimeoutError</a></h4>
@@ -2835,7 +2835,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2846,7 +2846,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2897,7 +2897,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/user.html
+++ b/docs/classes/user.html
@@ -2841,7 +2841,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L578">src/global.ts:578</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L578">src/global.ts:578</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2851,7 +2851,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">birthdate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L573">src/global.ts:573</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L573">src/global.ts:573</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2861,7 +2861,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L570">src/global.ts:570</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L570">src/global.ts:570</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2871,7 +2871,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L571">src/global.ts:571</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L571">src/global.ts:571</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2881,7 +2881,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">family_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L563">src/global.ts:563</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L563">src/global.ts:563</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2891,7 +2891,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">gender<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L572">src/global.ts:572</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L572">src/global.ts:572</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2901,7 +2901,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">given_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L562">src/global.ts:562</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L562">src/global.ts:562</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2911,7 +2911,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L575">src/global.ts:575</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L575">src/global.ts:575</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2921,7 +2921,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">middle_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L564">src/global.ts:564</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L564">src/global.ts:564</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2931,7 +2931,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L561">src/global.ts:561</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L561">src/global.ts:561</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2941,7 +2941,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">nickname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L565">src/global.ts:565</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L565">src/global.ts:565</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2951,7 +2951,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L576">src/global.ts:576</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L576">src/global.ts:576</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2961,7 +2961,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L577">src/global.ts:577</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L577">src/global.ts:577</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2971,7 +2971,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L568">src/global.ts:568</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L568">src/global.ts:568</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2981,7 +2981,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">preferred_<wbr>username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L566">src/global.ts:566</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L566">src/global.ts:566</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2991,7 +2991,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">profile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L567">src/global.ts:567</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L567">src/global.ts:567</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3001,7 +3001,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">sub<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L580">src/global.ts:580</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L580">src/global.ts:580</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3011,7 +3011,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">updated_<wbr>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L579">src/global.ts:579</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L579">src/global.ts:579</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3021,7 +3021,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">website<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L569">src/global.ts:569</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L569">src/global.ts:569</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3031,7 +3031,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">zoneinfo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L574">src/global.ts:574</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L574">src/global.ts:574</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -3324,7 +3324,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>access_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>decodedToken<span class="tsd-signature-symbol">: </span><a href="interfaces/decodedtoken.html" class="tsd-signature-type">DecodedToken</a><span class="tsd-signature-symbol">; </span>expires_in<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>id_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>oauthTokenScope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>refresh_token<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3366,7 +3366,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Key<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3390,7 +3390,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L227">src/global.ts:227</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L227">src/global.ts:227</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3405,17 +3405,17 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cacheable<span class="tsd-signature-symbol">:</span> <a href="globals.html#wrappedcacheentry" class="tsd-signature-type">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
 					</ul>
 				</aside>
 			</section>
 			<section class="tsd-panel tsd-member tsd-kind-type-alias">
 				<a name="gettokensilentlyverboseresponse" class="tsd-anchor"></a>
 				<h3>Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response</h3>
-				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
+				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L595">src/global.ts:595</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L595">src/global.ts:595</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3425,7 +3425,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Key<wbr>Manifest<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3443,7 +3443,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Maybe<wbr>Promise&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">T</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
 					</ul>
 				</aside>
 				<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3459,7 +3459,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Wrapped<wbr>Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="globals.html#cacheentry" class="tsd-signature-type">CacheEntry</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>expiresAt<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3480,7 +3480,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L314">src/global.ts:314</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L314">src/global.ts:314</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3493,7 +3493,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>KEY_<wbr>PREFIX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@auth0spajs@@"</span><span class="tsd-signature-symbol"> = &quot;@@auth0spajs@@&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3503,7 +3503,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3513,7 +3513,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3523,7 +3523,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>EXPIRY_<wbr>ADJUSTMENT_<wbr>SECONDS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3540,7 +3540,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/constants.ts#L80">src/constants.ts:80</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/constants.ts#L80">src/constants.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -3557,7 +3557,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/index.ts#L19">src/index.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/index.ts#L19">src/index.ts:19</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3325,7 +3325,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>access_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>decodedToken<span class="tsd-signature-symbol">: </span><a href="interfaces/decodedtoken.html" class="tsd-signature-type">DecodedToken</a><span class="tsd-signature-symbol">; </span>expires_in<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>id_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>oauthTokenScope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>refresh_token<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3367,7 +3367,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Key<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3391,7 +3391,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L227">src/global.ts:227</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L227">src/global.ts:227</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3406,17 +3406,17 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cacheable<span class="tsd-signature-symbol">:</span> <a href="globals.html#wrappedcacheentry" class="tsd-signature-type">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
 					</ul>
 				</aside>
 			</section>
 			<section class="tsd-panel tsd-member tsd-kind-type-alias">
 				<a name="gettokensilentlyverboseresponse" class="tsd-anchor"></a>
 				<h3>Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response</h3>
-				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
+				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L595">src/global.ts:595</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L595">src/global.ts:595</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3426,7 +3426,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Key<wbr>Manifest<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3444,7 +3444,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Maybe<wbr>Promise&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">T</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
 					</ul>
 				</aside>
 				<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3460,7 +3460,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Wrapped<wbr>Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="globals.html#cacheentry" class="tsd-signature-type">CacheEntry</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>expiresAt<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3481,7 +3481,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L314">src/global.ts:314</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L314">src/global.ts:314</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3494,7 +3494,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>KEY_<wbr>PREFIX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@auth0spajs@@"</span><span class="tsd-signature-symbol"> = &quot;@@auth0spajs@@&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3504,7 +3504,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3514,7 +3514,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3524,7 +3524,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>EXPIRY_<wbr>ADJUSTMENT_<wbr>SECONDS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3541,7 +3541,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/constants.ts#L80">src/constants.ts:80</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/constants.ts#L80">src/constants.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -3558,7 +3558,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/index.ts#L19">src/index.ts:19</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/index.ts#L19">src/index.ts:19</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/advancedoptions.html
+++ b/docs/interfaces/advancedoptions.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">default<wbr>Scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L107">src/global.ts:107</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L107">src/global.ts:107</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/auth0clientoptions.html
+++ b/docs/interfaces/auth0clientoptions.html
@@ -2885,7 +2885,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2895,7 +2895,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">advanced<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="advancedoptions.html" class="tsd-signature-type">AdvancedOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L199">src/global.ts:199</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L199">src/global.ts:199</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2911,7 +2911,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2926,7 +2926,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">authorize<wbr>Timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L165">src/global.ts:165</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L165">src/global.ts:165</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2942,7 +2942,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<span class="tsd-signature-symbol">:</span> <a href="icache.html" class="tsd-signature-type">ICache</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L151">src/global.ts:151</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L151">src/global.ts:151</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2957,7 +2957,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L146">src/global.ts:146</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L146">src/global.ts:146</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2974,7 +2974,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L124">src/global.ts:124</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L124">src/global.ts:124</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2990,7 +2990,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3008,7 +3008,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3028,7 +3028,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L116">src/global.ts:116</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L116">src/global.ts:116</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3046,7 +3046,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3062,7 +3062,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3077,7 +3077,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">issuer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L120">src/global.ts:120</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L120">src/global.ts:120</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3092,7 +3092,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">leeway<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L138">src/global.ts:138</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L138">src/global.ts:138</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3109,7 +3109,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">legacy<wbr>Same<wbr>Site<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L181">src/global.ts:181</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L181">src/global.ts:181</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3130,7 +3130,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3149,7 +3149,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3166,7 +3166,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">now<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L221">src/global.ts:221</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L221">src/global.ts:221</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3198,7 +3198,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3216,7 +3216,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3236,7 +3236,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L132">src/global.ts:132</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L132">src/global.ts:132</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3256,7 +3256,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3274,7 +3274,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3292,7 +3292,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">session<wbr>Check<wbr>Expiry<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L205">src/global.ts:205</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L205">src/global.ts:205</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3309,7 +3309,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3325,7 +3325,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Cookies<wbr>For<wbr>Transactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L194">src/global.ts:194</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L194">src/global.ts:194</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3348,7 +3348,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Form<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L214">src/global.ts:214</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L214">src/global.ts:214</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3366,7 +3366,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Refresh<wbr>Tokens<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L159">src/global.ts:159</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L159">src/global.ts:159</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/decodedtoken.html
+++ b/docs/interfaces/decodedtoken.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">claims<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IdToken</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L58">src/cache/shared.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L58">src/cache/shared.ts:58</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2775,7 +2775,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <a href="../classes/user.html" class="tsd-signature-type">User</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L59">src/cache/shared.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L59">src/cache/shared.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/getidtokenclaimsoptions.html
+++ b/docs/interfaces/getidtokenclaimsoptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L308">src/global.ts:308</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L308">src/global.ts:308</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2780,7 +2780,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L304">src/global.ts:304</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L304">src/global.ts:304</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokensilentlyoptions.html
+++ b/docs/interfaces/gettokensilentlyoptions.html
@@ -2791,7 +2791,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L341">src/global.ts:341</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L341">src/global.ts:341</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2806,7 +2806,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">detailed<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L354">src/global.ts:354</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L354">src/global.ts:354</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2823,7 +2823,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L321">src/global.ts:321</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L321">src/global.ts:321</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2839,7 +2839,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L331">src/global.ts:331</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L331">src/global.ts:331</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2859,7 +2859,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L336">src/global.ts:336</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L336">src/global.ts:336</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L346">src/global.ts:346</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L346">src/global.ts:346</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokenwithpopupoptions.html
+++ b/docs/interfaces/gettokenwithpopupoptions.html
@@ -2829,7 +2829,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2840,7 +2840,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2856,7 +2856,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2895,7 +2895,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2910,7 +2910,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L368">src/global.ts:368</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L368">src/global.ts:368</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2927,7 +2927,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2943,7 +2943,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2980,7 +2980,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2998,7 +2998,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3019,7 +3019,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3037,7 +3037,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3056,7 +3056,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/getuseroptions.html
+++ b/docs/interfaces/getuseroptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L297">src/global.ts:297</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L297">src/global.ts:297</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2780,7 +2780,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L293">src/global.ts:293</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L293">src/global.ts:293</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/icache.html
+++ b/docs/interfaces/icache.html
@@ -2783,7 +2783,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L91">src/cache/shared.ts:91</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L91">src/cache/shared.ts:91</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2800,7 +2800,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L89">src/cache/shared.ts:89</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L89">src/cache/shared.ts:89</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2829,7 +2829,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L90">src/cache/shared.ts:90</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L90">src/cache/shared.ts:90</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2852,7 +2852,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/cache/shared.ts#L88">src/cache/shared.ts:88</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/cache/shared.ts#L88">src/cache/shared.ts:88</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/interfaces/logoutoptions.html
+++ b/docs/interfaces/logoutoptions.html
@@ -2773,7 +2773,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L430">src/global.ts:430</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L430">src/global.ts:430</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2791,7 +2791,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L439">src/global.ts:439</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L439">src/global.ts:439</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2810,7 +2810,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">local<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L447">src/global.ts:447</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L447">src/global.ts:447</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2828,7 +2828,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L419">src/global.ts:419</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L419">src/global.ts:419</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logouturloptions.html
+++ b/docs/interfaces/logouturloptions.html
@@ -2769,7 +2769,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L395">src/global.ts:395</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L395">src/global.ts:395</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2787,7 +2787,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L403">src/global.ts:403</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L403">src/global.ts:403</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2805,7 +2805,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L384">src/global.ts:384</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L384">src/global.ts:384</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popupconfigoptions.html
+++ b/docs/interfaces/popupconfigoptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L286">src/global.ts:286</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L286">src/global.ts:286</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2782,7 +2782,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L279">src/global.ts:279</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L279">src/global.ts:279</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popuploginoptions.html
+++ b/docs/interfaces/popuploginoptions.html
@@ -2830,7 +2830,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2841,7 +2841,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2857,7 +2857,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2875,7 +2875,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2896,7 +2896,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2912,7 +2912,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2928,7 +2928,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2947,7 +2947,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2965,7 +2965,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2983,7 +2983,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3004,7 +3004,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3022,7 +3022,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2841,7 +2841,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2851,7 +2851,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L254">src/global.ts:254</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L254">src/global.ts:254</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2867,7 +2867,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2883,7 +2883,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2901,7 +2901,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2921,7 +2921,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">fragment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L258">src/global.ts:258</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L258">src/global.ts:258</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2937,7 +2937,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2953,7 +2953,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2969,7 +2969,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2988,7 +2988,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3006,7 +3006,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3024,7 +3024,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3044,7 +3044,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect<wbr>Method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"replace"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"assign"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L262">src/global.ts:262</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L262">src/global.ts:262</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3059,7 +3059,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L250">src/global.ts:250</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L250">src/global.ts:250</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3078,7 +3078,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3096,7 +3096,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3115,7 +3115,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginresult.html
+++ b/docs/interfaces/redirectloginresult.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/59017f3/src/global.ts#L269">src/global.ts:269</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/3ec6763/src/global.ts#L269">src/global.ts:269</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.19.1';
+export default '1.19.2';


### PR DESCRIPTION

**Fixed**
- GetTokenSilentlyVerboseResponse no longer uses partial TokenEndpointResponse type [\#820](https://github.com/auth0/auth0-spa-js/pull/820) ([stevehobbsdev](https://github.com/stevehobbsdev))
