### PR TITLE
Update jest to fix warning with mocked function

### DIFF
--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,6 +1,6 @@
 import * as esCookie from 'es-cookie';
 import { MockedObject } from 'ts-jest/dist/utils/testing';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 import { CookieStorage, CookieStorageWithLegacySameSite } from '../src/storage';
 
 jest.mock('es-cookie');

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,6 +1,4 @@
 import * as esCookie from 'es-cookie';
-import { MockedObject } from 'ts-jest/dist/utils/testing';
-import { mocked } from 'jest-mock';
 import { CookieStorage, CookieStorageWithLegacySameSite } from '../src/storage';
 
 jest.mock('es-cookie');
@@ -9,7 +7,7 @@ describe('CookieStorage', () => {
   let cookieMock;
 
   beforeEach(() => {
-    cookieMock = mocked(esCookie);
+    cookieMock = jest.mocked(esCookie);
   });
 
   it('saves a cookie', () => {
@@ -85,7 +83,7 @@ describe('CookieStorageWithLegacySameSite', () => {
   let cookieMock;
 
   beforeEach(() => {
-    cookieMock = mocked(esCookie);
+    cookieMock = jest.mocked(esCookie);
   });
 
   it('saves object', () => {

--- a/__tests__/transaction-manager.test.ts
+++ b/__tests__/transaction-manager.test.ts
@@ -1,7 +1,6 @@
 import TransactionManager from '../src/transaction-manager';
 import { SessionStorage } from '../src/storage';
 import { TEST_CLIENT_ID, TEST_STATE } from './constants';
-import { mocked } from 'jest-mock';
 
 const TRANSACTION_KEY_PREFIX = 'a0.spajs.txs';
 
@@ -40,7 +39,7 @@ describe('transaction manager', () => {
     });
 
     it('`create` creates the transaction', () => {
-      mocked(sessionStorage.getItem).mockReturnValue(transactionJson);
+      jest.mocked(sessionStorage.getItem).mockReturnValue(transactionJson);
       tm.create(transaction);
       expect(tm.get()).toMatchObject(transaction);
     });

--- a/__tests__/transaction-manager.test.ts
+++ b/__tests__/transaction-manager.test.ts
@@ -1,7 +1,7 @@
 import TransactionManager from '../src/transaction-manager';
 import { SessionStorage } from '../src/storage';
 import { TEST_CLIENT_ID, TEST_STATE } from './constants';
-import { mocked } from 'ts-jest/utils';
+import { mocked } from 'jest-mock';
 
 const TRANSACTION_KEY_PREFIX = 'a0.spajs.txs';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "gzip-size": "^6.0.0",
         "husky": "^7.0.4",
         "idtoken-verifier": "^2.2.2",
-        "jest": "^27.3.1",
+        "jest": "^27.5.1",
         "jest-junit": "^13.0.0",
         "jest-localstorage-mock": "^2.4.18",
         "jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gzip-size": "^6.0.0",
     "husky": "^7.0.4",
     "idtoken-verifier": "^2.2.2",
-    "jest": "^27.3.1",
+    "jest": "^27.5.1",
     "jest-junit": "^13.0.0",
     "jest-localstorage-mock": "^2.4.18",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
### Changes

Running our init tests without the `silent` flag will output the following warning:

> `mocked` util function is now deprecated and has been moved to Jest repository, see https://github.com/facebook/jest/pull/12089. In `ts-jest` v28.0.0, `mocked` function will be completely removed. Users are encouraged to use to Jest v27.4.0 or above to have `mocked` function available from `jest-mock`. One can disable this warning by setting environment variable process.env.DISABLE_MOCKED_WARNING=true

This PR bumps jest and updates the mocked import path, removing the warning when running the tests.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
