### PR TITLE
[SDK-3610] Remove `getIdTokenClaimsOptions` type

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -357,11 +357,6 @@ export interface GetIdTokenClaimsOptions {
   audience?: string;
 }
 
-/*
- * TODO: Remove this on the next major
- */
-export type getIdTokenClaimsOptions = GetIdTokenClaimsOptions;
-
 export interface GetTokenSilentlyOptions {
   /**
    * When `off`, ignores the cache and always sends a


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

Removes the `getIdTokenClaimsOptions` as it was noted to be removed in the next semver major release, it was an alias for `GetIdTokenClaimsOptions` so usage should be replace with that

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
