### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->
+
 ### Changes
 
 <!--


### PR DESCRIPTION
Borrowed from [Lock](https://github.com/auth0/lock/blob/master/.github/PULL_REQUEST_TEMPLATE.md).

I prefer this one as it uses HTML comments for the user instructions, as opposed to the organization one which does not.