### PR TITLE
Bump tslib and configure terser for dev bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "rollup-plugin-web-worker-loader": "^1.6.1",
         "serve": "^12.0.1",
         "ts-jest": "^27.0.7",
-        "tslib": "^2.3.1",
+        "tslib": "^2.4.0",
         "tslint": "^6.1.3",
         "tslint-config-security": "^1.16.0",
         "typedoc": "0.18.0",
@@ -14003,9 +14003,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/tslint": {
@@ -25924,9 +25924,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "tslint": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rollup-plugin-web-worker-loader": "^1.6.1",
     "serve": "^12.0.1",
     "ts-jest": "^27.0.7",
-    "tslib": "^2.3.1",
+    "tslib": "^2.4.0",
     "tslint": "^6.1.3",
     "tslint-config-security": "^1.16.0",
     "typedoc": "0.18.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,7 +48,13 @@ const getPlugins = shouldMinify => {
       }
     }),
     replace({ 'process.env.NODE_ENV': `'${process.env.NODE_ENV}'` }),
-    shouldMinify && terser(),
+    shouldMinify
+      ? terser()
+      : terser({
+          compress: false,
+          mangle: false,
+          format: { beautify: true }
+        }),
     sourcemaps()
   ];
 };


### PR DESCRIPTION
### Changes

Currently, projects using our SDK will pull in TSLib's 0BSD license, which gives issues with our own tooling.
This has been fixed in a recent version of TSLib, where the license comment in question can be removed safely by terser.

Therefore, this PR both:
- bumps `tslib`
- enabled `terser` for our development bundles, but without `compression`, `mangling` and `beautify`.

### References

- PR that changes the license of TSLib: https://github.com/microsoft/tslib/pull/96
- PR that resolves the fact that the license can not be removed from the output: https://github.com/microsoft/tslib/pull/160

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
