### PR TITLE
Release v1.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v1.22.3](https://github.com/auth0/auth0-spa-js/tree/v1.22.3) (2022-08-25)
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.2...v1.22.3)
+
+**Added**
+- feat(ClientStorage#remove):added support of cookieDomain [\#935](https://github.com/auth0/auth0-spa-js/pull/935) ([Dannnir](https://github.com/Dannnir))
+
+**Fixed**
+- Pin es-cookie to patch versions only [\#965](https://github.com/auth0/auth0-spa-js/pull/965) ([frederikprijck](https://github.com/frederikprijck))
+
 ## [v1.22.2](https://github.com/auth0/auth0-spa-js/tree/v1.22.2) (2022-07-19)
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.1...v1.22.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,31 @@
 # Change Log
 
 ## [v1.22.3](https://github.com/auth0/auth0-spa-js/tree/v1.22.3) (2022-08-25)
+
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.2...v1.22.3)
 
-**Added**
+**Changed**
+
 - feat(ClientStorage#remove):added support of cookieDomain [\#935](https://github.com/auth0/auth0-spa-js/pull/935) ([Dannnir](https://github.com/Dannnir))
 
 **Fixed**
+
 - Pin es-cookie to patch versions only [\#965](https://github.com/auth0/auth0-spa-js/pull/965) ([frederikprijck](https://github.com/frederikprijck))
 
 ## [v1.22.2](https://github.com/auth0/auth0-spa-js/tree/v1.22.2) (2022-07-19)
+
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.1...v1.22.2)
 
 **Changed**
+
 - Avoid sending unnecessary request parameters [\#920](https://github.com/auth0/auth0-spa-js/pull/920) ([frederikprijck](https://github.com/frederikprijck))
 
 ## [v1.22.1](https://github.com/auth0/auth0-spa-js/tree/v1.22.1) (2022-06-14)
+
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.0...v1.22.1)
 
 **Changed**
+
 - Stronger typing for screen_hint property [\#912](https://github.com/auth0/auth0-spa-js/pull/912) ([iAmWillShepherd](https://github.com/iAmWillShepherd))
 - Add env to auth0Client userAgent [\#913](https://github.com/auth0/auth0-spa-js/pull/913) ([frederikprijck](https://github.com/frederikprijck))
 

--- a/docs/classes/auth0client.html
+++ b/docs/classes/auth0client.html
@@ -2834,7 +2834,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L216">src/Auth0Client.ts:216</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L216">src/Auth0Client.ts:216</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2856,7 +2856,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L215">src/Auth0Client.ts:215</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L215">src/Auth0Client.ts:215</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2873,7 +2873,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L421">src/Auth0Client.ts:421</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L421">src/Auth0Client.ts:421</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2907,7 +2907,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L1009">src/Auth0Client.ts:1009</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L1009">src/Auth0Client.ts:1009</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2939,7 +2939,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L772">src/Auth0Client.ts:772</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L772">src/Auth0Client.ts:772</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2984,7 +2984,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L620">src/Auth0Client.ts:620</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L620">src/Auth0Client.ts:620</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3020,7 +3020,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L801">src/Auth0Client.ts:801</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L801">src/Auth0Client.ts:801</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3063,7 +3063,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L810">src/Auth0Client.ts:810</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L810">src/Auth0Client.ts:810</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3115,7 +3115,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L957">src/Auth0Client.ts:957</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L957">src/Auth0Client.ts:957</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3153,7 +3153,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L590">src/Auth0Client.ts:590</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L590">src/Auth0Client.ts:590</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3198,7 +3198,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L662">src/Auth0Client.ts:662</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L662">src/Auth0Client.ts:662</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3235,7 +3235,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L996">src/Auth0Client.ts:996</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L996">src/Auth0Client.ts:996</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3260,7 +3260,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L481">src/Auth0Client.ts:481</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L481">src/Auth0Client.ts:481</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3307,7 +3307,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L648">src/Auth0Client.ts:648</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L648">src/Auth0Client.ts:648</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3347,7 +3347,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/Auth0Client.ts#L1041">src/Auth0Client.ts:1041</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/Auth0Client.ts#L1041">src/Auth0Client.ts:1041</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/authenticationerror.html
+++ b/docs/classes/authenticationerror.html
@@ -2821,7 +2821,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L33">src/errors.ts:33</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L33">src/errors.ts:33</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2852,7 +2852,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L39">src/errors.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L39">src/errors.ts:39</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2863,7 +2863,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2874,7 +2874,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L38">src/errors.ts:38</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L38">src/errors.ts:38</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2935,7 +2935,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cachekey.html
+++ b/docs/classes/cachekey.html
@@ -2803,7 +2803,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2828,7 +2828,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L14">src/cache/shared.ts:14</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2838,7 +2838,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L12">src/cache/shared.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L12">src/cache/shared.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2848,7 +2848,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L16">src/cache/shared.ts:16</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L16">src/cache/shared.ts:16</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2858,7 +2858,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L13">src/cache/shared.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L13">src/cache/shared.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2875,7 +2875,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L26">src/cache/shared.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L26">src/cache/shared.ts:26</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2898,7 +2898,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L46">src/cache/shared.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L46">src/cache/shared.ts:46</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2930,7 +2930,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L35">src/cache/shared.ts:35</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L35">src/cache/shared.ts:35</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/classes/cachekeymanifest.html
+++ b/docs/classes/cachekeymanifest.html
@@ -2786,7 +2786,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/key-manifest.ts#L9">src/cache/key-manifest.ts:9</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/key-manifest.ts#L9">src/cache/key-manifest.ts:9</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2815,7 +2815,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/key-manifest.ts#L15">src/cache/key-manifest.ts:15</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/key-manifest.ts#L15">src/cache/key-manifest.ts:15</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2838,7 +2838,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/key-manifest.ts#L46">src/cache/key-manifest.ts:46</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/key-manifest.ts#L46">src/cache/key-manifest.ts:46</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2855,7 +2855,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/key-manifest.ts#L42">src/cache/key-manifest.ts:42</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/key-manifest.ts#L42">src/cache/key-manifest.ts:42</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><a href="../globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2872,7 +2872,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/key-manifest.ts#L27">src/cache/key-manifest.ts:27</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/key-manifest.ts#L27">src/cache/key-manifest.ts:27</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/cachemanager.html
+++ b/docs/classes/cachemanager.html
@@ -2786,7 +2786,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L14">src/cache/cache-manager.ts:14</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L14">src/cache/cache-manager.ts:14</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2830,7 +2830,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L83">src/cache/cache-manager.ts:83</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L83">src/cache/cache-manager.ts:83</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2853,7 +2853,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L102">src/cache/cache-manager.ts:102</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L102">src/cache/cache-manager.ts:102</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2881,7 +2881,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L23">src/cache/cache-manager.ts:23</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L23">src/cache/cache-manager.ts:23</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2907,7 +2907,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L70">src/cache/cache-manager.ts:70</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L70">src/cache/cache-manager.ts:70</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/genericerror.html
+++ b/docs/classes/genericerror.html
@@ -2832,7 +2832,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L11">src/errors.ts:11</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L11">src/errors.ts:11</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2857,7 +2857,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2867,7 +2867,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">error_<wbr>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2927,7 +2927,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/inmemorycache.html
+++ b/docs/classes/inmemorycache.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">enclosed<wbr>Cache<span class="tsd-signature-symbol">:</span> <a href="../interfaces/icache.html" class="tsd-signature-type">ICache</a><span class="tsd-signature-symbol"> = (function () {let cache: Record&lt;string, unknown&gt; &#x3D; {};return {set&lt;T &#x3D; Cacheable&gt;(key: string, entry: T) {cache[key] &#x3D; entry;},get&lt;T &#x3D; Cacheable&gt;(key: string) {const cacheEntry &#x3D; cache[key] as T;if (!cacheEntry) {return;}return cacheEntry;},remove(key: string) {delete cache[key];},allKeys(): string[] {return Object.keys(cache);}};})()</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-memory.ts#L4">src/cache/cache-memory.ts:4</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-memory.ts#L4">src/cache/cache-memory.ts:4</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/classes/localstoragecache.html
+++ b/docs/classes/localstoragecache.html
@@ -2784,7 +2784,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#allkeys">allKeys</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-localstorage.ts#L26">src/cache/cache-localstorage.ts:26</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-localstorage.ts#L26">src/cache/cache-localstorage.ts:26</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4>
@@ -2802,7 +2802,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#get">get</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-localstorage.ts#L8">src/cache/cache-localstorage.ts:8</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-localstorage.ts#L8">src/cache/cache-localstorage.ts:8</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2832,7 +2832,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#remove">remove</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-localstorage.ts#L22">src/cache/cache-localstorage.ts:22</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-localstorage.ts#L22">src/cache/cache-localstorage.ts:22</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2856,7 +2856,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Implementation of <a href="../interfaces/icache.html">ICache</a>.<a href="../interfaces/icache.html#set">set</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-localstorage.ts#L4">src/cache/cache-localstorage.ts:4</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-localstorage.ts#L4">src/cache/cache-localstorage.ts:4</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/classes/mfarequirederror.html
+++ b/docs/classes/mfarequirederror.html
@@ -2816,7 +2816,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L84">src/errors.ts:84</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L84">src/errors.ts:84</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2845,7 +2845,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2856,7 +2856,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2877,7 +2877,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">mfa_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L89">src/errors.ts:89</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L89">src/errors.ts:89</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2917,7 +2917,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/missingrefreshtokenerror.html
+++ b/docs/classes/missingrefreshtokenerror.html
@@ -2813,7 +2813,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L97">src/errors.ts:97</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L97">src/errors.ts:97</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2838,7 +2838,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L99">src/errors.ts:99</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L99">src/errors.ts:99</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2849,7 +2849,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2860,7 +2860,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2892,7 +2892,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L99">src/errors.ts:99</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L99">src/errors.ts:99</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2921,7 +2921,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popupcancellederror.html
+++ b/docs/classes/popupcancellederror.html
@@ -2809,7 +2809,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L72">src/errors.ts:72</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L72">src/errors.ts:72</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2832,7 +2832,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2843,7 +2843,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2875,7 +2875,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L74">src/errors.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L74">src/errors.ts:74</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2904,7 +2904,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/popuptimeouterror.html
+++ b/docs/classes/popuptimeouterror.html
@@ -2816,7 +2816,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="timeouterror.html">TimeoutError</a>.<a href="timeouterror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L63">src/errors.ts:63</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L63">src/errors.ts:63</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2839,7 +2839,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2850,7 +2850,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2882,7 +2882,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L65">src/errors.ts:65</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L65">src/errors.ts:65</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2911,7 +2911,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/timeouterror.html
+++ b/docs/classes/timeouterror.html
@@ -2818,7 +2818,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Overrides <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#constructor">constructor</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L51">src/errors.ts:51</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L51">src/errors.ts:51</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="timeouterror.html" class="tsd-signature-type">TimeoutError</a></h4>
@@ -2835,7 +2835,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error">error</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2846,7 +2846,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#error_description">error_description</a></p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L13">src/errors.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L13">src/errors.ts:13</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2897,7 +2897,7 @@ img {
 						<aside class="tsd-sources">
 							<p>Inherited from <a href="genericerror.html">GenericError</a>.<a href="genericerror.html#frompayload">fromPayload</a></p>
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/errors.ts#L18">src/errors.ts:18</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/errors.ts#L18">src/errors.ts:18</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/user.html
+++ b/docs/classes/user.html
@@ -2841,7 +2841,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">address<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L622">src/global.ts:622</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L622">src/global.ts:622</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2851,7 +2851,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">birthdate<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L617">src/global.ts:617</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L617">src/global.ts:617</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2861,7 +2861,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L614">src/global.ts:614</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L614">src/global.ts:614</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2871,7 +2871,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">email_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L615">src/global.ts:615</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L615">src/global.ts:615</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2881,7 +2881,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">family_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L607">src/global.ts:607</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L607">src/global.ts:607</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2891,7 +2891,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">gender<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L616">src/global.ts:616</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L616">src/global.ts:616</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2901,7 +2901,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">given_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L606">src/global.ts:606</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L606">src/global.ts:606</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2911,7 +2911,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">locale<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L619">src/global.ts:619</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L619">src/global.ts:619</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2921,7 +2921,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">middle_<wbr>name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L608">src/global.ts:608</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L608">src/global.ts:608</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2931,7 +2931,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L605">src/global.ts:605</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L605">src/global.ts:605</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2941,7 +2941,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">nickname<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L609">src/global.ts:609</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L609">src/global.ts:609</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2951,7 +2951,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L620">src/global.ts:620</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L620">src/global.ts:620</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2961,7 +2961,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">phone_<wbr>number_<wbr>verified<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L621">src/global.ts:621</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L621">src/global.ts:621</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2971,7 +2971,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">picture<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L612">src/global.ts:612</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L612">src/global.ts:612</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2981,7 +2981,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">preferred_<wbr>username<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L610">src/global.ts:610</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L610">src/global.ts:610</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2991,7 +2991,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">profile<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L611">src/global.ts:611</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L611">src/global.ts:611</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3001,7 +3001,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">sub<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L624">src/global.ts:624</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L624">src/global.ts:624</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3011,7 +3011,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">updated_<wbr>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L623">src/global.ts:623</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L623">src/global.ts:623</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3021,7 +3021,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">website<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L613">src/global.ts:613</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L613">src/global.ts:613</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3031,7 +3031,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">zoneinfo<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L618">src/global.ts:618</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L618">src/global.ts:618</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -3328,7 +3328,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>access_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>decodedToken<span class="tsd-signature-symbol">: </span><a href="interfaces/decodedtoken.html" class="tsd-signature-type">DecodedToken</a><span class="tsd-signature-symbol">; </span>expires_in<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>id_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>oauthTokenScope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>refresh_token<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3370,7 +3370,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Key<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3394,7 +3394,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L270">src/global.ts:270</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L270">src/global.ts:270</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3409,7 +3409,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cacheable<span class="tsd-signature-symbol">:</span> <a href="globals.html#wrappedcacheentry" class="tsd-signature-type">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3419,7 +3419,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L639">src/global.ts:639</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L639">src/global.ts:639</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3429,7 +3429,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Key<wbr>Manifest<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3447,7 +3447,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Maybe<wbr>Promise&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">T</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
 					</ul>
 				</aside>
 				<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3463,7 +3463,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Wrapped<wbr>Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="globals.html#cacheentry" class="tsd-signature-type">CacheEntry</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>expiresAt<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3484,7 +3484,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L358">src/global.ts:358</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L358">src/global.ts:358</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3497,7 +3497,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>KEY_<wbr>PREFIX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@auth0spajs@@"</span><span class="tsd-signature-symbol"> = &quot;@@auth0spajs@@&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3507,7 +3507,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3517,7 +3517,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3527,7 +3527,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>EXPIRY_<wbr>ADJUSTMENT_<wbr>SECONDS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3544,7 +3544,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/constants.ts#L79">src/constants.ts:79</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/constants.ts#L79">src/constants.ts:79</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -3561,7 +3561,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/index.ts#L28">src/index.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/index.ts#L28">src/index.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3329,7 +3329,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>access_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>decodedToken<span class="tsd-signature-symbol">: </span><a href="interfaces/decodedtoken.html" class="tsd-signature-type">DecodedToken</a><span class="tsd-signature-symbol">; </span>expires_in<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>id_token<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>oauthTokenScope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>refresh_token<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L62">src/cache/shared.ts:62</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3371,7 +3371,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Key<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>audience<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>client_id<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L5">src/cache/shared.ts:5</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3395,7 +3395,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cache<wbr>Location<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"localstorage"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L270">src/global.ts:270</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L270">src/global.ts:270</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3410,7 +3410,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Cacheable<span class="tsd-signature-symbol">:</span> <a href="globals.html#wrappedcacheentry" class="tsd-signature-type">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="globals.html#keymanifestentry" class="tsd-signature-type">KeyManifestEntry</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L83">src/cache/shared.ts:83</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3420,7 +3420,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Get<wbr>Token<wbr>Silently<wbr>Verbose<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TokenEndpointResponse</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"refresh_token"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L639">src/global.ts:639</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L639">src/global.ts:639</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3430,7 +3430,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Key<wbr>Manifest<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L79">src/cache/shared.ts:79</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3448,7 +3448,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Maybe<wbr>Promise&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">T</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L85">src/cache/shared.ts:85</a></li>
 					</ul>
 				</aside>
 				<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -3464,7 +3464,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">Wrapped<wbr>Cache<wbr>Entry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>body<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><a href="globals.html#cacheentry" class="tsd-signature-type">CacheEntry</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>expiresAt<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L74">src/cache/shared.ts:74</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">
@@ -3485,7 +3485,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">get<wbr>IdToken<wbr>Claims<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="interfaces/getidtokenclaimsoptions.html" class="tsd-signature-type">GetIdTokenClaimsOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L358">src/global.ts:358</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L358">src/global.ts:358</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3498,7 +3498,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>KEY_<wbr>PREFIX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"@@auth0spajs@@"</span><span class="tsd-signature-symbol"> = &quot;@@auth0spajs@@&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L3">src/cache/shared.ts:3</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3508,7 +3508,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>LOCAL_<wbr>STORAGE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"localstorage"</span><span class="tsd-signature-symbol"> = &quot;localstorage&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/constants.ts#L32">src/constants.ts:32</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/constants.ts#L32">src/constants.ts:32</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3518,7 +3518,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">CACHE_<wbr>LOCATION_<wbr>MEMORY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"memory"</span><span class="tsd-signature-symbol"> = &quot;memory&quot;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/constants.ts#L31">src/constants.ts:31</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/constants.ts#L31">src/constants.ts:31</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3528,7 +3528,7 @@ client.loginWithPopup({
 				<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>EXPIRY_<wbr>ADJUSTMENT_<wbr>SECONDS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> = 0</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/cache-manager.ts#L12">src/cache/cache-manager.ts:12</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -3545,7 +3545,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/constants.ts#L79">src/constants.ts:79</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/constants.ts#L79">src/constants.ts:79</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -3562,7 +3562,7 @@ client.loginWithPopup({
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/index.ts#L28">src/index.ts:28</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/index.ts#L28">src/index.ts:28</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/advancedoptions.html
+++ b/docs/interfaces/advancedoptions.html
@@ -2761,7 +2761,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">default<wbr>Scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L107">src/global.ts:107</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L107">src/global.ts:107</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/auth0clientoptions.html
+++ b/docs/interfaces/auth0clientoptions.html
@@ -2897,7 +2897,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2907,7 +2907,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">advanced<wbr>Options<span class="tsd-signature-symbol">:</span> <a href="advancedoptions.html" class="tsd-signature-type">AdvancedOptions</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L229">src/global.ts:229</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L229">src/global.ts:229</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2923,7 +2923,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2938,7 +2938,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">authorize<wbr>Timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L186">src/global.ts:186</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L186">src/global.ts:186</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2954,7 +2954,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<span class="tsd-signature-symbol">:</span> <a href="icache.html" class="tsd-signature-type">ICache</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L151">src/global.ts:151</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L151">src/global.ts:151</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2969,7 +2969,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cache<wbr>Location<span class="tsd-signature-symbol">:</span> <a href="../globals.html#cachelocation" class="tsd-signature-type">CacheLocation</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L146">src/global.ts:146</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L146">src/global.ts:146</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2986,7 +2986,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L124">src/global.ts:124</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L124">src/global.ts:124</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3002,7 +3002,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3019,7 +3019,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cookie<wbr>Domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L248">src/global.ts:248</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L248">src/global.ts:248</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3040,7 +3040,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3060,7 +3060,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L116">src/global.ts:116</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L116">src/global.ts:116</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3077,7 +3077,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">http<wbr>Timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L191">src/global.ts:191</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L191">src/global.ts:191</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3093,7 +3093,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3109,7 +3109,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3124,7 +3124,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">issuer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L120">src/global.ts:120</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L120">src/global.ts:120</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3139,7 +3139,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">leeway<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L138">src/global.ts:138</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L138">src/global.ts:138</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3156,7 +3156,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">legacy<wbr>Same<wbr>Site<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L211">src/global.ts:211</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L211">src/global.ts:211</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3177,7 +3177,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3196,7 +3196,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3213,7 +3213,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">now<wbr>Provider<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L264">src/global.ts:264</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L264">src/global.ts:264</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3245,7 +3245,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3263,7 +3263,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3283,7 +3283,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L132">src/global.ts:132</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L132">src/global.ts:132</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3303,7 +3303,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3321,7 +3321,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3339,7 +3339,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">session<wbr>Check<wbr>Expiry<wbr>Days<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L235">src/global.ts:235</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L235">src/global.ts:235</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3356,7 +3356,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3372,7 +3372,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Cookies<wbr>For<wbr>Transactions<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L224">src/global.ts:224</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L224">src/global.ts:224</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3395,7 +3395,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Form<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L257">src/global.ts:257</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L257">src/global.ts:257</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3413,7 +3413,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Refresh<wbr>Tokens<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L159">src/global.ts:159</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L159">src/global.ts:159</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3430,7 +3430,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">use<wbr>Refresh<wbr>Tokens<wbr>Fallback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L180">src/global.ts:180</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L180">src/global.ts:180</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/decodedtoken.html
+++ b/docs/interfaces/decodedtoken.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">claims<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IdToken</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L58">src/cache/shared.ts:58</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L58">src/cache/shared.ts:58</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2775,7 +2775,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <a href="../classes/user.html" class="tsd-signature-type">User</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L59">src/cache/shared.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L59">src/cache/shared.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/getidtokenclaimsoptions.html
+++ b/docs/interfaces/getidtokenclaimsoptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L352">src/global.ts:352</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L352">src/global.ts:352</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2780,7 +2780,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L348">src/global.ts:348</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L348">src/global.ts:348</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokensilentlyoptions.html
+++ b/docs/interfaces/gettokensilentlyoptions.html
@@ -2791,7 +2791,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L385">src/global.ts:385</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L385">src/global.ts:385</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2806,7 +2806,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">detailed<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L398">src/global.ts:398</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L398">src/global.ts:398</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2823,7 +2823,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L365">src/global.ts:365</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L365">src/global.ts:365</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2839,7 +2839,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L375">src/global.ts:375</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L375">src/global.ts:375</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2859,7 +2859,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L380">src/global.ts:380</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L380">src/global.ts:380</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L390">src/global.ts:390</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L390">src/global.ts:390</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/gettokenwithpopupoptions.html
+++ b/docs/interfaces/gettokenwithpopupoptions.html
@@ -2829,7 +2829,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2840,7 +2840,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2856,7 +2856,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2895,7 +2895,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2910,7 +2910,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">ignore<wbr>Cache<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L412">src/global.ts:412</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L412">src/global.ts:412</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2927,7 +2927,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2943,7 +2943,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2980,7 +2980,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2998,7 +2998,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3019,7 +3019,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3037,7 +3037,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3056,7 +3056,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/getuseroptions.html
+++ b/docs/interfaces/getuseroptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L341">src/global.ts:341</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L341">src/global.ts:341</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2780,7 +2780,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L337">src/global.ts:337</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L337">src/global.ts:337</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/icache.html
+++ b/docs/interfaces/icache.html
@@ -2783,7 +2783,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L91">src/cache/shared.ts:91</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L91">src/cache/shared.ts:91</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <a href="../globals.html#maybepromise" class="tsd-signature-type">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -2800,7 +2800,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L89">src/cache/shared.ts:89</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L89">src/cache/shared.ts:89</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -2829,7 +2829,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L90">src/cache/shared.ts:90</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L90">src/cache/shared.ts:90</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -2852,7 +2852,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/cache/shared.ts#L88">src/cache/shared.ts:88</a></li>
+								<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/cache/shared.ts#L88">src/cache/shared.ts:88</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/interfaces/logoutoptions.html
+++ b/docs/interfaces/logoutoptions.html
@@ -2773,7 +2773,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L474">src/global.ts:474</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L474">src/global.ts:474</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2791,7 +2791,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L483">src/global.ts:483</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L483">src/global.ts:483</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2810,7 +2810,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">local<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L491">src/global.ts:491</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L491">src/global.ts:491</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2828,7 +2828,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L463">src/global.ts:463</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L463">src/global.ts:463</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logouturloptions.html
+++ b/docs/interfaces/logouturloptions.html
@@ -2769,7 +2769,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">client_<wbr>id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L439">src/global.ts:439</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L439">src/global.ts:439</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2787,7 +2787,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">federated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L447">src/global.ts:447</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L447">src/global.ts:447</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2805,7 +2805,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L428">src/global.ts:428</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L428">src/global.ts:428</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popupconfigoptions.html
+++ b/docs/interfaces/popupconfigoptions.html
@@ -2765,7 +2765,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L330">src/global.ts:330</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L330">src/global.ts:330</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2782,7 +2782,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">timeout<wbr>InSeconds<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L323">src/global.ts:323</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L323">src/global.ts:323</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/popuploginoptions.html
+++ b/docs/interfaces/popuploginoptions.html
@@ -2830,7 +2830,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2841,7 +2841,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2857,7 +2857,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2875,7 +2875,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2896,7 +2896,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2912,7 +2912,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2928,7 +2928,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2947,7 +2947,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2965,7 +2965,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2983,7 +2983,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3004,7 +3004,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3022,7 +3022,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3041,7 +3041,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginoptions.html
+++ b/docs/interfaces/redirectloginoptions.html
@@ -2849,7 +2849,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.acr_values</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L59">src/global.ts:59</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L59">src/global.ts:59</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2859,7 +2859,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TAppState</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L298">src/global.ts:298</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L298">src/global.ts:298</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2875,7 +2875,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.audience</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L71">src/global.ts:71</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L71">src/global.ts:71</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2891,7 +2891,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.connection</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L78">src/global.ts:78</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L78">src/global.ts:78</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2909,7 +2909,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.display</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L13">src/global.ts:13</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L13">src/global.ts:13</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2929,7 +2929,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">fragment<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L302">src/global.ts:302</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L302">src/global.ts:302</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2945,7 +2945,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.id_token_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L39">src/global.ts:39</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L39">src/global.ts:39</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2961,7 +2961,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.invitation</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L91">src/global.ts:91</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L91">src/global.ts:91</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2977,7 +2977,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.login_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L57">src/global.ts:57</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L57">src/global.ts:57</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2996,7 +2996,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.max_age</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L28">src/global.ts:28</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L28">src/global.ts:28</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3014,7 +3014,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.organization</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L86">src/global.ts:86</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L86">src/global.ts:86</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3032,7 +3032,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.prompt</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L21">src/global.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L21">src/global.ts:21</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3052,7 +3052,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect<wbr>Method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"replace"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">"assign"</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L306">src/global.ts:306</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L306">src/global.ts:306</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3067,7 +3067,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">redirect_<wbr>uri<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L294">src/global.ts:294</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L294">src/global.ts:294</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3086,7 +3086,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.scope</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L66">src/global.ts:66</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L66">src/global.ts:66</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3104,7 +3104,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.screen_hint</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L48">src/global.ts:48</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L48">src/global.ts:48</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3123,7 +3123,7 @@ img {
 				<aside class="tsd-sources">
 					<p>Inherited from BaseLoginOptions.ui_locales</p>
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L34">src/global.ts:34</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L34">src/global.ts:34</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/redirectloginresult.html
+++ b/docs/interfaces/redirectloginresult.html
@@ -2769,7 +2769,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">app<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TAppState</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/963bcfc/src/global.ts#L313">src/global.ts:313</a></li>
+						<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/b8ee5f2/src/global.ts#L313">src/global.ts:313</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-spa-js",
-      "version": "1.22.2",
+      "version": "1.22.3",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.22.2",
+  "version": "1.22.3",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.22.2';
+export default '1.22.3';


### PR DESCRIPTION
**Changed**
- feat(ClientStorage#remove):added support of cookieDomain [\#935](https://github.com/auth0/auth0-spa-js/pull/935) ([Dannnir](https://github.com/Dannnir))

**Fixed**
- Pin es-cookie to patch versions only [\#965](https://github.com/auth0/auth0-spa-js/pull/965) ([frederikprijck](https://github.com/frederikprijck))
