### PR TITLE
Add env to auth0Client userAgent

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -194,7 +194,11 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * Internal property to send information about the client to the authorization server.
    * @internal
    */
-  auth0Client?: { name: string; version: string };
+  auth0Client?: {
+    name: string;
+    version: string;
+    env?: { [key: string]: string };
+  };
 
   /**
    * Sets an additional cookie with no SameSite attribute to support legacy browsers


### PR DESCRIPTION
The auth0Client object didnt allow to pass in an `env`, which can be useful to track additional environment information