### PR TITLE
[SDK-3613] Move defaultScope from advancedOptions to the root object

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,17 +377,15 @@ if (organization && invitation) {
 }
 ```
 
-### Advanced options
+### Overriding Default Scopes
 
-Advanced options can be set by specifying the `advancedOptions` property when configuring `Auth0Client`. Learn about the complete set of advanced options in the [API documentation](https://auth0.github.io/auth0-spa-js/interfaces/advancedoptions.html)
+To override the default scopes that are set, specify the `defaultScope` property on the `Auth0Client`. By default this is set to `profile email`. `openid` will always be set by the SDK regardless of this setting.
 
 ```js
 createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
-  advancedOptions: {
-    defaultScope: 'email' // change the scopes that are applied to every authz request. **Note**: `openid` is always specified regardless of this setting
-  }
+  defaultScope: 'email' // change the scopes that are applied to every authz request. **Note**: `openid` is always specified regardless of this setting
 });
 ```
 

--- a/__tests__/Auth0Client/constructor.test.ts
+++ b/__tests__/Auth0Client/constructor.test.ts
@@ -89,9 +89,7 @@ describe('Auth0Client', () => {
 
     it('ensures the openid scope is defined when customizing default scopes', () => {
       const auth0 = setup({
-        advancedOptions: {
-          defaultScope: 'test-scope'
-        }
+        defaultScope: 'test-scope'
       });
 
       expect((<any>auth0).scope).toBe('openid test-scope');
@@ -99,9 +97,7 @@ describe('Auth0Client', () => {
 
     it('allows an empty custom default scope', () => {
       const auth0 = setup({
-        advancedOptions: {
-          defaultScope: null
-        }
+        defaultScope: null
       });
 
       expect((<any>auth0).scope).toBe('openid');

--- a/__tests__/Auth0Client/getIdTokenClaims.test.ts
+++ b/__tests__/Auth0Client/getIdTokenClaims.test.ts
@@ -124,9 +124,7 @@ describe('Auth0Client', () => {
               authorizationParams: {
                 scope: 'scope1'
               },
-              advancedOptions: {
-                defaultScope: 'scope2'
-              }
+              defaultScope: 'scope2'
             });
             await login(auth0, { authorizationParams: { scope: 'scope3' } });
 
@@ -153,9 +151,7 @@ describe('Auth0Client', () => {
                 authorizationParams: {
                   scope: 'scope1'
                 },
-                advancedOptions: {
-                  defaultScope: 'scope2'
-                },
+                defaultScope: 'scope2',
                 useRefreshTokens: true
               });
               await login(auth0, { authorizationParams: { scope: 'scope3' } });

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -503,9 +503,7 @@ describe('Auth0Client', () => {
 
     it('refreshes the token using custom default scope', async () => {
       const auth0 = setup({
-        advancedOptions: {
-          defaultScope: 'email'
-        }
+        defaultScope: 'email'
       });
 
       await loginWithRedirect(auth0, undefined, {
@@ -536,9 +534,7 @@ describe('Auth0Client', () => {
     it('refreshes the token using custom default scope when using refresh tokens', async () => {
       const auth0 = setup({
         useRefreshTokens: true,
-        advancedOptions: {
-          defaultScope: 'email'
-        }
+        defaultScope: 'email'
       });
 
       await loginWithRedirect(auth0, undefined, {
@@ -2294,9 +2290,7 @@ describe('Auth0Client', () => {
         authorizationParams: {
           scope: 'read:messages'
         },
-        advancedOptions: {
-          defaultScope: 'email'
-        }
+        defaultScope: 'email'
       });
 
       await loginWithRedirect(auth0, undefined, {

--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -110,9 +110,7 @@ describe('Auth0Client', () => {
 
     it('respects customized scopes', async () => {
       const auth0 = await localSetup({
-        advancedOptions: {
-          defaultScope: 'email'
-        },
+        defaultScope: 'email',
         authorizationParams: {
           scope: 'read:email'
         }

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -130,9 +130,7 @@ describe('Auth0Client', () => {
         authorizationParams: {
           scope: 'scope1'
         },
-        advancedOptions: {
-          defaultScope: 'scope2'
-        }
+        defaultScope: 'scope2'
       });
       await loginWithPopup(auth0, { authorizationParams: { scope: 'scope3' } });
 

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -184,9 +184,7 @@ describe('Auth0Client', () => {
 
     it('should log the user in using different default scope', async () => {
       const auth0 = setup({
-        advancedOptions: {
-          defaultScope: 'email'
-        }
+        defaultScope: 'email'
       });
 
       await loginWithRedirect(auth0);
@@ -341,9 +339,7 @@ describe('Auth0Client', () => {
         authorizationParams: {
           scope: 'scope1'
         },
-        advancedOptions: {
-          defaultScope: 'scope2'
-        }
+        defaultScope: 'scope2'
       });
 
       await loginWithRedirect(auth0, {
@@ -559,9 +555,7 @@ describe('Auth0Client', () => {
       // list in Auth0Client._getParams so that it is not sent to the IdP
       const auth0 = setup({
         useRefreshTokens: true,
-        advancedOptions: {
-          defaultScope: 'openid profile email offline_access'
-        },
+        defaultScope: 'openid profile email offline_access',
         useCookiesForTransactions: true,
         authorizeTimeoutInSeconds: 10,
         cacheLocation: 'localstorage',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -178,6 +178,7 @@ export class Auth0Client {
 
   private readonly defaultOptions: Partial<Auth0ClientOptions> = {
     authorizationParams: {},
+    defaultScope: DEFAULT_SCOPE,
     useRefreshTokensFallback: false,
     useFormData: true
   };
@@ -233,9 +234,7 @@ export class Auth0Client {
 
     this.scope = getUniqueScopes(
       'openid',
-      this.options.advancedOptions?.defaultScope !== undefined
-        ? this.options.advancedOptions.defaultScope
-        : DEFAULT_SCOPE,
+      this.options.defaultScope,
       this.options.authorizationParams?.scope
     );
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -114,16 +114,6 @@ interface BaseLoginOptions {
   authorizationParams?: AuthorizationParams;
 }
 
-export interface AdvancedOptions {
-  /**
-   * The default scope to be included with all requests.
-   * If not provided, 'openid profile email' is used. This can be set to `null` in order to effectively remove the default scopes.
-   *
-   * Note: The `openid` scope is **always applied** regardless of this setting.
-   */
-  defaultScope?: string;
-}
-
 export interface Auth0ClientOptions extends BaseLoginOptions {
   /**
    * Your Auth0 account domain such as `'example.auth0.com'`,
@@ -234,11 +224,6 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
   useCookiesForTransactions?: boolean;
 
   /**
-   * Changes to recommended defaults, like defaultScope
-   */
-  advancedOptions?: AdvancedOptions;
-
-  /**
    * Number of days until the cookie `auth0.is.authenticated` will expire
    * Defaults to 1.
    */
@@ -271,6 +256,14 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
    * **Note**: Using this improperly can potentially compromise the token validation.
    */
   nowProvider?: () => Promise<number> | number;
+
+  /**
+   * The default scope to be included with all requests.
+   * If not provided, 'openid profile email' is used. This can be set to `null` in order to effectively remove the default scopes.
+   *
+   * Note: The `openid` scope is **always applied** regardless of this setting.
+   */
+  defaultScope?: string;
 }
 
 /**


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

Moves `defaultScope` to the root of the options object from the `advancedOptions` object. This choice was taken as there have been no other parameters added to this object since the addition.

For those who are using this property currently, the change is as follows

```diff
createAuth0Client({
  domain: '<AUTH0_DOMAIN>',
  clientId: '<AUTH0_CLIENT_ID>',
- advancedOptions: {
-   defaultScope: 'email'
- }
+  defaultScope: 'email'
});
```

```diff
const client = new Auth0Client({
  domain: '<AUTH0_DOMAIN>',
  clientId: '<AUTH0_CLIENT_ID>',
- advancedOptions: {
-   defaultScope: 'email'
- }
+  defaultScope: 'email'
});
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
