### PR TITLE
Prevent cache.get when key is undefined

### DIFF
--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -34,7 +34,10 @@ export class CacheManager {
       if (!keys) return;
 
       const matchedKey = this.matchExistingCacheKey(cacheKey, keys);
-      wrappedEntry = await this.cache.get<WrappedCacheEntry>(matchedKey);
+
+      if (matchedKey) {
+        wrappedEntry = await this.cache.get<WrappedCacheEntry>(matchedKey);
+      }
     }
 
     // If we still don't have an entry, exit.


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

This PR fixes an issue where the cache manager will still try to call `cache.get` with a key of `undefined`. This scenario could have occured when using a custom cache implementation that returns `[]` from `allKeys`.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

Closes #879

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
