### PR TITLE
clarify documentation comment for getTokenSilently

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -787,11 +787,17 @@ export default class Auth0Client {
    * const token = await auth0.getTokenSilently(options);
    * ```
    *
-   * If there's a valid token stored, return it. Otherwise, opens an
-   * iframe with the `/authorize` URL using the parameters provided
-   * as arguments. Random and secure `state` and `nonce` parameters
-   * will be auto-generated. If the response is successful, results
-   * will be valid according to their expiration times.
+   * If there's a valid token stored and it has more than 60 seconds
+   * remaining before expiration, return the token. Otherwise, attempt 
+   * to obtain a new token. 
+   *
+   * A new token will be obtained eby either opening an iframe or a 
+   * refresh token.
+   
+   * If iframes are used, opens an iframe with the `/authorize` URL 
+   * using the parameters provided as arguments. Random and secure `state` 
+   * and `nonce` parameters will be auto-generated. If the response is successful, 
+   * results will be valid according to their expiration times.
    *
    * If refresh tokens are used, the token endpoint is called directly with the
    * 'refresh_token' grant. If no refresh token is available to make this call,


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

This clarifies the documentation for `getTokenSilently`.  I had to dig through the code a bit to find out
if would try to get a new token before the old one expired. Based on my reading of the code I updated
the docs to explain the behavior more clearly.

### References

There is a comment in the code stating that it will try to get a new token 60 seconds before expiration: https://github.com/auth0/auth0-spa-js/blob/master/src/Auth0Client.ts#L1245


### Testing

This is a documentation only change, so no tests were added or updated.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
