### PR TITLE
[SDK-3538] Fix spelling mistakes in id token validation

### DIFF
--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -329,7 +329,7 @@ describe('jwt', () => {
     expect(() =>
       verify({ ...verifyOptions, id_token, max_age: maxAge, leeway })
     ).toThrow(
-      `Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Currrent time (${new Date(
+      `Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (${new Date(
         now
       )}) is after last auth at ${authTimeDateCorrected}`
     );

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -179,13 +179,13 @@ export const verify = (options: JWTVerifyOptions) => {
 
   if (isNumber(decoded.claims.nbf) && now < nbfDate) {
     throw new Error(
-      `Not Before time (nbf) claim in the ID token indicates that this token can't be used just yet. Currrent time (${now}) is before ${nbfDate}`
+      `Not Before time (nbf) claim in the ID token indicates that this token can't be used just yet. Current time (${now}) is before ${nbfDate}`
     );
   }
 
   if (isNumber(decoded.claims.auth_time) && now > authTimeDate) {
     throw new Error(
-      `Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Currrent time (${now}) is after last auth at ${authTimeDate}`
+      `Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (${now}) is after last auth at ${authTimeDate}`
     );
   }
 


### PR DESCRIPTION
### Changes

This PR fixes spelling issues in the validation message for both the `Not Before (nbf)` claims as well as the `Authentication Time (auth_time)` claim.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
