### PR TITLE
[SDK-3541] Rework ignoreCache to cacheMode and introduce 'cache-only'.

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -539,7 +539,7 @@ describe('Auth0Client', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('does not refresh the token when cacheMode is only', async () => {
+    it('does not refresh the token when cacheMode is cache-only', async () => {
       const auth0 = setup();
       await loginWithRedirect(auth0, undefined, {
         token: {
@@ -549,13 +549,13 @@ describe('Auth0Client', () => {
 
       mockFetch.mockReset();
 
-      const token = await getTokenSilently(auth0, { cacheMode: 'only' });
+      const token = await getTokenSilently(auth0, { cacheMode: 'cache-only' });
 
       expect(token).toBe(TEST_ACCESS_TOKEN);
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('does not refresh the token when cacheMode is only and nothing in cache', async () => {
+    it('does not refresh the token when cacheMode is cache-only and nothing in cache', async () => {
       const auth0 = setup();
       await loginWithRedirect(auth0, undefined, {
         token: {
@@ -565,7 +565,7 @@ describe('Auth0Client', () => {
 
       mockFetch.mockReset();
 
-      const token = await getTokenSilently(auth0, { cacheMode: 'only' });
+      const token = await getTokenSilently(auth0, { cacheMode: 'cache-only' });
 
       expect(token).toBeUndefined();
       expect(mockFetch).not.toHaveBeenCalled();

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -256,7 +256,7 @@ describe('Auth0Client', () => {
       mockFetch.mockReset();
 
       await getTokenSilently(auth0, {
-        ignoreCache: true
+        cacheMode: 'off'
       });
 
       assertPost(
@@ -286,7 +286,7 @@ describe('Auth0Client', () => {
 
       await getTokenSilently(auth0, {
         redirect_uri,
-        ignoreCache: true
+        cacheMode: 'off'
       });
 
       assertPost(
@@ -315,7 +315,7 @@ describe('Auth0Client', () => {
 
       await getTokenSilently(auth0, {
         redirect_uri: null,
-        ignoreCache: true
+        cacheMode: 'off'
       });
 
       assertPost(
@@ -539,6 +539,38 @@ describe('Auth0Client', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
+    it('does not refresh the token when cacheMode is only', async () => {
+      const auth0 = setup();
+      await loginWithRedirect(auth0, undefined, {
+        token: {
+          response: { expires_in: 70, access_token: TEST_ACCESS_TOKEN }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      const token = await getTokenSilently(auth0, { cacheMode: 'only' });
+
+      expect(token).toBe(TEST_ACCESS_TOKEN);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh the token when cacheMode is only and nothing in cache', async () => {
+      const auth0 = setup();
+      await loginWithRedirect(auth0, undefined, {
+        token: {
+          response: { expires_in: 70, access_token: null }
+        }
+      });
+
+      mockFetch.mockReset();
+
+      const token = await getTokenSilently(auth0, { cacheMode: 'only' });
+
+      expect(token).toBeUndefined();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('refreshes the token when expires_in < constant leeway & refresh tokens are used', async () => {
       const auth0 = setup({
         useRefreshTokens: true
@@ -566,7 +598,7 @@ describe('Auth0Client', () => {
 
       await loginWithRedirect(auth0);
 
-      const access_token = await getTokenSilently(auth0, { ignoreCache: true });
+      const access_token = await getTokenSilently(auth0, { cacheMode: 'off' });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -618,7 +650,7 @@ describe('Auth0Client', () => {
         })
       );
 
-      const access_token = await auth0.getTokenSilently({ ignoreCache: true });
+      const access_token = await auth0.getTokenSilently({ cacheMode: 'off' });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -663,7 +695,7 @@ describe('Auth0Client', () => {
         }
       );
 
-      const access_token = await getTokenSilently(auth0, { ignoreCache: true });
+      const access_token = await getTokenSilently(auth0, { cacheMode: 'off' });
 
       assertPost(
         'https://auth0_domain/oauth/token',
@@ -800,7 +832,7 @@ describe('Auth0Client', () => {
       mockFetch.mockImplementation(() => Promise.reject(new Error('my_error')));
 
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow('my_error');
 
       expect(mockFetch).toBeCalledTimes(3);
@@ -824,7 +856,7 @@ describe('Auth0Client', () => {
       );
 
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow('my_error_description');
 
       expect(mockFetch).toBeCalledTimes(1);
@@ -861,7 +893,7 @@ describe('Auth0Client', () => {
       jest.spyOn(AbortController.prototype, 'abort');
 
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow(`Timeout when executing 'fetch'`);
 
       // Called thrice for the refresh token grant in token worker
@@ -895,7 +927,7 @@ describe('Auth0Client', () => {
           expires_in: 86400
         })
       );
-      const access_token = await auth0.getTokenSilently({ ignoreCache: true });
+      const access_token = await auth0.getTokenSilently({ cacheMode: 'off' });
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
       expect(utils.runIframe).toHaveBeenCalled();
     });
@@ -925,7 +957,7 @@ describe('Auth0Client', () => {
       );
 
       await expect(
-        getTokenSilently(auth0, { ignoreCache: true })
+        getTokenSilently(auth0, { cacheMode: 'off' })
       ).rejects.toThrow(
         "Missing Refresh Token (audience: '', scope: 'openid profile email offline_access')"
       );
@@ -943,7 +975,7 @@ describe('Auth0Client', () => {
       mockFetch.mockReset();
       mockFetch.mockImplementation(() => Promise.reject(new Error('my_error')));
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow('my_error');
       expect(mockFetch).toBeCalledTimes(3);
     });
@@ -963,7 +995,7 @@ describe('Auth0Client', () => {
         })
       );
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow('my_error_description');
       expect(mockFetch).toBeCalledTimes(1);
     });
@@ -996,7 +1028,7 @@ describe('Auth0Client', () => {
       );
       jest.spyOn(AbortController.prototype, 'abort');
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow(`Timeout when executing 'fetch'`);
       // Called thrice for the refresh token grant in http.switchFetch
       expect(AbortController.prototype.abort).toBeCalledTimes(3);
@@ -1029,7 +1061,7 @@ describe('Auth0Client', () => {
           expires_in: 86400
         })
       );
-      const access_token = await auth0.getTokenSilently({ ignoreCache: true });
+      const access_token = await auth0.getTokenSilently({ cacheMode: 'off' });
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
       expect(utils.runIframe).toHaveBeenCalled();
     });
@@ -1060,7 +1092,7 @@ describe('Auth0Client', () => {
       );
 
       await expect(
-        getTokenSilently(auth0, { ignoreCache: true })
+        getTokenSilently(auth0, { cacheMode: 'off' })
       ).rejects.toThrow(
         "Missing Refresh Token (audience: '', scope: 'openid profile email offline_access')"
       );
@@ -1096,7 +1128,7 @@ describe('Auth0Client', () => {
           expires_in: 86400
         })
       );
-      const access_token = await auth0.getTokenSilently({ ignoreCache: true });
+      const access_token = await auth0.getTokenSilently({ cacheMode: 'off' });
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
       expect(utils.runIframe).toHaveBeenCalled();
       Object.defineProperty(window.navigator, 'userAgent', {
@@ -1304,7 +1336,7 @@ describe('Auth0Client', () => {
       );
 
       await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         custom_param: 'hello world'
       });
 
@@ -1354,7 +1386,7 @@ describe('Auth0Client', () => {
       expect(utils.runIframe).not.toHaveBeenCalled();
 
       const access_token = await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         custom_param: 'hello world'
       });
 
@@ -1691,7 +1723,7 @@ describe('Auth0Client', () => {
         state: TEST_STATE
       });
 
-      await auth0.getTokenSilently({ ignoreCache: true });
+      await auth0.getTokenSilently({ cacheMode: 'off' });
 
       expect(utils['runIframe']).toHaveBeenCalled();
     });
@@ -1723,7 +1755,7 @@ describe('Auth0Client', () => {
       );
 
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow('login_required');
       expect(auth0.logout).toHaveBeenCalledWith({ localOnly: true });
     });
@@ -1736,7 +1768,7 @@ describe('Auth0Client', () => {
       jest.spyOn(auth0, 'logout');
 
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toThrow('login_required');
 
       expect(auth0.logout).toHaveBeenCalledWith({ localOnly: true });
@@ -1758,7 +1790,7 @@ describe('Auth0Client', () => {
       }));
 
       await expect(
-        auth0.getTokenSilently({ ignoreCache: true })
+        auth0.getTokenSilently({ cacheMode: 'off' })
       ).rejects.toHaveProperty('error', 'login_required');
 
       expect(auth0.logout).toHaveBeenCalledWith({ localOnly: true });
@@ -1784,7 +1816,7 @@ describe('Auth0Client', () => {
       );
 
       const response = await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         detailedResponse: true
       });
 
@@ -1812,7 +1844,7 @@ describe('Auth0Client', () => {
       );
 
       const response = await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         detailedResponse: true
       });
 
@@ -1877,7 +1909,7 @@ describe('Auth0Client', () => {
       jest.spyOn(auth0['cacheManager'], 'set');
 
       await auth0.getTokenSilently({
-        ignoreCache: true,
+        cacheMode: 'off',
         scope: 'read:messages'
       });
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -885,7 +885,7 @@ export default class Auth0Client {
       }
     }
 
-    if (cacheMode === 'only') {
+    if (cacheMode === 'cache-only') {
       return;
     }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -361,7 +361,7 @@ export interface GetTokenSilentlyOptions {
   /**
    * When `off`, ignores the cache and always sends a
    * request to Auth0.
-   * When `only`, only reads from the cache and never sends a request to Auth0.
+   * When `cache-only`, only reads from the cache and never sends a request to Auth0.
    * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */
   cacheMode?: 'on' | 'off' | 'cache-only';
@@ -409,7 +409,7 @@ export interface GetTokenSilentlyOptions {
 export interface GetTokenWithPopupOptions extends PopupLoginOptions {
   /**
    * When `off`, ignores the cache and always sends a request to Auth0.
-   * When `only`, only reads from the cache and never sends a request to Auth0.
+   * When `cache-only`, only reads from the cache and never sends a request to Auth0.
    * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */
   cacheMode?: 'on' | 'off' | 'cache-only';

--- a/src/global.ts
+++ b/src/global.ts
@@ -359,10 +359,12 @@ export type getIdTokenClaimsOptions = GetIdTokenClaimsOptions;
 
 export interface GetTokenSilentlyOptions {
   /**
-   * When `true`, ignores the cache and always sends a
+   * When `off`, ignores the cache and always sends a
    * request to Auth0.
+   * When `only`, only reads from the cache and never sends a request to Auth0.
+   * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */
-  ignoreCache?: boolean;
+  cacheMode?: 'on' | 'off' | 'only';
 
   /**
    * There's no actual redirect when getting a token silently,
@@ -406,10 +408,11 @@ export interface GetTokenSilentlyOptions {
 
 export interface GetTokenWithPopupOptions extends PopupLoginOptions {
   /**
-   * When `true`, ignores the cache and always sends a
-   * request to Auth0.
+   * When `off`, ignores the cache and always sends a request to Auth0.
+   * When `only`, only reads from the cache and never sends a request to Auth0.
+   * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */
-  ignoreCache?: boolean;
+  cacheMode?: 'on' | 'off' | 'only';
 }
 
 export interface LogoutUrlOptions {

--- a/src/global.ts
+++ b/src/global.ts
@@ -364,7 +364,7 @@ export interface GetTokenSilentlyOptions {
    * When `only`, only reads from the cache and never sends a request to Auth0.
    * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */
-  cacheMode?: 'on' | 'off' | 'only';
+  cacheMode?: 'on' | 'off' | 'cache-only';
 
   /**
    * There's no actual redirect when getting a token silently,
@@ -412,7 +412,7 @@ export interface GetTokenWithPopupOptions extends PopupLoginOptions {
    * When `only`, only reads from the cache and never sends a request to Auth0.
    * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */
-  cacheMode?: 'on' | 'off' | 'only';
+  cacheMode?: 'on' | 'off' | 'cache-only';
 }
 
 export interface LogoutUrlOptions {

--- a/static/index.html
+++ b/static/index.html
@@ -693,7 +693,7 @@
               .getTokenSilently({
                 audience: audience,
                 scope: scope,
-                ignoreCache: !_self.useCache
+                cacheMode: _self.useCache ? 'on' : 'off'
               })
               .then(function (token) {
                 access_tokens.push(token);

--- a/static/multiple_clients.html
+++ b/static/multiple_clients.html
@@ -191,7 +191,7 @@
           async getTokenWith(client) {
             try {
               client.access_token = await client.auth0.getTokenSilently({
-                ignoreCache: true
+                cacheMode: 'off'
               });
 
               client.error = null;

--- a/static/perf.html
+++ b/static/perf.html
@@ -83,7 +83,7 @@
         await client.loginWithPopup();
 
         await runTokenTest(
-          () => client.getTokenSilently({ ignoreCache: true }),
+          () => client.getTokenSilently({ cacheMode: 'off' }),
           'getTokenSilently (iframe)',
           5
         );
@@ -100,7 +100,7 @@
         await client.loginWithPopup();
 
         await runTokenTest(
-          () => client.getTokenSilently({ ignoreCache: true }),
+          () => client.getTokenSilently({ cacheMode: 'off' }),
           'getTokenSilently (refresh token)',
           5
         );


### PR DESCRIPTION
### Changes

This PR reworks `ignoreCache` to use `cacheMode` instead, allowing for three `caching` modes.

- **on** (default): read from the cache caching, but fall back to Auth0 as needed
- **off**: don’t read from the cache
- **cache-only**: read from the cache, don’t fall back to Auth0

With the new `cache-only` option, we provide the user with the ability to try and retrieve a token from the cache, but not call Auth0 when there isn't any token to return, or the token is expired.

Users that used to use `ignoreCache: true`, should now use `cacheMode: 'off'` instead.

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
