### PR TITLE
[SDK-3582] Use form-encoded data by default

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -246,7 +246,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls the token endpoint with the correct params when using refresh tokens', async () => {
+    it('calls the token endpoint with the correct params when using refresh tokens and not using useFormData', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
         useFormData: false
@@ -274,7 +274,36 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls the token endpoint with the correct params when passing redirect uri and using refresh tokens', async () => {
+    it('calls the token endpoint with the correct params when using refresh tokens', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true
+      });
+
+      await loginWithRedirect(auth0);
+
+      mockFetch.mockReset();
+
+      await getTokenSilently(auth0, {
+        ignoreCache: true
+      });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        undefined,
+        false
+      );
+    });
+
+    it('calls the token endpoint with the correct params when passing redirect uri, using refresh tokens and not using useFormData', async () => {
       const redirect_uri = 'https://custom';
 
       const auth0 = setup({
@@ -305,7 +334,39 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls the token endpoint with the correct params when not providing any redirect uri and using refresh tokens', async () => {
+    it('calls the token endpoint with the correct params when passing redirect uri and using refresh tokens', async () => {
+      const redirect_uri = 'https://custom';
+
+      const auth0 = setup({
+        useRefreshTokens: true
+      });
+
+      await loginWithRedirect(auth0);
+
+      mockFetch.mockReset();
+
+      await getTokenSilently(auth0, {
+        redirect_uri,
+        ignoreCache: true
+      });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri,
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        undefined,
+        false
+      );
+    });
+
+    it('calls the token endpoint with the correct params when not providing any redirect uri, using refresh tokens and not using useFormData', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
         redirect_uri: null,
@@ -332,6 +393,37 @@ describe('Auth0Client', () => {
         {
           'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         }
+      );
+    });
+
+    it('calls the token endpoint with the correct params when not providing any redirect uri and using refresh tokens', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        redirect_uri: null
+      });
+
+      await loginWithRedirect(auth0);
+
+      mockFetch.mockReset();
+
+      await getTokenSilently(auth0, {
+        redirect_uri: null,
+        ignoreCache: true
+      });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: 'http://localhost',
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        undefined,
+        false
       );
     });
 
@@ -594,7 +686,7 @@ describe('Auth0Client', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('refreshes the token from a web worker', async () => {
+    it('refreshes the token from a web worker when not using useFormData', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
         useFormData: false
@@ -623,7 +715,36 @@ describe('Auth0Client', () => {
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
     });
 
-    it('refreshes the token without the worker', async () => {
+    it('refreshes the token from a web worker', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true
+      });
+
+      expect((<any>auth0).worker).toBeDefined();
+
+      await loginWithRedirect(auth0);
+
+      const access_token = await getTokenSilently(auth0, { ignoreCache: true });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          redirect_uri: TEST_REDIRECT_URI,
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        1,
+        false
+      );
+
+      expect(access_token).toEqual(TEST_ACCESS_TOKEN);
+    });
+
+    it('refreshes the token without the worker when not using useFormData', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
         cacheLocation: 'localstorage',
@@ -676,7 +797,62 @@ describe('Auth0Client', () => {
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
     });
 
-    it('refreshes the token without the worker, when window.Worker is undefined', async () => {
+    it('refreshes the token without the worker', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'localstorage'
+      });
+
+      expect((<any>auth0).worker).toBeUndefined();
+
+      await loginWithRedirect(auth0);
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        undefined,
+        false
+      );
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          expires_in: 86400
+        })
+      );
+
+      const access_token = await auth0.getTokenSilently({ ignoreCache: true });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          redirect_uri: TEST_REDIRECT_URI,
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        1,
+        false
+      );
+
+      expect(access_token).toEqual(TEST_ACCESS_TOKEN);
+    });
+
+    it('refreshes the token without the worker, when window.Worker is undefined when not using useFormData', async () => {
       mockWindow.Worker = undefined;
 
       const auth0 = setup({
@@ -717,6 +893,54 @@ describe('Auth0Client', () => {
           'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
         },
         1
+      );
+
+      expect(access_token).toEqual(TEST_ACCESS_TOKEN);
+    });
+
+    it('refreshes the token without the worker, when window.Worker is undefined', async () => {
+      mockWindow.Worker = undefined;
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'memory'
+      });
+
+      expect((<any>auth0).worker).toBeUndefined();
+
+      await loginWithRedirect(auth0);
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        undefined,
+        false
+      );
+
+      const access_token = await getTokenSilently(auth0, { ignoreCache: true });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          redirect_uri: TEST_REDIRECT_URI,
+          refresh_token: TEST_REFRESH_TOKEN
+        },
+        {
+          'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT))
+        },
+        1,
+        false
       );
 
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
@@ -1322,7 +1546,7 @@ describe('Auth0Client', () => {
       expect(releaseLockSpy).toHaveBeenCalled();
     });
 
