### PR TITLE
FEAT override cookie domain option

### DIFF
--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -24,12 +24,13 @@ describe('CookieStorage', () => {
   it('saves a cookie with options', () => {
     const key = 'key';
     const value = { some: 'value' };
-    const options = { daysUntilExpire: 1 };
+    const options = { daysUntilExpire: 1, cookieDomain: '.example.com' };
 
     CookieStorage.save(key, value, options);
 
     expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {
-      expires: options.daysUntilExpire
+      expires: options.daysUntilExpire,
+      domain: options.cookieDomain
     });
   });
 
@@ -90,12 +91,13 @@ describe('CookieStorageWithLegacySameSite', () => {
   it('saves object', () => {
     const key = 'key';
     const value = { some: 'value' };
-    const options = { daysUntilExpire: 1 };
+    const options = { daysUntilExpire: 1, cookieDomain: '.example.com' };
 
     CookieStorageWithLegacySameSite.save(key, value, options);
 
     expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {
-      expires: options.daysUntilExpire
+      expires: options.daysUntilExpire,
+      domain: options.cookieDomain
     });
 
     expect(cookieMock.set).toHaveBeenCalledWith(

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -546,7 +546,8 @@ export default class Auth0Client {
     await this.cacheManager.set(cacheEntry);
 
     this.cookieStorage.save(this.isAuthenticatedCookieName, true, {
-      daysUntilExpire: this.sessionCheckExpiryDays
+      daysUntilExpire: this.sessionCheckExpiryDays,
+      cookieDomain: this.options.cookieDomain
     });
 
     this._processOrgIdHint(decodedToken.claims.org_id);
@@ -713,7 +714,8 @@ export default class Auth0Client {
     });
 
     this.cookieStorage.save(this.isAuthenticatedCookieName, true, {
-      daysUntilExpire: this.sessionCheckExpiryDays
+      daysUntilExpire: this.sessionCheckExpiryDays,
+      cookieDomain: this.options.cookieDomain
     });
 
     this._processOrgIdHint(decodedToken.claims.org_id);
@@ -755,7 +757,8 @@ export default class Auth0Client {
       } else {
         // Migrate the existing cookie to the new name scoped by client ID
         this.cookieStorage.save(this.isAuthenticatedCookieName, true, {
-          daysUntilExpire: this.sessionCheckExpiryDays
+          daysUntilExpire: this.sessionCheckExpiryDays,
+          cookieDomain: this.options.cookieDomain
         });
 
         this.cookieStorage.remove(OLD_IS_AUTHENTICATED_COOKIE_NAME);
@@ -797,15 +800,15 @@ export default class Auth0Client {
    * ```
    *
    * If there's a valid token stored and it has more than 60 seconds
-   * remaining before expiration, return the token. Otherwise, attempt 
-   * to obtain a new token. 
+   * remaining before expiration, return the token. Otherwise, attempt
+   * to obtain a new token.
    *
-   * A new token will be obtained either by opening an iframe or a 
+   * A new token will be obtained either by opening an iframe or a
    * refresh token (if `useRefreshTokens` is `true`)
-   
-   * If iframes are used, opens an iframe with the `/authorize` URL 
-   * using the parameters provided as arguments. Random and secure `state` 
-   * and `nonce` parameters will be auto-generated. If the response is successful, 
+
+   * If iframes are used, opens an iframe with the `/authorize` URL
+   * using the parameters provided as arguments. Random and secure `state`
+   * and `nonce` parameters will be auto-generated. If the response is successful,
    * results will be validated according to their expiration times.
    *
    * If refresh tokens are used, the token endpoint is called directly with the
@@ -895,7 +898,8 @@ export default class Auth0Client {
         });
 
         this.cookieStorage.save(this.isAuthenticatedCookieName, true, {
-          daysUntilExpire: this.sessionCheckExpiryDays
+          daysUntilExpire: this.sessionCheckExpiryDays,
+          cookieDomain: this.options.cookieDomain
         });
 
         if (options.detailedResponse) {

--- a/src/global.ts
+++ b/src/global.ts
@@ -210,6 +210,15 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   sessionCheckExpiryDays?: number;
 
   /**
+   * The domain the cookie is accessible from. Defaults to the current domain
+   * including the subdomain.
+   *
+   * To keep a user logged in across multiple subdomains set this to your
+   * top-level domain and prefixed with a `.` (eg: `.example.com`).
+   */
+  cookieDomain?: string;
+
+  /**
    * When true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON. The default is false, but will default to true in a
    * future major version.
    *

--- a/src/global.ts
+++ b/src/global.ts
@@ -210,8 +210,12 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   sessionCheckExpiryDays?: number;
 
   /**
-   * The domain the cookie is accessible from. Defaults to the current domain
-   * including the subdomain.
+   * The domain the cookie is accessible from. If not set, the cookie is scoped to
+   * the current domain, including the subdomain.
+   *
+   * Note: setting this incorrectly may cause silent authentication to stop working
+   * on page load.
+   *
    *
    * To keep a user logged in across multiple subdomains set this to your
    * top-level domain and prefixed with a `.` (eg: `.example.com`).

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,6 +2,7 @@ import * as Cookies from 'es-cookie';
 
 interface ClientStorageOptions {
   daysUntilExpire: number;
+  cookieDomain?: string;
 }
 
 /**
@@ -39,6 +40,10 @@ export const CookieStorage = {
 
     if (options?.daysUntilExpire) {
       cookieAttributes.expires = options.daysUntilExpire;
+    }
+
+    if (options?.cookieDomain) {
+      cookieAttributes.domain = options.cookieDomain;
     }
 
     Cookies.set(key, JSON.stringify(value), cookieAttributes);


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

Added an optional `cookieDomain` setting to the client options that allows the domain set on the cookie to be explicitly set.

This is intended to allow a cookie to work across subdomains by setting it to top-level domain (eg: `.example.com`).

### References

This is intended to solve this issue https://github.com/auth0/auth0-spa-js/issues/884

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
