### PR TITLE
Make RedirectLoginOptions and RedirectLoginResult accept generic AppState

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -615,7 +615,9 @@ export default class Auth0Client {
    *
    * @param options
    */
-  public async loginWithRedirect(options: RedirectLoginOptions = {}) {
+  public async loginWithRedirect<TAppState = any>(
+    options: RedirectLoginOptions<TAppState> = {}
+  ) {
     const { redirectMethod, ...urlOptions } = options;
     const url = await this.buildAuthorizeUrl(urlOptions);
     window.location[redirectMethod || 'assign'](url);
@@ -627,9 +629,9 @@ export default class Auth0Client {
    * responses from Auth0. If the response is successful, results
    * will be valid according to their expiration times.
    */
-  public async handleRedirectCallback(
+  public async handleRedirectCallback<TAppState = any>(
     url: string = window.location.href
-  ): Promise<RedirectLoginResult> {
+  ): Promise<RedirectLoginResult<TAppState>> {
     const queryStringFragments = url.split('?').slice(1);
 
     if (queryStringFragments.length === 0) {

--- a/src/global.ts
+++ b/src/global.ts
@@ -240,7 +240,8 @@ export interface AuthorizeOptions extends BaseLoginOptions {
   code_challenge_method: string;
 }
 
-export interface RedirectLoginOptions extends BaseLoginOptions {
+export interface RedirectLoginOptions<TAppState = any>
+  extends BaseLoginOptions {
   /**
    * The URL where Auth0 will redirect your browser to with
    * the authentication result. It must be whitelisted in
@@ -251,7 +252,7 @@ export interface RedirectLoginOptions extends BaseLoginOptions {
   /**
    * Used to store state before doing the redirect
    */
-  appState?: any;
+  appState?: TAppState;
   /**
    * Used to add to the URL fragment before redirecting
    */
@@ -262,11 +263,11 @@ export interface RedirectLoginOptions extends BaseLoginOptions {
   redirectMethod?: 'replace' | 'assign';
 }
 
-export interface RedirectLoginResult {
+export interface RedirectLoginResult<TAppState = any> {
   /**
    * State stored when the redirect request was made
    */
-  appState?: any;
+  appState?: TAppState;
 }
 
 export interface PopupLoginOptions extends BaseLoginOptions {}


### PR DESCRIPTION
This SDK uses an `appState` property on both `RedirectLoginOptions` and `RedirectLoginResult`, allowing consumers to put object of `any` type as the appState on login, and get the values back from the transaction.

This PR adds a generic parameter to both `RedirectLoginOptions` and `RedirectLoginResult` so that consumers can specify the type for the `appState` they are using.

For example, the angular sdk uses `{ target: string }` (https://github.com/auth0/auth0-angular/blob/master/projects/auth0-angular/src/lib/auth.service.ts#L305) for the appState to restore the previous route after redirecting, however the users have no type hinting and have no idea that `appState` accepts a `target` property because `appState` is of type any.