### PR TITLE
#880: Ensure getTokenSilently() handles undefined params correctly

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -378,6 +378,35 @@ describe('Auth0Client', () => {
       expect((http.switchFetch as jest.Mock).mock.calls[0][6]).toEqual(30000);
     });
 
+      it('it correct handles params set as undefined', async () => {
+          const auth0 = setup({
+              useRefreshTokens: true,
+              audience: 'api',
+              scope: TEST_SCOPES
+          });
+
+          await loginWithRedirect(auth0);
+
+          mockFetch.mockReset();
+
+          // @ts-ignore
+          const _getTokenSilently = jest.spyOn(auth0, '_getTokenSilently').mockImplementation(async () => {});
+
+          await getTokenSilently(auth0, {
+              audience: undefined,
+              ignoreCache: undefined,
+              scope: undefined,
+          });
+
+          expect(_getTokenSilently).toHaveBeenCalledWith(
+              expect.objectContaining({
+                  audience: 'api',
+                  ignoreCache: false,
+                  scope: 'openid profile email offline_access',
+              })
+          );
+      });
+
     it('refreshes the token when no cache available', async () => {
       const auth0 = setup();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-spa-js",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -797,15 +797,15 @@ export default class Auth0Client {
    * ```
    *
    * If there's a valid token stored and it has more than 60 seconds
-   * remaining before expiration, return the token. Otherwise, attempt 
-   * to obtain a new token. 
+   * remaining before expiration, return the token. Otherwise, attempt
+   * to obtain a new token.
    *
-   * A new token will be obtained either by opening an iframe or a 
+   * A new token will be obtained either by opening an iframe or a
    * refresh token (if `useRefreshTokens` is `true`)
-   
-   * If iframes are used, opens an iframe with the `/authorize` URL 
-   * using the parameters provided as arguments. Random and secure `state` 
-   * and `nonce` parameters will be auto-generated. If the response is successful, 
+
+   * If iframes are used, opens an iframe with the `/authorize` URL
+   * using the parameters provided as arguments. Random and secure `state`
+   * and `nonce` parameters will be auto-generated. If the response is successful,
    * results will be validated according to their expiration times.
    *
    * If refresh tokens are used, the token endpoint is called directly with the
@@ -826,6 +826,10 @@ export default class Auth0Client {
   public async getTokenSilently(
     options: GetTokenSilentlyOptions = {}
   ): Promise<string | GetTokenSilentlyVerboseResponse> {
+    // Strip any undefined values.
+    Object.keys(options).forEach(key => options[key] === undefined && delete options[key])
+
+    // Combine the configurations.
     const { ignoreCache, ...getTokenOptions } = {
       audience: this.options.audience,
       ignoreCache: false,


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->
Due to the use of destructuring, keys that are set to `undefined` in the `options` param of `getTokenSilently()` avoid the proper defaults being assigned, specifically the `audience`.

This PR ensures removal of undefined values from the `options` param passed to `getTokenSilently()`.

Some thoughts:
- Although I would class the current functionality as "buggy", this change could also be classed as breaking for those relying on the incorrect `audience` being selected.
- Sure there is a better way to test this, but the `call` approach used in the other config tests times out when an audience is set. Suggestions?

### References
closes #880 
<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
