### PR TITLE
[SDK-3583] Do not throw from checkSession

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -194,14 +194,15 @@ describe('Auth0', () => {
       expect(utils.runIframe).toHaveBeenCalled();
     });
 
-    it('should absorb other recoverable errors', async () => {
+    it('should absorb errors', async () => {
       const { utils, cookieStorage } = await setup();
       cookieStorage.get.mockReturnValue(true);
       const recoverableErrors = [
         'consent_required',
         'interaction_required',
         'account_selection_required',
-        'access_denied'
+        'access_denied',
+        'some_other_error'
       ];
       for (let error of recoverableErrors) {
         utils.runIframe.mockClear();
@@ -213,31 +214,6 @@ describe('Auth0', () => {
         expect(auth0).toBeInstanceOf(Auth0Client);
         expect(utils.runIframe).toHaveBeenCalledTimes(1);
       }
-    });
-
-    it('should throw for other errors that are not recoverable', async () => {
-      const { utils, cookieStorage } = await setup();
-
-      utils.runIframe.mockImplementation(() => {
-        throw {
-          error: 'some_other_error',
-          error_message: 'This is a different error to login_required'
-        };
-      });
-
-      cookieStorage.get.mockReturnValue(true);
-
-      await expect(Promise.reject(new Error('foo'))).rejects.toThrow(Error);
-
-      await expect(
-        createAuth0Client({
-          domain: TEST_DOMAIN,
-          client_id: TEST_CLIENT_ID
-        })
-      ).rejects.toStrictEqual({
-        error: 'some_other_error',
-        error_message: 'This is a different error to login_required'
-      });
     });
   });
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -47,7 +47,6 @@ import {
   DEFAULT_AUTHORIZE_TIMEOUT_IN_SECONDS,
   MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_SCOPE,
-  RECOVERABLE_ERRORS,
   DEFAULT_SESSION_CHECK_EXPIRY_DAYS,
   DEFAULT_AUTH0_CLIENT,
   INVALID_REFRESH_TOKEN_ERROR_MESSAGE,
@@ -786,11 +785,7 @@ export default class Auth0Client {
 
     try {
       await this.getTokenSilently(options);
-    } catch (error) {
-      if (!RECOVERABLE_ERRORS.includes(error.error)) {
-        throw error;
-      }
-    }
+    } catch (_) {}
   }
 
   /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,23 +47,6 @@ export const INVALID_REFRESH_TOKEN_ERROR_MESSAGE = 'invalid refresh token';
 export const DEFAULT_SCOPE = 'openid profile email';
 
 /**
- * A list of errors that can be issued by the authorization server which the
- * user can recover from by signing in interactively.
- * https://openid.net/specs/openid-connect-core-1_0.html#AuthError
- * @ignore
- */
-export const RECOVERABLE_ERRORS = [
-  'login_required',
-  'consent_required',
-  'interaction_required',
-  'account_selection_required',
-  // Strictly speaking the user can't recover from `access_denied` - but they
-  // can get more information about their access being denied by logging in
-  // interactively.
-  'access_denied'
-];
-
-/**
  * @ignore
  */
 export const DEFAULT_SESSION_CHECK_EXPIRY_DAYS = 1;


### PR DESCRIPTION
### Changes

Our SDK has [a set of recoverable errors it swallows](https://github.com/auth0/auth0-spa-js/blob/master/src/Auth0Client.ts#L790), the other errors are surfaced to the user. This has caused some confusion before, and as checkSession is a silent wrapper around getTokenSilently to see if a user can be obtained to initialize the SDK, it should swallow any exceptions. Any error probably indicates there is no user, and the SDK should behave as such. Once the user calls any of the other SDK methods (e.g. loginWithRedirect or getTokenSilently), it should surface the exact same error that was swallowed by checkSession.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