-    it('sends custom options through to the token endpoint when using an iframe', async () => {
+    it('sends custom options through to the token endpoint when using an iframe when not using useFormData', async () => {
       const auth0 = setup({
         custom_param: 'foo',
         another_custom_param: 'bar',
@@ -1366,7 +1590,58 @@ describe('Auth0Client', () => {
       });
     });
 
-    it('sends custom options through to the token endpoint when using refresh tokens', async () => {
+    it('sends custom options through to the token endpoint when using an iframe', async () => {
+      const auth0 = setup({
+        custom_param: 'foo',
+        another_custom_param: 'bar'
+      });
+
+      await loginWithRedirect(auth0);
+
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+
+      mockFetch.mockResolvedValue(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          expires_in: 86400
+        })
+      );
+
+      await auth0.getTokenSilently({
+        ignoreCache: true,
+        custom_param: 'hello world'
+      });
+
+      expect(
+        (<any>utils.runIframe).mock.calls[0][0].includes(
+          'custom_param=hello%20world&another_custom_param=bar'
+        )
+      ).toBe(true);
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'authorization_code',
+          custom_param: 'hello world',
+          another_custom_param: 'bar',
+          code_verifier: TEST_CODE_VERIFIER
+        },
+        {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        1,
+        false
+      );
+    });
+
+    it('sends custom options through to the token endpoint when using refresh tokens when not using useFormData', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
         custom_param: 'foo',
@@ -1409,6 +1684,61 @@ describe('Auth0Client', () => {
         custom_param: 'hello world',
         another_custom_param: 'bar'
       });
+
+      expect(access_token).toEqual(TEST_ACCESS_TOKEN);
+    });
+
+    it('sends custom options through to the token endpoint when using refresh tokens', async () => {
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        custom_param: 'foo',
+        another_custom_param: 'bar'
+      });
+
+      await loginWithRedirect(auth0, undefined, {
+        token: {
+          response: { refresh_token: 'a_refresh_token' }
+        }
+      });
+
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+
+      mockFetch.mockResolvedValue(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          expires_in: 86400
+        })
+      );
+
+      expect(utils.runIframe).not.toHaveBeenCalled();
+
+      const access_token = await auth0.getTokenSilently({
+        ignoreCache: true,
+        custom_param: 'helloworld'
+      });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: 'a_refresh_token',
+          custom_param: 'helloworld',
+          another_custom_param: 'bar'
+        },
+        {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        1,
+        false
+      );
 
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
     });

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -284,7 +284,7 @@ describe('Auth0Client', () => {
       mockFetch.mockReset();
 
       await getTokenSilently(auth0, {
-        ignoreCache: true
+        cacheMode: 'off'
       });
 
       assertPost(
@@ -347,7 +347,7 @@ describe('Auth0Client', () => {
 
       await getTokenSilently(auth0, {
         redirect_uri,
-        ignoreCache: true
+        cacheMode: 'off'
       });
 
       assertPost(
@@ -408,7 +408,7 @@ describe('Auth0Client', () => {
 
       await getTokenSilently(auth0, {
         redirect_uri: null,
-        ignoreCache: true
+        cacheMode: 'off'
       });
 
       assertPost(
@@ -724,7 +724,7 @@ describe('Auth0Client', () => {
 
       await loginWithRedirect(auth0);
 
-      const access_token = await getTokenSilently(auth0, { ignoreCache: true });
+      const access_token = await getTokenSilently(auth0, { cacheMode: 'off' });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -832,7 +832,7 @@ describe('Auth0Client', () => {
         })
       );
 
-      const access_token = await auth0.getTokenSilently({ ignoreCache: true });
+      const access_token = await auth0.getTokenSilently({ cacheMode: 'off' });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -926,7 +926,7 @@ describe('Auth0Client', () => {
         false
       );
 
-      const access_token = await getTokenSilently(auth0, { ignoreCache: true });
+      const access_token = await getTokenSilently(auth0, { cacheMode: 'off' });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -1613,7 +1613,7 @@ describe('Auth0Client', () => {
       );
 
       await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         custom_param: 'hello world'
       });
 
@@ -1719,7 +1719,7 @@ describe('Auth0Client', () => {
       expect(utils.runIframe).not.toHaveBeenCalled();
 
       const access_token = await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         custom_param: 'helloworld'
       });
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -189,7 +189,9 @@ describe('Auth0Client', () => {
     });
 
     it('calls the token endpoint with the correct params', async () => {
-      const auth0 = setup();
+      const auth0 = setup({
+        useFormData: false
+      });
 
       jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
         access_token: TEST_ACCESS_TOKEN,
@@ -216,9 +218,7 @@ describe('Auth0Client', () => {
     });
 
     it('calls the token endpoint with the correct data format when using useFormData', async () => {
-      const auth0 = setup({
-        useFormData: true
-      });
+      const auth0 = setup();
 
       jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
         access_token: TEST_ACCESS_TOKEN,
@@ -248,7 +248,8 @@ describe('Auth0Client', () => {
 
     it('calls the token endpoint with the correct params when using refresh tokens', async () => {
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useFormData: false
       });
 
       await loginWithRedirect(auth0);
@@ -277,7 +278,8 @@ describe('Auth0Client', () => {
       const redirect_uri = 'https://custom';
 
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useFormData: false
       });
 
       await loginWithRedirect(auth0);
@@ -306,7 +308,8 @@ describe('Auth0Client', () => {
     it('calls the token endpoint with the correct params when not providing any redirect uri and using refresh tokens', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
-        redirect_uri: null
+        redirect_uri: null,
+        useFormData: false
       });
 
       await loginWithRedirect(auth0);
@@ -475,7 +478,9 @@ describe('Auth0Client', () => {
         },
         {
           'Auth0-Client': btoa(JSON.stringify(auth0Client))
-        }
+        },
+        undefined,
+        false
       );
     });
 
@@ -591,7 +596,8 @@ describe('Auth0Client', () => {
 
     it('refreshes the token from a web worker', async () => {
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useFormData: false
       });
 
       expect((<any>auth0).worker).toBeDefined();
@@ -620,7 +626,8 @@ describe('Auth0Client', () => {
     it('refreshes the token without the worker', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
-        cacheLocation: 'localstorage'
+        cacheLocation: 'localstorage',
+        useFormData: false
       });
 
       expect((<any>auth0).worker).toBeUndefined();
@@ -674,7 +681,8 @@ describe('Auth0Client', () => {
 
       const auth0 = setup({
         useRefreshTokens: true,
-        cacheLocation: 'memory'
+        cacheLocation: 'memory',
+        useFormData: false
       });
 
       expect((<any>auth0).worker).toBeUndefined();
@@ -1317,7 +1325,8 @@ describe('Auth0Client', () => {
     it('sends custom options through to the token endpoint when using an iframe', async () => {
       const auth0 = setup({
         custom_param: 'foo',
-        another_custom_param: 'bar'
+        another_custom_param: 'bar',
+        useFormData: false
       });
 
       await loginWithRedirect(auth0);
@@ -1361,7 +1370,8 @@ describe('Auth0Client', () => {
       const auth0 = setup({
         useRefreshTokens: true,
         custom_param: 'foo',
-        another_custom_param: 'bar'
+        another_custom_param: 'bar',
+        useFormData: false
       });
 
       await loginWithRedirect(auth0, undefined, {

--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -159,10 +159,8 @@ describe('Auth0Client', () => {
       expect(config.popup.location.href).toMatch(/screen_hint/);
     });
 
-    it('should use form data if useFormData is true', async () => {
-      const auth0 = await localSetup({
-        useFormData: true
-      });
+    it('should use form data by default', async () => {
+      const auth0 = await localSetup({});
 
       const loginOptions = {
         audience: 'other-audience',

--- a/__tests__/Auth0Client/handleRedirectCallback.test.ts
+++ b/__tests__/Auth0Client/handleRedirectCallback.test.ts
@@ -312,7 +312,7 @@ describe('Auth0Client', () => {
     });
   });
 
-  it('calls oauth/token without redirect uri if not set in transaction', async () => {
+  it('calls oauth/token without redirect uri if not set in transaction when not using useFormData', async () => {
     window.history.pushState(
       {},
       'Test',
@@ -341,6 +341,45 @@ describe('Auth0Client', () => {
     expect(fetchBody.redirect_uri).toBeUndefined();
   });
 
+  it('calls oauth/token without redirect uri if not set in transaction', async () => {
+    window.history.pushState(
+      {},
+      'Test',
+      `#/callback/?code=${TEST_CODE}&state=${TEST_ENCODED_STATE}`
+    );
+
+    mockFetch.mockResolvedValueOnce(
+      fetchResponse(true, {
+        id_token: TEST_ID_TOKEN,
+        refresh_token: TEST_REFRESH_TOKEN,
+        access_token: TEST_ACCESS_TOKEN,
+        expires_in: 86400
+      })
+    );
+
+    const auth0 = setup();
+    delete auth0['options']['redirect_uri'];
+
+    await loginWithRedirect(auth0);
+
+    assertPostFn(mockFetch)(
+      'https://auth0_domain/oauth/token',
+      {
+        redirect_uri: undefined,
+        client_id: TEST_CLIENT_ID,
+        code_verifier: TEST_CODE_VERIFIER,
+        grant_type: 'authorization_code',
+        code: TEST_CODE
+      },
+      {
+        'Auth0-Client': btoa(JSON.stringify(DEFAULT_AUTH0_CLIENT)),
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      0,
+      false
+    );
+  });
+
   it('calls oauth/token and uses form data if specified in the options', async () => {
     window.history.pushState(
       {},
@@ -357,7 +396,7 @@ describe('Auth0Client', () => {
       })
     );
 
-    const auth0 = setup({});
+    const auth0 = setup();
 
     await loginWithRedirect(auth0);
 

--- a/__tests__/Auth0Client/handleRedirectCallback.test.ts
+++ b/__tests__/Auth0Client/handleRedirectCallback.test.ts
@@ -328,7 +328,9 @@ describe('Auth0Client', () => {
       })
     );
 
-    const auth0 = setup();
+    const auth0 = setup({
+      useFormData: false
+    });
     delete auth0['options']['redirect_uri'];
 
     await loginWithRedirect(auth0);
@@ -355,9 +357,7 @@ describe('Auth0Client', () => {
       })
     );
 
-    const auth0 = setup({
-      useFormData: true
-    });
+    const auth0 = setup({});
 
     await loginWithRedirect(auth0);
 

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -336,7 +336,7 @@ describe('Auth0Client', () => {
     });
 
     it('should log the user in with a popup and get the token with form data', async () => {
-      const auth0 = setup({});
+      const auth0 = setup();
 
       await loginWithPopup(auth0);
       expect(mockWindow.open).toHaveBeenCalled();

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -312,7 +312,9 @@ describe('Auth0Client', () => {
     });
 
     it('should log the user in with a popup and get the token', async () => {
-      const auth0 = setup();
+      const auth0 = setup({
+        useFormData: false
+      });
 
       await loginWithPopup(auth0);
       expect(mockWindow.open).toHaveBeenCalled();
@@ -334,9 +336,7 @@ describe('Auth0Client', () => {
     });
 
     it('should log the user in with a popup and get the token with form data', async () => {
-      const auth0 = setup({
-        useFormData: true
-      });
+      const auth0 = setup({});
 
       await loginWithPopup(auth0);
       expect(mockWindow.open).toHaveBeenCalled();
@@ -429,7 +429,9 @@ describe('Auth0Client', () => {
     });
 
     it('uses a custom popup specified in the configuration and get a token', async () => {
-      const auth0 = setup();
+      const auth0 = setup({
+        useFormData: false
+      });
       const popup = {
         location: { href: '' },
         close: jest.fn()

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -103,7 +103,9 @@ describe('Auth0Client', () => {
 
   describe('loginWithRedirect', () => {
     it('should log the user in and get the token', async () => {
-      const auth0 = setup();
+      const auth0 = setup({
+        useFormData: false
+      });
 
       await loginWithRedirect(auth0);
 
@@ -507,8 +509,7 @@ describe('Auth0Client', () => {
         cacheLocation: 'localstorage',
         legacySameSiteCookie: true,
         nowProvider: () => Date.now(),
-        sessionCheckExpiryDays: 1,
-        useFormData: true
+        sessionCheckExpiryDays: 1
       });
 
       await loginWithRedirect(auth0);

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -102,7 +102,7 @@ describe('Auth0Client', () => {
   });
 
   describe('loginWithRedirect', () => {
-    it('should log the user in and get the token', async () => {
+    it('should log the user in and get the token when not using useFormData', async () => {
       const auth0 = setup({
         useFormData: false
       });
@@ -140,6 +140,47 @@ describe('Auth0Client', () => {
             })
           )
         }
+      );
+    });
+
+    it('should log the user in and get the token', async () => {
+      const auth0 = setup();
+
+      await loginWithRedirect(auth0);
+
+      const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
+
+      assertUrlEquals(url, TEST_DOMAIN, '/authorize', {
+        client_id: TEST_CLIENT_ID,
+        redirect_uri: TEST_REDIRECT_URI,
+        scope: TEST_SCOPES,
+        response_type: 'code',
+        response_mode: 'query',
+        state: TEST_STATE,
+        nonce: TEST_NONCE,
+        code_challenge: TEST_CODE_CHALLENGE,
+        code_challenge_method: 'S256'
+      });
+
+      assertPost(
+        'https://auth0_domain/oauth/token',
+        {
+          redirect_uri: TEST_REDIRECT_URI,
+          client_id: TEST_CLIENT_ID,
+          code_verifier: TEST_CODE_VERIFIER,
+          grant_type: 'authorization_code',
+          code: TEST_CODE
+        },
+        {
+          'Auth0-Client': btoa(
+            JSON.stringify({
+              name: 'auth0-spa-js',
+              version: version
+            })
+          )
+        },
+        undefined,
+        false
       );
     });
 

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -96,7 +96,7 @@ export function createApp(opts) {
   provider.use(async (ctx, next) => {
     await next();
 
-    if (ctx.oidc.route === 'end_session_success') {
+    if (ctx.oidc?.route === 'end_session_success') {
       ctx.redirect('http://127.0.0.1:3000');
     }
   });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -306,6 +306,8 @@ export class Auth0Client {
     }
 
     this.customOptions = getCustomInitialOptions(options);
+
+    this.options.useFormData = this.options.useFormData !== false;
   }
 
   private _url(path: string) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -209,6 +209,7 @@ export class Auth0Client {
   private readonly isAuthenticatedCookieName: string;
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
+  private readonly useFormData: boolean;
 
   cacheLocation: CacheLocation;
   private worker: Worker;
@@ -307,7 +308,7 @@ export class Auth0Client {
 
     this.customOptions = getCustomInitialOptions(options);
 
-    this.options.useFormData = this.options.useFormData !== false;
+    this.useFormData = this.options.useFormData !== false;
   }
 
   private _url(path: string) {
@@ -551,7 +552,7 @@ export class Auth0Client {
         grant_type: 'authorization_code',
         redirect_uri: params.redirect_uri,
         auth0Client: this.options.auth0Client,
-        useFormData: this.options.useFormData,
+        useFormData: this.useFormData,
         timeout: this.httpTimeoutMs
       } as OAuthTokenOptions,
       this.worker
@@ -730,7 +731,7 @@ export class Auth0Client {
       grant_type: 'authorization_code',
       code,
       auth0Client: this.options.auth0Client,
-      useFormData: this.options.useFormData,
+      useFormData: this.useFormData,
       timeout: this.httpTimeoutMs
     } as OAuthTokenOptions;
     // some old versions of the SDK might not have added redirect_uri to the
@@ -1170,7 +1171,7 @@ export class Auth0Client {
           grant_type: 'authorization_code',
           redirect_uri: params.redirect_uri,
           auth0Client: this.options.auth0Client,
-          useFormData: this.options.useFormData,
+          useFormData: this.useFormData,
           timeout: customOptions.timeout || this.httpTimeoutMs
         } as OAuthTokenOptions,
         this.worker
@@ -1267,7 +1268,7 @@ export class Auth0Client {
           redirect_uri,
           ...(timeout && { timeout }),
           auth0Client: this.options.auth0Client,
-          useFormData: this.options.useFormData,
+          useFormData: this.useFormData,
           timeout: this.httpTimeoutMs
         } as RefreshTokenOptions,
         this.worker

--- a/src/global.ts
+++ b/src/global.ts
@@ -250,8 +250,8 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   /**
    * If true, data to the token endpoint is transmitted as x-www-form-urlencoded data, if false it will be transmitted as JSON. The default setting is `true`.
    *
-   * **Note:** If you are using Auth0 rules and are sending custom, non-primitive data make sure to verify that your Auth0 Rules continue to work as expected. If they do not,
-   * then set this to `false`.
+   * **Note:** Setting this to `false` may affect you if you use Auth0 Rules and are sending custom, non-primitive data. If you disable this,
+   * please verify that your Auth0 Rules continue to work as intended.
    */
   useFormData?: boolean;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -248,11 +248,10 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   cookieDomain?: string;
 
   /**
-   * When true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON. The default is false, but will default to true in a
-   * future major version.
+   * If true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON. The default setting is `true`.
    *
-   * **Note:** Setting this to `true` may affect you if you use Auth0 Rules and are sending custom, non-primative data. If you enable this, please verify that your Auth0 Rules
-   * continue to work as intended.
+   * **Note:** If you are using Auth0 rules and are sending custom, non-primitive data make sure to verify that your Auth0 Rules continue to work as expected. If they do not,
+   * then set this to `false`.
    */
   useFormData?: boolean;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -248,7 +248,7 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   cookieDomain?: string;
 
   /**
-   * If true, data to the token endpoint is transmitted as x-www-form-urlencoded data instead of JSON. The default setting is `true`.
+   * If true, data to the token endpoint is transmitted as x-www-form-urlencoded data, if false it will be transmitted as JSON. The default setting is `true`.
    *
    * **Note:** If you are using Auth0 rules and are sending custom, non-primitive data make sure to verify that your Auth0 Rules continue to work as expected. If they do not,
    * then set this to `false`.

--- a/static/index.html
+++ b/static/index.html
@@ -606,7 +606,7 @@
             this.useConstructor = false;
             this.useCookiesForTransactions = false;
             this.organization = defaultOrganization;
-            this.useFormData = false;
+            this.useFormData = true;
             this.useOrgAtLogin = false;
             this.useRefreshTokensFallback = false
             this.saveForm();
@@ -632,7 +632,7 @@
             this.clientId = defaultClientId;
             this.audience = defaultAudience;
             this.organization = defaultOrganization;
-            this.useFormData = false;
+            this.useFormData = true;
             this.saveForm();
           },
           useNodeOidcProvider() {


### PR DESCRIPTION
### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

Updates the `useFormData` property to now default to true. Consequently, updates any tests where `useFormData: true` was previously set to now use the default, and sets `useFormData: false` where the assertions on the testcase indicate it should be.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
