### PR TITLE
Pin es-cookie to patch versions only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "abortcontroller-polyfill": "^1.7.3",
         "browser-tabs-lock": "^1.2.15",
         "core-js": "^3.24.0",
-        "es-cookie": "^1.3.2",
+        "es-cookie": "~1.3.2",
         "fast-text-encoding": "^1.0.4",
         "promise-polyfill": "^8.2.3",
         "unfetch": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "abortcontroller-polyfill": "^1.7.3",
     "browser-tabs-lock": "^1.2.15",
     "core-js": "^3.24.0",
-    "es-cookie": "^1.3.2",
+    "es-cookie": "~1.3.2",
     "fast-text-encoding": "^1.0.4",
     "promise-polyfill": "^8.2.3",
     "unfetch": "^4.2.0"


### PR DESCRIPTION
### Changes

`es-cookie` has released 1.4.0 which breaks our CJS bundle, this is intentional and we need to lock our version to patch versions only to ensure we exclude 1.4.0.

Closes #964 

### References

https://github.com/theodorejb/es-cookie/issues/10
https://github.com/auth0/auth0-spa-js/issues/964

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
