### PR TITLE
[SDK-3586] Do not fallback to refreshing tokens via iframe method by default

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -873,9 +873,10 @@ describe('Auth0Client', () => {
       });
     });
 
-    it('falls back to iframe when missing refresh token errors from the worker', async () => {
+    it('falls back to iframe when missing refresh token errors from the worker and useRefreshTokensFallback is set to true', async () => {
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
       });
       expect((<any>auth0).worker).toBeDefined();
       await loginWithRedirect(auth0, undefined, {
@@ -900,10 +901,9 @@ describe('Auth0Client', () => {
       expect(utils.runIframe).toHaveBeenCalled();
     });
 
-    it('does not fall back to iframe when missing refresh token errors from the worker and useRefreshTokensFallback set to false', async () => {
+    it('does not fall back to iframe when missing refresh token errors from the worker and useRefreshTokensFallback not provided', async () => {
       const auth0 = setup({
-        useRefreshTokens: true,
-        useRefreshTokensFallback: false
+        useRefreshTokens: true
       });
       expect((<any>auth0).worker).toBeDefined();
       await loginWithRedirect(auth0, undefined, {
@@ -1006,10 +1006,11 @@ describe('Auth0Client', () => {
       });
     });
 
-    it('falls back to iframe when missing refresh token without the worker', async () => {
+    it('falls back to iframe when missing refresh token without the worker and useRefreshTokensFallback is set to true', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
-        cacheLocation: 'localstorage'
+        cacheLocation: 'localstorage',
+        useRefreshTokensFallback: true
       });
       expect((<any>auth0).worker).toBeUndefined();
       await loginWithRedirect(auth0, undefined, {
@@ -1034,10 +1035,9 @@ describe('Auth0Client', () => {
       expect(utils.runIframe).toHaveBeenCalled();
     });
 
-    it('does not fall back to iframe when missing refresh token without the worker when useRefreshTokensFallback is set to false', async () => {
+    it('does not fall back to iframe when missing refresh token without the worker when useRefreshTokensFallback is not provided', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
-        useRefreshTokensFallback: false,
         cacheLocation: 'localstorage'
       });
       expect((<any>auth0).worker).toBeUndefined();
@@ -1068,7 +1068,7 @@ describe('Auth0Client', () => {
       expect(utils.runIframe).not.toHaveBeenCalled();
     });
 
-    it('falls back to iframe when missing refresh token in ie11', async () => {
+    it('falls back to iframe when missing refresh token in ie11 and useRefreshTokensFallback is set to true', async () => {
       const originalUserAgent = window.navigator.userAgent;
       Object.defineProperty(window.navigator, 'userAgent', {
         value:
@@ -1076,7 +1076,8 @@ describe('Auth0Client', () => {
         configurable: true
       });
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
       });
       expect((<any>auth0).worker).toBeUndefined();
       await loginWithRedirect(auth0, undefined, {
@@ -1654,9 +1655,10 @@ describe('Auth0Client', () => {
       expect((http.switchFetch as jest.Mock).mock.calls[0][6]).toEqual(20000);
     });
 
-    it('when using Refresh Tokens, falls back to iframe when refresh token is expired', async () => {
+    it('when using Refresh Tokens, falls back to iframe when refresh token is expired and useRefreshTokensFallback is set to true', async () => {
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
       });
 
       await loginWithRedirect(auth0);
@@ -1698,7 +1700,8 @@ describe('Auth0Client', () => {
 
     it('when using Refresh Tokens and fallback fails, ensure the user is logged out', async () => {
       const auth0 = setup({
-        useRefreshTokens: true
+        useRefreshTokens: true,
+        useRefreshTokensFallback: true
       });
 
       await loginWithRedirect(auth0);

--- a/cypress/integration/getTokenSilently.js
+++ b/cypress/integration/getTokenSilently.js
@@ -126,6 +126,8 @@ describe('getTokenSilently', () => {
       cy.setSwitch('local-storage', true);
       cy.setSwitch('use-cache', false);
       cy.setSwitch('refresh-tokens', true);
+      cy.setSwitch('refresh-token-fallback', true);
+
       cy.login();
 
       cy.intercept({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -209,7 +209,6 @@ export class Auth0Client {
   private readonly isAuthenticatedCookieName: string;
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
-  private readonly useRefreshTokensFallback: boolean;
 
   cacheLocation: CacheLocation;
   private worker: Worker;
@@ -307,9 +306,6 @@ export class Auth0Client {
     }
 
     this.customOptions = getCustomInitialOptions(options);
-
-    this.useRefreshTokensFallback =
-      this.options.useRefreshTokensFallback === true;
   }
 
   private _url(path: string) {
@@ -817,7 +813,7 @@ export class Auth0Client {
    * remaining before expiration, return the token. Otherwise, attempt
    * to obtain a new token.
    *
-   * A new token will be obtained either by opening an iframe (if `useRefreshTokensFallback` is true) or a
+   * A new token will be obtained either by opening an iframe or a
    * refresh token (if `useRefreshTokens` is `true`).
 
    * If iframes are used, opens an iframe with the `/authorize` URL
@@ -829,7 +825,7 @@ export class Auth0Client {
    * 'refresh_token' grant. If no refresh token is available to make this call,
    * the SDK will only fall back to using an iframe to the '/authorize' URL if 
    * the `useRefreshTokensFallback` setting has been set to `true`. By default this
-   * setting is false.
+   * setting is `false`.
    *
    * This method may use a web worker to perform the token call if the in-memory
    * cache is used.
@@ -1193,7 +1189,7 @@ export class Auth0Client {
     // and useRefreshTokensFallback was explicitly enabled
     // fallback to an iframe
     if ((!cache || !cache.refresh_token) && !this.worker) {
-      if (this.useRefreshTokensFallback) {
+      if (this.options.useRefreshTokensFallback) {
         return await this._getTokenFromIFrame(options);
       }
 
@@ -1252,7 +1248,7 @@ export class Auth0Client {
           // and useRefreshTokensFallback is explicitly enabled. Fallback to an iframe.
           (e.message &&
             e.message.indexOf(INVALID_REFRESH_TOKEN_ERROR_MESSAGE) > -1)) &&
-        this.useRefreshTokensFallback
+        this.options.useRefreshTokensFallback
       ) {
         return await this._getTokenFromIFrame(options);
       }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -309,7 +309,7 @@ export class Auth0Client {
     this.customOptions = getCustomInitialOptions(options);
 
     this.useRefreshTokensFallback =
-      this.options.useRefreshTokensFallback !== false;
+      this.options.useRefreshTokensFallback === true;
   }
 
   private _url(path: string) {
@@ -817,8 +817,8 @@ export class Auth0Client {
    * remaining before expiration, return the token. Otherwise, attempt
    * to obtain a new token.
    *
-   * A new token will be obtained either by opening an iframe or a
-   * refresh token (if `useRefreshTokens` is `true`)
+   * A new token will be obtained either by opening an iframe (if `useRefreshTokensFallback` is true) or a
+   * refresh token (if `useRefreshTokens` is `true`).
 
    * If iframes are used, opens an iframe with the `/authorize` URL
    * using the parameters provided as arguments. Random and secure `state`
@@ -827,7 +827,9 @@ export class Auth0Client {
    *
    * If refresh tokens are used, the token endpoint is called directly with the
    * 'refresh_token' grant. If no refresh token is available to make this call,
-   * the SDK falls back to using an iframe to the '/authorize' URL.
+   * the SDK will only fall back to using an iframe to the '/authorize' URL if 
+   * the `useRefreshTokensFallback` setting has been set to `true`. By default this
+   * setting is false.
    *
    * This method may use a web worker to perform the token call if the in-memory
    * cache is used.
@@ -1188,7 +1190,8 @@ export class Auth0Client {
 
     // If you don't have a refresh token in memory
     // and you don't have a refresh token in web worker memory
-    // fallback to an iframe.
+    // and useRefreshTokensFallback was explicitly enabled
+    // fallback to an iframe
     if ((!cache || !cache.refresh_token) && !this.worker) {
       if (this.useRefreshTokensFallback) {
         return await this._getTokenFromIFrame(options);
@@ -1245,8 +1248,8 @@ export class Auth0Client {
         // The web worker didn't have a refresh token in memory so
         // fallback to an iframe.
         (e.message.indexOf(MISSING_REFRESH_TOKEN_ERROR_MESSAGE) > -1 ||
-          // A refresh token was found, but is it no longer valid.
-          // Fallback to an iframe.
+          // A refresh token was found, but is it no longer valid 
+          // and useRefreshTokensFallback is explicitly enabled. Fallback to an iframe.
           (e.message &&
             e.message.indexOf(INVALID_REFRESH_TOKEN_ERROR_MESSAGE) > -1)) &&
         this.useRefreshTokensFallback

--- a/src/global.ts
+++ b/src/global.ts
@@ -160,11 +160,11 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
 
   /**
    * If true, fallback to the technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens. If false, the iframe fallback is not used and
-   * errors relating to a failed Refresh Grant should be handled appropriately by having the user to login. The default setting is `false`.
+   * errors relating to a failed `refresh_token` grant should be handled appropriately. The default setting is `false`.
    *
    * **Note**: There might be situations where doing silent auth with a Web Message response from an iframe is not possible,
    * like when you're serving your application from the file system or a custom protocol (like in a Desktop or Native app).
-   * In situations like this you can disable the iframe fallback and handle the failed Refresh Grant and prompt the user to login interactively with `loginWithRedirect` or `loginWithPopup`."
+   * In situations like this you can disable the iframe fallback and handle the failed `refresh_token` grant and prompt the user to login interactively with `loginWithRedirect` or `loginWithPopup`."
    *
    * E.g. Using the `file:` protocol in an Electron application does not support that legacy technique.
    *

--- a/src/global.ts
+++ b/src/global.ts
@@ -159,8 +159,8 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   useRefreshTokens?: boolean;
 
   /**
-   * If true, fallback to the technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens.
-   * The default setting is `true`.
+   * If true, fallback to the technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens. If false, the iframe fallback is not used and
+   * errors relating to a failed Refresh Grant should be handled appropriately by having the user to login. The default setting is `false`.
    *
    * **Note**: There might be situations where doing silent auth with a Web Message response from an iframe is not possible,
    * like when you're serving your application from the file system or a custom protocol (like in a Desktop or Native app).

--- a/static/index.html
+++ b/static/index.html
@@ -307,6 +307,21 @@
                 >Use token cache when fetching new tokens</label
               >
             </div>
+
+            <div class="custom-control custom-switch mb-5">
+              <input
+                type="checkbox"
+                class="custom-control-input"
+                id="refresh-token-fallback-switch"
+                v-model="useRefreshTokensFallback"
+              />
+              <label
+                for="refresh-token-fallback-switch"
+                class="custom-control-label"
+                data-cy="switch-refresh-token-fallback"
+                >Use iframe as a fallback for refresh tokens</label
+              >
+            </div>
           </div>
           <div class="col-md-6">
             <div class="custom-control custom-switch mb-5">
@@ -436,6 +451,7 @@
             organization: data.organization || defaultOrganization,
             useFormData: data.useFormData || false,
             useOrgAtLogin: data.useOrgAtLogin || false,
+            useRefreshTokensFallback: data.useRefreshTokensFallback || false,
             clientOptions: '',
             audienceScopes: [
               {
@@ -486,6 +502,10 @@
           useFormData: function () {
             this.initializeClient();
             this.saveForm();
+          },
+          useRefreshTokensFallback: function () {
+            this.initializeClient();
+            this.saveForm();
           }
         },
         computed: {
@@ -507,7 +527,8 @@
               useRefreshTokens: _self.useRefreshTokens,
               useCookiesForTransactions: _self.useCookiesForTransactions,
               redirect_uri: window.location.origin,
-              useFormData: _self.useFormData
+              useFormData: _self.useFormData,
+              useRefreshTokensFallback: _self.useRefreshTokensFallback
             };
 
             if (_self.audience) {
@@ -567,7 +588,8 @@
                 audience: this.audience,
                 organization: this.organization,
                 useFormData: this.useFormData,
-                useOrgAtLogin: this.useOrgAtLogin
+                useOrgAtLogin: this.useOrgAtLogin,
+                useRefreshTokensFallback: this.useRefreshTokensFallback
               })
             );
 
@@ -586,6 +608,7 @@
             this.organization = defaultOrganization;
             this.useFormData = false;
             this.useOrgAtLogin = false;
+            this.useRefreshTokensFallback = false
             this.saveForm();
           },
           showAuth0Info: function () {


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

Updates the `useRefreshTokensFallback` property to now default to false, so the library will no longer fallback to the iframe method by default when refreshing a token fails.

Updates any tests where required (all tests that can have opposite cases do) and adds a toggle to the playground for this setting so that the integration tests continue to function.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
