### PR TITLE
Add documentation for checkSession usage in private tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9516,17 +9516,12 @@
           "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
           "dev": true
         },
-        "paseto2": {
-          "version": "npm:paseto@2.1.3",
-          "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
-          "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
-          "dev": true
-        },
         "paseto3": {
           "version": "npm:paseto@3.1.0",
           "resolved": "https://registry.npmjs.org/paseto/-/paseto-3.1.0.tgz",
           "integrity": "sha512-oVSKoCH89M0WU3I+13NoCP9wGRel0BlQumwxsDZPk1yJtqS76PWKRM7vM9D4bz4PcScT0aIiAipC7lW6hSgkBQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9693,6 +9688,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
+    "paseto2": {
+      "version": "npm:paseto@2.1.3",
+      "resolved": "https://registry.npmjs.org/paseto/-/paseto-2.1.3.tgz",
+      "integrity": "sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==",
       "dev": true
     },
     "path-exists": {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -711,6 +711,12 @@ export default class Auth0Client {
    * `Auth0Client` constructor. You should not need this if you are using the
    * `createAuth0Client` factory.
    *
+   * **Note:** the cookie **may not** be present if running an app using a private tab, as some
+   * browsers clear JS cookie data and local storage when the tab or page is closed, or on page reload. This effectively
+   * means that `checkSession` could silently return without authenticating the user on page refresh when
+   * using a private tab, despite having previously logged in. As a workaround, use `getTokenSilently` instead
+   * and handle the possible `login_required` error [as shown in the readme](https://github.com/auth0/auth0-spa-js#creating-the-client).
+   *
    * @param options
    */
   public async checkSession(options?: GetTokenSilentlyOptions) {
@@ -858,12 +864,8 @@ export default class Auth0Client {
         });
 
         if (options.detailedResponse) {
-          const {
-            id_token,
-            access_token,
-            oauthTokenScope,
-            expires_in
-          } = authResult;
+          const { id_token, access_token, oauthTokenScope, expires_in } =
+            authResult;
 
           return {
             id_token,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import './global';
 export * from './global';
 
 /**
- * Asyncronously creates the Auth0Client instance and calls `checkSession`.
+ * Asynchronously creates the Auth0Client instance and calls `checkSession`.
  *
  * **Note:** There are caveats to using this in a private browser tab, which may not silently authenticae
  * a user on page refresh. Please see [the checkSession docs](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#checksession) for more info.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,15 @@ import './global';
 
 export * from './global';
 
+/**
+ * Asyncronously creates the Auth0Client instance and calls `checkSession`.
+ *
+ * **Note:** There are caveats to using this in a private browser tab, which may not silently authenticae
+ * a user on page refresh. Please see [the checkSession docs](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#checksession) for more info.
+ *
+ * @param options The client options
+ * @returns An instance of Auth0Client
+ */
 export default async function createAuth0Client(options: Auth0ClientOptions) {
   const auth0 = new Auth0Client(options);
   await auth0.checkSession();


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

This adds some docs around usage of `checkSession` and `createAuth0Client` inside a private browser tab, which may not silently
authenticate a user on page reload thanks to the `is.authenticated` cookie being removed.

Also, ran `npm audit fix`.

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

### References

Fixes #819

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
