### PR TITLE
Org ID hint cookie expiry now aligns with is.authenticated cookie

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1408,13 +1408,17 @@ describe('Auth0Client', () => {
       expect(esCookie.set).toHaveBeenCalledWith(
         `auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
-        {}
+        {
+          expires: 1
+        }
       );
 
       expect(esCookie.set).toHaveBeenCalledWith(
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
-        {}
+        {
+          expires: 1
+        }
       );
     });
 

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -634,13 +634,17 @@ describe('Auth0Client', () => {
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
-        {}
+        {
+          expires: 1
+        }
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
-        {}
+        {
+          expires: 1
+        }
       );
     });
 

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -390,13 +390,17 @@ describe('Auth0Client', () => {
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
-        {}
+        {
+          expires: 1
+        }
       );
 
       expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
-        {}
+        {
+          expires: 1
+        }
       );
     });
 

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -12,7 +12,16 @@ describe('CookieStorage', () => {
     cookieMock = mocked(esCookie);
   });
 
-  it('saves object', () => {
+  it('saves a cookie', () => {
+    const key = 'key';
+    const value = { some: 'value' };
+
+    CookieStorage.save(key, value);
+
+    expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {});
+  });
+
+  it('saves a cookie with options', () => {
     const key = 'key';
     const value = { some: 'value' };
     const options = { daysUntilExpire: 1 };

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -379,7 +379,9 @@ export default class Auth0Client {
 
   private _processOrgIdHint(organizationId?: string) {
     if (organizationId) {
-      this.cookieStorage.save(this.orgHintCookieName, organizationId);
+      this.cookieStorage.save(this.orgHintCookieName, organizationId, {
+        daysUntilExpire: this.sessionCheckExpiryDays
+      });
     } else {
       this.cookieStorage.remove(this.orgHintCookieName);
     }


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

This PR aligns the Org ID hint cookie expiry with that of the `is.authenticated` cookie. This means that if you close the browser window, you shouldn't get a discrepancy where the authenticated hint cookie is there but not the org ID hint cookie. Thus the app should be able to re-log into the organization during `checkSession()` calls.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

Fixes #854

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
