### PR TITLE
[SDK-3615] Do not build CJS module with externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,12 @@
     "@typescript-eslint/eslint-plugin-tslint": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
     "browserstack-cypress-cli": "1.8.1",
+    "browser-tabs-lock": "^1.2.15",
     "cli-table": "^0.3.6",
     "concurrently": "^7.3.0",
     "cypress": "7.2.0",
     "es-check": "^7.0.0",
+    "es-cookie": "^1.3.2",
     "eslint": "^8.22.0",
     "gzip-size": "^7.0.0",
     "husky": "^7.0.4",
@@ -78,10 +80,6 @@
     "typedoc": "^0.23.10",
     "typescript": "^4.7.4",
     "wait-on": "^6.0.0"
-  },
-  "dependencies": {
-    "browser-tabs-lock": "^1.2.15",
-    "es-cookie": "^1.3.2"
   },
   "files": [
     "src",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -126,8 +126,7 @@ if (isProduction) {
           format: 'cjs'
         }
       ],
-      plugins: getPlugins(false),
-      external: Object.keys(pkg.dependencies)
+      plugins: getPlugins(false)
     }
   );
 }


### PR DESCRIPTION
### Changes

Some of our modules are bundles with, and others are bundles without our dependencies marked as external. Let’s take the opportunity to be consistent among our bundles and remove the external property from the CJS bundle.

As we are bundling our dependencies, I have moved the dependencies to be devDependencies instead. This also avoids any unnecessary console output with our users from installing third-party packages through our installing our SDK.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
