### PR TITLE
Allow to disable the use of silent auth when using Refresh Tokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,18 @@
       "program": "${workspaceFolder}/node_modules/.bin/rollup",
       "args": ["-m", "-c"],
       "console": "integratedTerminal"
+    },
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
     }
   ]
 }

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -927,7 +927,7 @@ describe('Auth0Client', () => {
       await expect(
         getTokenSilently(auth0, { ignoreCache: true })
       ).rejects.toThrow(
-        "Missing Refresh Token (audience: 'default', scope: 'openid profile email offline_access')"
+        "Missing Refresh Token (audience: '', scope: 'openid profile email offline_access')"
       );
 
       expect(utils.runIframe).not.toHaveBeenCalled();
@@ -1062,7 +1062,7 @@ describe('Auth0Client', () => {
       await expect(
         getTokenSilently(auth0, { ignoreCache: true })
       ).rejects.toThrow(
-        "Missing Refresh Token (audience: 'default', scope: 'openid profile email offline_access')"
+        "Missing Refresh Token (audience: '', scope: 'openid profile email offline_access')"
       );
 
       expect(utils.runIframe).not.toHaveBeenCalled();

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -900,6 +900,39 @@ describe('Auth0Client', () => {
       expect(utils.runIframe).toHaveBeenCalled();
     });
 
+    it('does not fall back to iframe when missing refresh token errors from the worker and useRefreshTokensFallback set to false', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useRefreshTokensFallback: false
+      });
+      expect((<any>auth0).worker).toBeDefined();
+      await loginWithRedirect(auth0, undefined, {
+        token: {
+          response: { refresh_token: '' }
+        }
+      });
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          expires_in: 86400
+        })
+      );
+
+      await expect(
+        getTokenSilently(auth0, { ignoreCache: true })
+      ).rejects.toThrow(
+        "Missing Refresh Token (audience: 'default', scope: 'openid profile email offline_access')"
+      );
+
+      expect(utils.runIframe).not.toHaveBeenCalled();
+    });
+
     it('handles fetch errors without the worker', async () => {
       const auth0 = setup({
         useRefreshTokens: true,

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -1,7 +1,6 @@
 import unfetch from 'unfetch';
 import { MISSING_REFRESH_TOKEN_ERROR_MESSAGE } from '../src/constants';
 import { assertPostFn } from './Auth0Client/helpers';
-import { TEST_CODE } from './constants';
 import * as utils from '../src/utils';
 
 jest.mock('unfetch');
@@ -168,7 +167,7 @@ describe('token worker', () => {
       }
     });
 
-    expect(response.json.error_description).toEqual(
+    expect(response.json.error_description).toContain(
       MISSING_REFRESH_TOKEN_ERROR_MESSAGE
     );
   });
@@ -288,7 +287,7 @@ describe('token worker', () => {
     expect(mockFetch.mock.calls.length).toBe(2);
 
     expect(result.json.error_description).toContain(
-      'The web worker is missing the refresh token'
+      MISSING_REFRESH_TOKEN_ERROR_MESSAGE
     );
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -307,9 +307,7 @@ export default class Auth0Client {
     this.customOptions = getCustomInitialOptions(options);
 
     this.useRefreshTokensFallback =
-      this.options.useRefreshTokensFallback == null
-        ? true
-        : this.options.useRefreshTokensFallback;
+      this.options.useRefreshTokensFallback !== false;
   }
 
   private _url(path: string) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -309,7 +309,7 @@ export default class Auth0Client {
     this.useRefreshTokensFallback =
       this.options.useRefreshTokensFallback == null
         ? true
-        : this.options.useRefreshTokens;
+        : this.options.useRefreshTokensFallback;
   }
 
   private _url(path: string) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -207,7 +207,7 @@ export default class Auth0Client {
   private readonly isAuthenticatedCookieName: string;
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
-  private useRefreshTokensFallback: boolean;
+  private readonly useRefreshTokensFallback: boolean;
 
   cacheLocation: CacheLocation;
   private worker: Worker;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,8 +34,7 @@ export const CACHE_LOCATION_LOCAL_STORAGE = 'localstorage';
 /**
  * @ignore
  */
-export const MISSING_REFRESH_TOKEN_ERROR_MESSAGE =
-  'The web worker is missing the refresh token';
+export const MISSING_REFRESH_TOKEN_ERROR_MESSAGE = 'Missing Refresh Token';
 
 /**
  * @ignore

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -92,12 +92,18 @@ export class MfaRequiredError extends GenericError {
   }
 }
 
+function valueOrEmptyString(value: string, exclude: string[] = []) {
+  return value && !exclude.includes(value) ? value : '';
+}
+
 export class MissingRefreshTokenError extends GenericError {
   /* istanbul ignore next */
   constructor(public audience: string, public scope: string) {
     super(
       'missing_refresh_token',
-      `Missing Refresh Token (audience: '${audience}', scope: '${scope}')`
+      `Missing Refresh Token (audience: '${valueOrEmptyString(audience, [
+        'default'
+      ])}', scope: '${valueOrEmptyString(scope)}')`
     );
     Object.setPrototypeOf(this, MissingRefreshTokenError.prototype);
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,8 @@
  * https://github.com/gotwarlost/istanbul/issues/690
  */
 
+import { valueOrEmptyString } from './utils';
+
 /**
  * Thrown when network requests to the Auth server fail.
  */
@@ -90,10 +92,6 @@ export class MfaRequiredError extends GenericError {
     //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, MfaRequiredError.prototype);
   }
-}
-
-function valueOrEmptyString(value: string, exclude: string[] = []) {
-  return value && !exclude.includes(value) ? value : '';
 }
 
 export class MissingRefreshTokenError extends GenericError {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -91,3 +91,14 @@ export class MfaRequiredError extends GenericError {
     Object.setPrototypeOf(this, MfaRequiredError.prototype);
   }
 }
+
+export class MissingRefreshTokenError extends GenericError {
+  /* istanbul ignore next */
+  constructor(public audience: string, public scope: string) {
+    super(
+      'missing_refresh_token',
+      `Missing Refresh Token (audience: '${audience}', scope: '${scope}')`
+    );
+    Object.setPrototypeOf(this, MissingRefreshTokenError.prototype);
+  }
+}

--- a/src/global.ts
+++ b/src/global.ts
@@ -159,6 +159,17 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   useRefreshTokens?: boolean;
 
   /**
+   * If true, fallback to the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens.
+   * The default setting is `true`.
+   *
+   * **Note**: There might be situatins where using the legacy iframe technique is not supported, and using it as a fallback might be undesired.
+   * In situations like this, set the value to `false`, catch any `missing_refresh_token` or `invalid_grant` errors and initiate an interactive login by calling `loginWithRedirect()`.
+   *
+   * E.g. Using the `file:` protocol in an Electron application does not support that legacy technique.
+   */
+  useRefreshTokensFallback?: boolean;
+
+  /**
    * A maximum number of seconds to wait before declaring background calls to /authorize as failed for timeout
    * Defaults to 60s.
    */

--- a/src/global.ts
+++ b/src/global.ts
@@ -162,8 +162,8 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * If true, fallback to the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens.
    * The default setting is `true`.
    *
-   * **Note**: There might be situatins where using the legacy iframe technique is not supported, and using it as a fallback might be undesired.
-   * In situations like this, set the value to `false`, catch any `missing_refresh_token` or `invalid_grant` errors and initiate an interactive login by calling `loginWithRedirect()`.
+   * **Note**: There might be situations where using the legacy iframe technique is not supported, and using it as a fallback might be undesired.
+   * In situations like this, set the value to `false`, catch any `missing_refresh_token` or `invalid_grant` errors when calling `getTokenSilently()`, and initiate an interactive login by calling `loginWithRedirect()`.
    *
    * E.g. Using the `file:` protocol in an Electron application does not support that legacy technique.
    */

--- a/src/global.ts
+++ b/src/global.ts
@@ -166,6 +166,15 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * In situations like this, set the value to `false`, catch any `missing_refresh_token` or `invalid_grant` errors when calling `getTokenSilently()`, and initiate an interactive login by calling `loginWithRedirect()`.
    *
    * E.g. Using the `file:` protocol in an Electron application does not support that legacy technique.
+   *
+   *  let token: string;
+   *  try {
+   *    token = await auth0.getTokenSilently();
+   *  } catch (e) {
+   *  if (e.error === 'missing_refresh_token' || e.error === 'invalid_grant') {
+   *      auth0.loginWithRedirect();
+   *    }
+   *  }
    */
   useRefreshTokensFallback?: boolean;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -162,8 +162,9 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * If true, fallback to the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens.
    * The default setting is `true`.
    *
-   * **Note**: There might be situations where using the legacy iframe technique is not supported, and using it as a fallback might be undesired.
-   * In situations like this, set the value to `false`, catch any `missing_refresh_token` or `invalid_grant` errors when calling `getTokenSilently()`, and initiate an interactive login by calling `loginWithRedirect()`.
+   * **Note**: There might be situations where doing silent auth with a Web Message response from an iframe is not possible,
+   * like when you're serving your application from the file system or a custom protocol (like in a Desktop or Native app).
+   * In situations like this you can disable the iframe fallback and handle the failed Refresh Grant and prompt the user to login interactively with `loginWithRedirect` or `loginWithPopup`."
    *
    * E.g. Using the `file:` protocol in an Electron application does not support that legacy technique.
    *

--- a/src/global.ts
+++ b/src/global.ts
@@ -159,7 +159,7 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   useRefreshTokens?: boolean;
 
   /**
-   * If true, fallback to the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens.
+   * If true, fallback to the technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens.
    * The default setting is `true`.
    *
    * **Note**: There might be situations where doing silent auth with a Web Message response from an iframe is not possible,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,3 +241,13 @@ export const validateCrypto = () => {
     `);
   }
 };
+
+/**
+ * Returns an empty string when value is falsy, or when it's value is included in the exclude argument.
+ * @param value The value to check
+ * @param exclude An array of values that should result in an empty string.
+ * @returns The value, or an empty string when falsy or included in the exclude argument.
+ */
+export function valueOrEmptyString(value: string, exclude: string[] = []) {
+  return value && !exclude.includes(value) ? value : '';
+}

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -1,4 +1,4 @@
-import { MISSING_REFRESH_TOKEN_ERROR_MESSAGE } from '../constants';
+import { MissingRefreshTokenError } from '../errors';
 import { WorkerRefreshTokenMessage } from './worker.types';
 
 let refreshTokens: Record<string, string> = {};
@@ -50,7 +50,7 @@ const messageHandler = async ({
       const refreshToken = getRefreshToken(audience, scope);
 
       if (!refreshToken) {
-        throw new Error(MISSING_REFRESH_TOKEN_ERROR_MESSAGE);
+        throw new MissingRefreshTokenError(audience, scope);
       }
 
       fetchOptions.body = useFormData


### PR DESCRIPTION
When using our SDK in environments such as electron, where it's common to use the `file:` protocol, using silent auth (iframes) isn't supported. This is because of the fact that electron will set the window's `origin` to `file://`, which is a value not supported by Auth0.

This PR adds a flag, useRefreshTokensFallback, that, when set to `false`, allows disabling the use of silent auth when using Refresh Tokens. The flag defaults to `true`.

The implication here is that, as we won't fall back to iframes, the errors regarding refresh tokens (`missing_refresh_token` or `invalid_grant`) will be thrown to the end-user, needing them to catch these errors and send the user through an interactive login.

```ts
let token: string;
try {
  token = await auth0.getTokenSilently();
} catch (e) {
  if (e.error === 'missing_refresh_token' || e.error === 'invalid_grant') {
    auth0.loginWithRedirect();
  }
}
```