### PR TITLE
[SDK-3597] Replace manual querystring building with UrlSearchParams

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1342,7 +1342,7 @@ describe('Auth0Client', () => {
 
       expect(
         (<any>utils.runIframe).mock.calls[0][0].includes(
-          'custom_param=hello%20world&another_custom_param=bar'
+          'custom_param=hello+world&another_custom_param=bar'
         )
       ).toBe(true);
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1619,7 +1619,7 @@ describe('Auth0Client', () => {
 
       expect(
         (<any>utils.runIframe).mock.calls[0][0].includes(
-          'custom_param=hello%20world&another_custom_param=bar'
+          'custom_param=hello+world&another_custom_param=bar'
         )
       ).toBe(true);
 
@@ -1629,7 +1629,7 @@ describe('Auth0Client', () => {
           redirect_uri: TEST_REDIRECT_URI,
           client_id: TEST_CLIENT_ID,
           grant_type: 'authorization_code',
-          custom_param: 'hello world',
+          custom_param: 'hello+world',
           another_custom_param: 'bar',
           code_verifier: TEST_CODE_VERIFIER
         },
@@ -1689,7 +1689,6 @@ describe('Auth0Client', () => {
     });
 
     it('sends custom options through to the token endpoint when using refresh tokens', async () => {
-
       const auth0 = setup({
         useRefreshTokens: true,
         custom_param: 'foo',

--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -131,9 +131,7 @@ describe('Auth0Client', () => {
         TEST_ACCESS_TOKEN
       );
 
-      expect(config.popup.location.href).toMatch(
-        /openid%20email%20read%3Aemail/
-      );
+      expect(config.popup.location.href).toMatch(/openid\+email\+read%3Aemail/);
     });
 
     it('passes custom login options', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,11 +164,14 @@ export const createRandomString = () => {
 export const encode = (value: string) => btoa(value);
 export const decode = (value: string) => atob(value);
 
-export const createQueryParams = (params: any) => {
+const stripUndefined = (params: any) => {
   return Object.keys(params)
     .filter(k => typeof params[k] !== 'undefined')
-    .map(k => encodeURIComponent(k) + '=' + encodeURIComponent(params[k]))
-    .join('&');
+    .reduce((acc, key) => ({ ...acc, [key]: params[key] }), {});
+};
+
+export const createQueryParams = (params: any) => {
+  return new URLSearchParams(stripUndefined(params)).toString();
 };
 
 export const sha256 = async (s: string) => {

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -1,4 +1,5 @@
 import { MissingRefreshTokenError } from '../errors';
+import { createQueryParams } from '../utils';
 import { WorkerRefreshTokenMessage } from './worker.types';
 
 let refreshTokens: Record<string, string> = {};
@@ -54,10 +55,10 @@ const messageHandler = async ({
       }
 
       fetchOptions.body = useFormData
-        ? new URLSearchParams({
+        ? createQueryParams({
             ...body,
             refresh_token: refreshToken
-          }).toString()
+          })
         : JSON.stringify({
             ...body,
             refresh_token: refreshToken


### PR DESCRIPTION
### Changes

As [IE11 has no support for URLSearchParams,](https://caniuse.com/urlsearchparams) we used to rely on [manually building the querystring](https://github.com/auth0/auth0-spa-js/blob/master/src/utils.ts#L167-L172) when outside the worker, while [using URLSearchParams inside the worker](https://github.com/auth0/auth0-spa-js/blob/master/src/worker/token.worker.ts).

With support for IE11 being dropped, we should be able to use UrlSearchParams everywhere to ensure consistent URLs (URLSearchParams handles spaces differently than we do manually).

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
