### PR TITLE
Prevent nowProvider from being passed to authorize endpoint

### DIFF
--- a/__tests__/Auth0Client/constructor.test.ts
+++ b/__tests__/Auth0Client/constructor.test.ts
@@ -7,7 +7,7 @@ import * as scope from '../../src/scope';
 
 // @ts-ignore
 
-import { loginWithRedirectFn, setupFn } from './helpers';
+import { assertUrlEquals, loginWithRedirectFn, setupFn } from './helpers';
 
 import { TEST_CLIENT_ID, TEST_CODE_CHALLENGE, TEST_DOMAIN } from '../constants';
 import { ICache } from '../../src/cache';
@@ -32,15 +32,6 @@ jest
   .mockReturnValue(TEST_CODE_CHALLENGE);
 
 jest.spyOn(utils, 'runPopup');
-
-const assertUrlEquals = (actualUrl, host, path, queryParams) => {
-  const url = new URL(actualUrl);
-  expect(url.host).toEqual(host);
-  expect(url.pathname).toEqual(path);
-  for (let [key, value] of Object.entries(queryParams)) {
-    expect(url.searchParams.get(key)).toEqual(value);
-  }
-};
 
 const setup = setupFn(mockVerify);
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -146,6 +146,7 @@ describe('Auth0Client', () => {
       const [[url]] = (<jest.Mock>utils.runIframe).mock.calls;
 
       assertUrlEquals(url, 'auth0_domain', '/authorize', {
+        scope: TEST_SCOPES,
         client_id: TEST_CLIENT_ID,
         response_type: 'code',
         response_mode: 'web_message',
@@ -174,9 +175,15 @@ describe('Auth0Client', () => {
 
       const [[url]] = (<jest.Mock>utils.runIframe).mock.calls;
 
-      assertUrlEquals(url, 'auth0_domain', '/authorize', {
-        redirect_uri
-      });
+      assertUrlEquals(
+        url,
+        'auth0_domain',
+        '/authorize',
+        {
+          redirect_uri
+        },
+        false
+      );
     });
 
     it('calls the token endpoint with the correct params', async () => {
@@ -385,9 +392,15 @@ describe('Auth0Client', () => {
       await getTokenSilently(auth0);
 
       const [[url]] = (<jest.Mock>utils.runIframe).mock.calls;
-      assertUrlEquals(url, 'auth0_domain', '/authorize', {
-        scope: 'openid email'
-      });
+      assertUrlEquals(
+        url,
+        'auth0_domain',
+        '/authorize',
+        {
+          scope: 'openid email'
+        },
+        false
+      );
     });
 
     it('refreshes the token using custom default scope when using refresh tokens', async () => {

--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -65,12 +65,21 @@ const itorToObject = <K extends string | number | symbol, V>(
     return m;
   }, {} as Record<K, V>);
 
+/**
+ * Asserts that the supplied URL matches various criteria, including host, path, and query params.
+ * @param actualUrl The URL
+ * @param host The host
+ * @param path The URL path
+ * @param queryParams The query parameters to check
+ * @param strict If true, the query parameters must match the URL parameters exactly. Otherwise, a loose match is performed to check that
+ * the parameters passed in at least appear in the URL (but the URL can have extra ones). Default is true.
+ */
 export const assertUrlEquals = (
   actualUrl: URL | string,
   host: string,
   path: string,
   queryParams: Record<string, string>,
-  strict: boolean = false
+  strict: boolean = true
 ) => {
   const url = new URL(actualUrl);
   const searchParamsObj = itorToObject(url.searchParams.entries());
@@ -79,7 +88,10 @@ export const assertUrlEquals = (
   expect(url.pathname).toEqual(path);
 
   if (strict) {
-    expect(searchParamsObj).toStrictEqual(queryParams);
+    expect(searchParamsObj).toStrictEqual({
+      auth0Client: expect.any(String),
+      ...queryParams
+    });
   } else {
     expect(searchParamsObj).toMatchObject(queryParams);
   }

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -149,10 +149,16 @@ describe('Auth0Client', () => {
       // prettier-ignore
       const url = (utils.runPopup as jest.Mock).mock.calls[0][0].popup.location.href;
 
-      assertUrlEquals(url, 'auth0_domain', '/authorize', {
-        state: TEST_STATE,
-        nonce: TEST_NONCE
-      });
+      assertUrlEquals(
+        url,
+        'auth0_domain',
+        '/authorize',
+        {
+          state: TEST_STATE,
+          nonce: TEST_NONCE
+        },
+        false
+      );
     });
 
     it('creates `code_challenge` by using `utils.sha256` with the result of `utils.createRandomString`', async () => {
@@ -163,10 +169,16 @@ describe('Auth0Client', () => {
       // prettier-ignore
       const url = (utils.runPopup as jest.Mock).mock.calls[0][0].popup.location.href;
 
-      assertUrlEquals(url, 'auth0_domain', '/authorize', {
-        code_challenge: TEST_CODE_CHALLENGE,
-        code_challenge_method: 'S256'
-      });
+      assertUrlEquals(
+        url,
+        'auth0_domain',
+        '/authorize',
+        {
+          code_challenge: TEST_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        },
+        false
+      );
     });
 
     it('should log the user in with a popup and redirect using a default redirect URI', async () => {
@@ -235,9 +247,15 @@ describe('Auth0Client', () => {
       // prettier-ignore
       const url = (utils.runPopup as jest.Mock).mock.calls[0][0].popup.location.href;
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        scope: `${TEST_SCOPES} offline_access`
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          scope: `${TEST_SCOPES} offline_access`
+        },
+        false
+      );
     });
 
     it('should log the user and redirect when using different default redirect_uri', async () => {
@@ -250,9 +268,15 @@ describe('Auth0Client', () => {
       // prettier-ignore
       const url = (utils.runPopup as jest.Mock).mock.calls[0][0].popup.location.href;
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        redirect_uri
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          redirect_uri
+        },
+        false
+      );
     });
 
     it('should log the user in with a popup and get the token', async () => {
@@ -398,9 +422,15 @@ describe('Auth0Client', () => {
       // prettier-ignore
       const url = (utils.runPopup as jest.Mock).mock.calls[0][0].popup.location.href;
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        auth0Client: btoa(JSON.stringify(auth0Client))
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          auth0Client: btoa(JSON.stringify(auth0Client))
+        },
+        false
+      );
     });
 
     it('throws error if state from popup response is different from the provided state', async () => {

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -109,24 +109,17 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(
-        url,
-        TEST_DOMAIN,
-        '/authorize',
-        {
-          auth0Client: expect.any(String),
-          client_id: TEST_CLIENT_ID,
-          redirect_uri: TEST_REDIRECT_URI,
-          scope: TEST_SCOPES,
-          response_type: 'code',
-          response_mode: 'query',
-          state: TEST_STATE,
-          nonce: TEST_NONCE,
-          code_challenge: TEST_CODE_CHALLENGE,
-          code_challenge_method: 'S256'
-        },
-        true // strict mode
-      );
+      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        scope: TEST_SCOPES,
+        response_type: 'code',
+        response_mode: 'query',
+        state: TEST_STATE,
+        nonce: TEST_NONCE,
+        code_challenge: TEST_CODE_CHALLENGE,
+        code_challenge_method: 'S256'
+      });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -159,9 +152,15 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        scope: 'openid email'
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          scope: 'openid email'
+        },
+        false
+      );
     });
 
     it('should log the user in using different default redirect_uri', async () => {
@@ -175,9 +174,15 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        redirect_uri
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          redirect_uri
+        },
+        false
+      );
     });
 
     it('should log the user in when overriding default redirect_uri', async () => {
@@ -193,9 +198,15 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        redirect_uri: 'https://my-redirect-uri/callback'
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          redirect_uri: 'https://my-redirect-uri/callback'
+        },
+        false
+      );
     });
 
     it('should log the user in by calling window.location.replace when redirectMethod=replace param is passed', async () => {
@@ -208,9 +219,15 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.replace.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        audience: 'test_audience'
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          audience: 'test_audience'
+        },
+        false
+      );
     });
 
     it('should log the user in with custom params', async () => {
@@ -222,9 +239,15 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        audience: 'test_audience'
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          audience: 'test_audience'
+        },
+        false
+      );
     });
 
     it('should log the user in using offline_access when using refresh tokens', async () => {
@@ -236,9 +259,15 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        scope: `${TEST_SCOPES} offline_access`
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          scope: `${TEST_SCOPES} offline_access`
+        },
+        false
+      );
     });
 
     it('should log the user in and get the user', async () => {
@@ -482,24 +511,17 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(
-        url,
-        TEST_DOMAIN,
-        '/authorize',
-        {
-          auth0Client: expect.any(String),
-          client_id: TEST_CLIENT_ID,
-          redirect_uri: TEST_REDIRECT_URI,
-          scope: 'openid profile email offline_access',
-          response_type: 'code',
-          response_mode: 'query',
-          state: TEST_STATE,
-          nonce: TEST_NONCE,
-          code_challenge: TEST_CODE_CHALLENGE,
-          code_challenge_method: 'S256'
-        },
-        true // strict mode
-      );
+      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        scope: 'openid profile email offline_access',
+        response_type: 'code',
+        response_mode: 'query',
+        state: TEST_STATE,
+        nonce: TEST_NONCE,
+        code_challenge: TEST_CODE_CHALLENGE,
+        code_challenge_method: 'S256'
+      });
     });
   });
 });

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -109,17 +109,24 @@ describe('Auth0Client', () => {
 
       const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
 
-      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
-        client_id: TEST_CLIENT_ID,
-        redirect_uri: TEST_REDIRECT_URI,
-        scope: TEST_SCOPES,
-        response_type: 'code',
-        response_mode: 'query',
-        state: TEST_STATE,
-        nonce: TEST_NONCE,
-        code_challenge: TEST_CODE_CHALLENGE,
-        code_challenge_method: 'S256'
-      });
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          auth0Client: expect.any(String),
+          client_id: TEST_CLIENT_ID,
+          redirect_uri: TEST_REDIRECT_URI,
+          scope: TEST_SCOPES,
+          response_type: 'code',
+          response_mode: 'query',
+          state: TEST_STATE,
+          nonce: TEST_NONCE,
+          code_challenge: TEST_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        },
+        true // strict mode
+      );
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -451,6 +458,47 @@ describe('Auth0Client', () => {
         {
           expires: 2
         }
+      );
+    });
+
+    it('should not include client options on the URL', async () => {
+      // ** IMPORTANT **: if adding a new client option, ensure it is added to the destructure
+      // list in Auth0Client._getParams so that it is not sent to the IdP
+      const auth0 = setup({
+        useRefreshTokens: true,
+        advancedOptions: {
+          defaultScope: 'openid profile email offline_access'
+        },
+        useCookiesForTransactions: true,
+        authorizeTimeoutInSeconds: 10,
+        cacheLocation: 'localstorage',
+        legacySameSiteCookie: true,
+        nowProvider: () => Date.now(),
+        sessionCheckExpiryDays: 1,
+        useFormData: true
+      });
+
+      await loginWithRedirect(auth0);
+
+      const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
+
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          auth0Client: expect.any(String),
+          client_id: TEST_CLIENT_ID,
+          redirect_uri: TEST_REDIRECT_URI,
+          scope: 'openid profile email offline_access',
+          response_type: 'code',
+          response_mode: 'query',
+          state: TEST_STATE,
+          nonce: TEST_NONCE,
+          code_challenge: TEST_CODE_CHALLENGE,
+          code_challenge_method: 'S256'
+        },
+        true // strict mode
       );
     });
   });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -309,9 +309,10 @@ export default class Auth0Client {
     code_challenge: string,
     redirect_uri: string
   ): AuthorizeOptions {
+    // These options should be excluded from the authorize URL,
+    // as they're options for the client and not for the IdP.
+    // ** IMPORTANT ** If adding a new client option, include it in this destructure list.
     const {
-      domain,
-      leeway,
       useRefreshTokens,
       useCookiesForTransactions,
       useFormData,
@@ -320,11 +321,16 @@ export default class Auth0Client {
       advancedOptions,
       detailedResponse,
       nowProvider,
-      ...withoutClientOptions
+      authorizeTimeoutInSeconds,
+      legacySameSiteCookie,
+      sessionCheckExpiryDays,
+      domain,
+      leeway,
+      ...loginOptions
     } = this.options;
 
     return {
-      ...withoutClientOptions,
+      ...loginOptions,
       ...authorizeOptions,
       scope: getUniqueScopes(
         this.defaultScope,
@@ -340,6 +346,7 @@ export default class Auth0Client {
       code_challenge_method: 'S256'
     };
   }
+
   private _authorizeUrl(authorizeOptions: AuthorizeOptions) {
     return this._url(`/authorize?${createQueryParams(authorizeOptions)}`);
   }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -319,6 +319,7 @@ export default class Auth0Client {
       cacheLocation,
       advancedOptions,
       detailedResponse,
+      nowProvider,
       ...withoutClientOptions
     } = this.options;
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "target": "es6"
   }
 }


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

This PR prevents `nowProvider` from being passed through the URL when logging in. The fundamental change is that `nowProvider` is added to the destructure list in `Auth0Client._getParams`.

In addition, I've attemped to help prevent this in the future by adding a test that includes all the client options and verifying they're not in the URL. Adding this test flagged up a couple other properties that should have been excluded, so these have also been added.

Also did some refactoring in `_getParams` to tidy up the code a bit.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

Fixes #836

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
