### PR TITLE
Release v1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v1.21.1](https://github.com/auth0/auth0-spa-js/tree/v1.21.1) (2022-05-10)
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.21.0...v1.21.1)
+
+**Fixed**
+- Organization ID hint cookie now respects `cookieDomain` config setting [\#900](https://github.com/auth0/auth0-spa-js/pull/900) ([Dannnir](https://github.com/Dannnir))
+
+**Security**
+- [Snyk] Upgrade core-js from 3.21.1 to 3.22.0 [\#901](https://github.com/auth0/auth0-spa-js/pull/901) ([snyk-bot](https://github.com/snyk-bot))
+- [Snyk] Upgrade promise-polyfill from 8.2.1 to 8.2.3 [\#893](https://github.com/auth0/auth0-spa-js/pull/893) ([snyk-bot](https://github.com/snyk-bot))
+
 ## [v1.21.0](https://github.com/auth0/auth0-spa-js/tree/v1.21.0) (2022-04-01)
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.20.1...v1.21.0)
 

--- a/docs/classes/auth0client.html
+++ b/docs/classes/auth0client.html
@@ -2834,7 +2834,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L207">src/Auth0Client.ts:207</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L207">src/Auth0Client.ts:207</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2856,7 +2856,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L206">src/Auth0Client.ts:206</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L206">src/Auth0Client.ts:206</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2873,7 +2873,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L408">src/Auth0Client.ts:408</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L409">src/Auth0Client.ts:409</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2907,7 +2907,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L996">src/Auth0Client.ts:996</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L997">src/Auth0Client.ts:997</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2939,7 +2939,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L759">src/Auth0Client.ts:759</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L760">src/Auth0Client.ts:760</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2984,7 +2984,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L607">src/Auth0Client.ts:607</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L608">src/Auth0Client.ts:608</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3020,7 +3020,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L788">src/Auth0Client.ts:788</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L789">src/Auth0Client.ts:789</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3063,7 +3063,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L797">src/Auth0Client.ts:797</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L798">src/Auth0Client.ts:798</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3115,7 +3115,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L944">src/Auth0Client.ts:944</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L945">src/Auth0Client.ts:945</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3153,7 +3153,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L577">src/Auth0Client.ts:577</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L578">src/Auth0Client.ts:578</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3198,7 +3198,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L649">src/Auth0Client.ts:649</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L650">src/Auth0Client.ts:650</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3235,7 +3235,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L983">src/Auth0Client.ts:983</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L984">src/Auth0Client.ts:984</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3260,7 +3260,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L468">src/Auth0Client.ts:468</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L469">src/Auth0Client.ts:469</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3307,7 +3307,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L635">src/Auth0Client.ts:635</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L636">src/Auth0Client.ts:636</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3347,7 +3347,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/Auth0Client.ts#L1028">src/Auth0Client.ts:1028</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/Auth0Client.ts#L1029">src/Auth0Client.ts:1029</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/authenticationerror.html
+++ b/docs/classes/authenticationerror.html
@@ -2821,7 +2821,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L31">src/errors.ts:31</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L31">src/errors.ts:31</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2852,7 +2852,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L37">src/errors.ts:37</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L37">src/errors.ts:37</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2863,7 +2863,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2874,7 +2874,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L36">src/errors.ts:36</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L36">src/errors.ts:36</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2935,7 +2935,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cachekey.html
+++ b/docs/classes/cachekey.html
@@ -2803,7 +2803,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2828,7 +2828,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2838,7 +2838,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L12">src/cache/shared.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L12">src/cache/shared.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2848,7 +2848,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L16">src/cache/shared.ts:16</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L16">src/cache/shared.ts:16</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2858,7 +2858,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L13">src/cache/shared.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L13">src/cache/shared.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2875,7 +2875,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L26">src/cache/shared.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L26">src/cache/shared.ts:26</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2898,7 +2898,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L46">src/cache/shared.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L46">src/cache/shared.ts:46</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2930,7 +2930,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L35">src/cache/shared.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L35">src/cache/shared.ts:35</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/cachekeymanifest.html
+++ b/docs/classes/cachekeymanifest.html
@@ -2786,7 +2786,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/key-manifest.ts#L9">src/cache/key-manifest.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/key-manifest.ts#L9">src/cache/key-manifest.ts:9</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2815,7 +2815,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/key-manifest.ts#L15">src/cache/key-manifest.ts:15</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/key-manifest.ts#L15">src/cache/key-manifest.ts:15</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2838,7 +2838,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/key-manifest.ts#L46">src/cache/key-manifest.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/key-manifest.ts#L46">src/cache/key-manifest.ts:46</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2855,7 +2855,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/key-manifest.ts#L42">src/cache/key-manifest.ts:42</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/key-manifest.ts#L42">src/cache/key-manifest.ts:42</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><a href="../globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2872,7 +2872,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/key-manifest.ts#L27">src/cache/key-manifest.ts:27</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/key-manifest.ts#L27">src/cache/key-manifest.ts:27</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cachemanager.html
+++ b/docs/classes/cachemanager.html
@@ -2786,7 +2786,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L14">src/cache/cache-manager.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L14">src/cache/cache-manager.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2830,7 +2830,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L83">src/cache/cache-manager.ts:83</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L83">src/cache/cache-manager.ts:83</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2853,7 +2853,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L102">src/cache/cache-manager.ts:102</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L102">src/cache/cache-manager.ts:102</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2881,7 +2881,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L23">src/cache/cache-manager.ts:23</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L23">src/cache/cache-manager.ts:23</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2907,7 +2907,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L70">src/cache/cache-manager.ts:70</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L70">src/cache/cache-manager.ts:70</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/genericerror.html
+++ b/docs/classes/genericerror.html
@@ -2829,7 +2829,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L9">src/errors.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L9">src/errors.ts:9</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2854,7 +2854,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2864,7 +2864,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error_<wbr>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2924,7 +2924,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/inmemorycache.html
+++ b/docs/classes/inmemorycache.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">enclosed<wbr>Cache<span class="tsd-signature-symbol">:</span> <a href="../interfaces/icache.html" class="tsd-signature-type">ICache</a><span class="tsd-signature-symbol"> = (function () {let cache: Record&lt;string, unknown&gt; &#x3D; {};return {set&lt;T &#x3D; Cacheable&gt;(key: string, entry: T) {cache[key] &#x3D; entry;},get&lt;T &#x3D; Cacheable&gt;(key: string) {const cacheEntry &#x3D; cache[key] as T;if (!cacheEntry) {return;}return cacheEntry;},remove(key: string) {delete cache[key];},allKeys(): string[] {return Object.keys(cache);}};})()</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-memory.ts#L4">src/cache/cache-memory.ts:4</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-memory.ts#L4">src/cache/cache-memory.ts:4</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/classes/localstoragecache.html
+++ b/docs/classes/localstoragecache.html
@@ -2784,7 +2784,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#allkeys">allKeys</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-localstorage.ts#L26">src/cache/cache-localstorage.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-localstorage.ts#L26">src/cache/cache-localstorage.ts:26</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -2802,7 +2802,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#get">get</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-localstorage.ts#L8">src/cache/cache-localstorage.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-localstorage.ts#L8">src/cache/cache-localstorage.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2832,7 +2832,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#remove">remove</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-localstorage.ts#L22">src/cache/cache-localstorage.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-localstorage.ts#L22">src/cache/cache-localstorage.ts:22</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2856,7 +2856,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#set">set</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-localstorage.ts#L4">src/cache/cache-localstorage.ts:4</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-localstorage.ts#L4">src/cache/cache-localstorage.ts:4</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/mfarequirederror.html
+++ b/docs/classes/mfarequirederror.html
@@ -2816,7 +2816,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L82">src/errors.ts:82</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L82">src/errors.ts:82</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2845,7 +2845,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2856,7 +2856,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2877,7 +2877,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">mfa_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L87">src/errors.ts:87</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L87">src/errors.ts:87</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popupcancellederror.html
+++ b/docs/classes/popupcancellederror.html
@@ -2809,7 +2809,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L70">src/errors.ts:70</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L70">src/errors.ts:70</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2832,7 +2832,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2843,7 +2843,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2875,7 +2875,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L72">src/errors.ts:72</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L72">src/errors.ts:72</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2904,7 +2904,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popuptimeouterror.html
+++ b/docs/classes/popuptimeouterror.html
@@ -2816,7 +2816,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="timeouterror.html">TimeoutError</a>.<a href="timeouterror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L61">src/errors.ts:61</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L61">src/errors.ts:61</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2839,7 +2839,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2850,7 +2850,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2882,7 +2882,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L63">src/errors.ts:63</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L63">src/errors.ts:63</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2911,7 +2911,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/timeouterror.html
+++ b/docs/classes/timeouterror.html
@@ -2818,7 +2818,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L49">src/errors.ts:49</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L49">src/errors.ts:49</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="timeouterror.html" class="tsd-signature-type">TimeoutError</a></h4>
@@ -2835,7 +2835,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2846,7 +2846,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L11">src/errors.ts:11</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L11">src/errors.ts:11</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2897,7 +2897,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/errors.ts#L16">src/errors.ts:16</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/errors.ts#L16">src/errors.ts:16</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/user.html
+++ b/docs/classes/user.html
@@ -2841,7 +2841,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L597">src/global.ts:597</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L597">src/global.ts:597</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2851,7 +2851,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">birthdate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L592">src/global.ts:592</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L592">src/global.ts:592</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2861,7 +2861,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L589">src/global.ts:589</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L589">src/global.ts:589</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2871,7 +2871,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L590">src/global.ts:590</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L590">src/global.ts:590</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2881,7 +2881,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">family_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L582">src/global.ts:582</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L582">src/global.ts:582</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2891,7 +2891,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">gender<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L591">src/global.ts:591</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L591">src/global.ts:591</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2901,7 +2901,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">given_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L581">src/global.ts:581</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L581">src/global.ts:581</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2911,7 +2911,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L594">src/global.ts:594</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L594">src/global.ts:594</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2921,7 +2921,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">middle_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L583">src/global.ts:583</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L583">src/global.ts:583</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2931,7 +2931,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L580">src/global.ts:580</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L580">src/global.ts:580</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2941,7 +2941,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">nickname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L584">src/global.ts:584</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L584">src/global.ts:584</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2951,7 +2951,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L595">src/global.ts:595</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L595">src/global.ts:595</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2961,7 +2961,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L596">src/global.ts:596</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L596">src/global.ts:596</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2971,7 +2971,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L587">src/global.ts:587</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L587">src/global.ts:587</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2981,7 +2981,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">preferred_<wbr>username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L585">src/global.ts:585</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L585">src/global.ts:585</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2991,7 +2991,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">profile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L586">src/global.ts:586</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L586">src/global.ts:586</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3001,7 +3001,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">sub<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L599">src/global.ts:599</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L599">src/global.ts:599</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3011,7 +3011,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">updated_<wbr>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L598">src/global.ts:598</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L598">src/global.ts:598</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3021,7 +3021,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">website<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L588">src/global.ts:588</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L588">src/global.ts:588</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3031,7 +3031,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">zoneinfo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L593">src/global.ts:593</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L593">src/global.ts:593</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -3324,7 +3324,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>access_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>decodedToken<span class="tsd-signature-symbol">: </span><a href="interfaces/decodedtoken.html" class="tsd-signature-type">DecodedToken</a><span class="tsd-signature-symbol">; </span>expires_in<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>id_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>oauthTokenScope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>refresh_token<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3366,7 +3366,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Key<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3390,7 +3390,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L245">src/global.ts:245</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L245">src/global.ts:245</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3405,7 +3405,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cacheable<span class="tsd-signature-symbol">:</span> <a href="globals.html#wrappedcacheentry" class="tsd-signature-type">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3415,7 +3415,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L614">src/global.ts:614</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L614">src/global.ts:614</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3425,7 +3425,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Key<wbr>Manifest<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3443,7 +3443,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Maybe<wbr>Promise&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">T</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
 					</ul>
 				</aside>
 				<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3459,7 +3459,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Wrapped<wbr>Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="globals.html#cacheentry" class="tsd-signature-type">CacheEntry</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>expiresAt<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3480,7 +3480,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L333">src/global.ts:333</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L333">src/global.ts:333</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3493,7 +3493,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>KEY_<wbr>PREFIX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@auth0spajs@@"</span><span class="tsd-signature-symbol"> = &quot;@@auth0spajs@@&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3503,7 +3503,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3513,7 +3513,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3523,7 +3523,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>EXPIRY_<wbr>ADJUSTMENT_<wbr>SECONDS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3540,7 +3540,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/constants.ts#L80">src/constants.ts:80</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/constants.ts#L80">src/constants.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -3557,7 +3557,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/index.ts#L28">src/index.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/index.ts#L28">src/index.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3325,7 +3325,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>access_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>decodedToken<span class="tsd-signature-symbol">: </span><a href="interfaces/decodedtoken.html" class="tsd-signature-type">DecodedToken</a><span class="tsd-signature-symbol">; </span>expires_in<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>id_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>oauthTokenScope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>refresh_token<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3367,7 +3367,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Key<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3391,7 +3391,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L245">src/global.ts:245</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L245">src/global.ts:245</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3406,7 +3406,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cacheable<span class="tsd-signature-symbol">:</span> <a href="globals.html#wrappedcacheentry" class="tsd-signature-type">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3416,7 +3416,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L614">src/global.ts:614</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L614">src/global.ts:614</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3426,7 +3426,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Key<wbr>Manifest<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3444,7 +3444,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Maybe<wbr>Promise&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">T</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
 					</ul>
 				</aside>
 				<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3460,7 +3460,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Wrapped<wbr>Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="globals.html#cacheentry" class="tsd-signature-type">CacheEntry</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>expiresAt<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3481,7 +3481,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L333">src/global.ts:333</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L333">src/global.ts:333</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3494,7 +3494,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>KEY_<wbr>PREFIX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@auth0spajs@@"</span><span class="tsd-signature-symbol"> = &quot;@@auth0spajs@@&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3504,7 +3504,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3514,7 +3514,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3524,7 +3524,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>EXPIRY_<wbr>ADJUSTMENT_<wbr>SECONDS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3541,7 +3541,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/constants.ts#L80">src/constants.ts:80</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/constants.ts#L80">src/constants.ts:80</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -3558,7 +3558,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/index.ts#L28">src/index.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/index.ts#L28">src/index.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/advancedoptions.html
+++ b/docs/interfaces/advancedoptions.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">default<wbr>Scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L107">src/global.ts:107</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L107">src/global.ts:107</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/auth0clientoptions.html
+++ b/docs/interfaces/auth0clientoptions.html
@@ -2893,7 +2893,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2903,7 +2903,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">advanced<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="advancedoptions.html" class="tsd-signature-type">AdvancedOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L204">src/global.ts:204</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L204">src/global.ts:204</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2919,7 +2919,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2934,7 +2934,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">authorize<wbr>Timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L165">src/global.ts:165</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L165">src/global.ts:165</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2950,7 +2950,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<span class="tsd-signature-symbol">:</span> <a href="icache.html" class="tsd-signature-type">ICache</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L151">src/global.ts:151</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L151">src/global.ts:151</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2965,7 +2965,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L146">src/global.ts:146</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L146">src/global.ts:146</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2982,7 +2982,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L124">src/global.ts:124</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L124">src/global.ts:124</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2998,7 +2998,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3015,7 +3015,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cookie<wbr>Domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L223">src/global.ts:223</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L223">src/global.ts:223</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3036,7 +3036,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3056,7 +3056,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L116">src/global.ts:116</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L116">src/global.ts:116</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3073,7 +3073,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">http<wbr>Timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L170">src/global.ts:170</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L170">src/global.ts:170</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3089,7 +3089,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3105,7 +3105,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3120,7 +3120,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">issuer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L120">src/global.ts:120</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L120">src/global.ts:120</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3135,7 +3135,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">leeway<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L138">src/global.ts:138</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L138">src/global.ts:138</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3152,7 +3152,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">legacy<wbr>Same<wbr>Site<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L186">src/global.ts:186</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L186">src/global.ts:186</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3173,7 +3173,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3192,7 +3192,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3209,7 +3209,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">now<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L239">src/global.ts:239</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L239">src/global.ts:239</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3241,7 +3241,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3259,7 +3259,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3279,7 +3279,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L132">src/global.ts:132</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L132">src/global.ts:132</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3299,7 +3299,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3317,7 +3317,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3335,7 +3335,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">session<wbr>Check<wbr>Expiry<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L210">src/global.ts:210</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L210">src/global.ts:210</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3352,7 +3352,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3368,7 +3368,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Cookies<wbr>For<wbr>Transactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L199">src/global.ts:199</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L199">src/global.ts:199</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3391,7 +3391,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Form<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L232">src/global.ts:232</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L232">src/global.ts:232</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3409,7 +3409,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Refresh<wbr>Tokens<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L159">src/global.ts:159</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L159">src/global.ts:159</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/decodedtoken.html
+++ b/docs/interfaces/decodedtoken.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">claims<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IdToken</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L58">src/cache/shared.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L58">src/cache/shared.ts:58</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2775,7 +2775,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <a href="../classes/user.html" class="tsd-signature-type">User</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L59">src/cache/shared.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L59">src/cache/shared.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/getidtokenclaimsoptions.html
+++ b/docs/interfaces/getidtokenclaimsoptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L327">src/global.ts:327</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L327">src/global.ts:327</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2780,7 +2780,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L323">src/global.ts:323</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L323">src/global.ts:323</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokensilentlyoptions.html
+++ b/docs/interfaces/gettokensilentlyoptions.html
@@ -2791,7 +2791,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L360">src/global.ts:360</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L360">src/global.ts:360</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2806,7 +2806,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">detailed<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L373">src/global.ts:373</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L373">src/global.ts:373</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2823,7 +2823,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L340">src/global.ts:340</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L340">src/global.ts:340</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2839,7 +2839,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L350">src/global.ts:350</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L350">src/global.ts:350</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2859,7 +2859,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L355">src/global.ts:355</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L355">src/global.ts:355</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L365">src/global.ts:365</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L365">src/global.ts:365</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokenwithpopupoptions.html
+++ b/docs/interfaces/gettokenwithpopupoptions.html
@@ -2829,7 +2829,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2840,7 +2840,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2856,7 +2856,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2895,7 +2895,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2910,7 +2910,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L387">src/global.ts:387</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L387">src/global.ts:387</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2927,7 +2927,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2943,7 +2943,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2980,7 +2980,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2998,7 +2998,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3019,7 +3019,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3037,7 +3037,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3056,7 +3056,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/getuseroptions.html
+++ b/docs/interfaces/getuseroptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L316">src/global.ts:316</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L316">src/global.ts:316</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2780,7 +2780,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L312">src/global.ts:312</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L312">src/global.ts:312</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/icache.html
+++ b/docs/interfaces/icache.html
@@ -2783,7 +2783,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L91">src/cache/shared.ts:91</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L91">src/cache/shared.ts:91</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2800,7 +2800,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L89">src/cache/shared.ts:89</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L89">src/cache/shared.ts:89</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2829,7 +2829,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L90">src/cache/shared.ts:90</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L90">src/cache/shared.ts:90</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2852,7 +2852,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/cache/shared.ts#L88">src/cache/shared.ts:88</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/cache/shared.ts#L88">src/cache/shared.ts:88</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/interfaces/logoutoptions.html
+++ b/docs/interfaces/logoutoptions.html
@@ -2773,7 +2773,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L449">src/global.ts:449</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L449">src/global.ts:449</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2791,7 +2791,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L458">src/global.ts:458</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L458">src/global.ts:458</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2810,7 +2810,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">local<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L466">src/global.ts:466</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L466">src/global.ts:466</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2828,7 +2828,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L438">src/global.ts:438</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L438">src/global.ts:438</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logouturloptions.html
+++ b/docs/interfaces/logouturloptions.html
@@ -2769,7 +2769,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L414">src/global.ts:414</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L414">src/global.ts:414</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2787,7 +2787,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L422">src/global.ts:422</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L422">src/global.ts:422</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2805,7 +2805,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L403">src/global.ts:403</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L403">src/global.ts:403</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popupconfigoptions.html
+++ b/docs/interfaces/popupconfigoptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L305">src/global.ts:305</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L305">src/global.ts:305</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2782,7 +2782,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L298">src/global.ts:298</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L298">src/global.ts:298</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popuploginoptions.html
+++ b/docs/interfaces/popuploginoptions.html
@@ -2830,7 +2830,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2841,7 +2841,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2857,7 +2857,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2875,7 +2875,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2896,7 +2896,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2912,7 +2912,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2928,7 +2928,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2947,7 +2947,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2965,7 +2965,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2983,7 +2983,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3004,7 +3004,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3022,7 +3022,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2849,7 +2849,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2859,7 +2859,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TAppState</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L273">src/global.ts:273</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L273">src/global.ts:273</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2875,7 +2875,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2891,7 +2891,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2909,7 +2909,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2929,7 +2929,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">fragment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L277">src/global.ts:277</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L277">src/global.ts:277</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2945,7 +2945,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2961,7 +2961,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2977,7 +2977,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2996,7 +2996,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3014,7 +3014,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3032,7 +3032,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3052,7 +3052,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect<wbr>Method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"replace"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"assign"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L281">src/global.ts:281</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L281">src/global.ts:281</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3067,7 +3067,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L269">src/global.ts:269</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L269">src/global.ts:269</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3086,7 +3086,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3104,7 +3104,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3123,7 +3123,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginresult.html
+++ b/docs/interfaces/redirectloginresult.html
@@ -2769,7 +2769,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TAppState</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/defbb63/src/global.ts#L288">src/global.ts:288</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/56ef0d8/src/global.ts#L288">src/global.ts:288</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-spa-js",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.21.0';
+export default '1.21.1';


### PR DESCRIPTION
**Fixed**
- Organization ID hint cookie now respects `cookieDomain` config setting [\#900](https://github.com/auth0/auth0-spa-js/pull/900) ([Dannnir](https://github.com/Dannnir))

**Security**
- [Snyk] Upgrade core-js from 3.21.1 to 3.22.0 [\#901](https://github.com/auth0/auth0-spa-js/pull/901) ([snyk-bot](https://github.com/snyk-bot))
- [Snyk] Upgrade promise-polyfill from 8.2.1 to 8.2.3 [\#893](https://github.com/auth0/auth0-spa-js/pull/893) ([snyk-bot](https://github.com/snyk-bot))