### PR TITLE
Add a random delay before trying to aquire a lock

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -251,3 +251,12 @@ export const validateCrypto = () => {
 export function valueOrEmptyString(value: string, exclude: string[] = []) {
   return value && !exclude.includes(value) ? value : '';
 }
+
+function getRandomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+export function randomDelay(min: number = 1, max: number = 10) {
+  const delayMs = getRandomInt(min, max) * 10;
+  return new Promise(resolve => setTimeout(resolve, delayMs));
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,11 +252,15 @@ export function valueOrEmptyString(value: string, exclude: string[] = []) {
   return value && !exclude.includes(value) ? value : '';
 }
 
-function getRandomInt(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min) + min);
+function getRandomInt(min: number, max: number, increment: number = 5) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+
+  const amountOfItems = Math.floor((max - min) / increment);
+  return Math.floor(Math.random() * amountOfItems) * increment + min;
 }
 
-export function randomDelay(min: number = 1, max: number = 10) {
-  const delayMs = getRandomInt(min, max) * 10;
+export function randomDelay(min: number = 10, max: number = 100) {
+  const delayMs = getRandomInt(min, max);
   return new Promise(resolve => setTimeout(resolve, delayMs));
 }


### PR DESCRIPTION
### Changes

Even tho not entirely related to the reported issue, but while looking into https://github.com/auth0/auth0-spa-js/issues/938, I noticed the following behavior when using our SDK:

- I opened 3 tabs, all using our playground
- I artificially slowed our getTokenSilently call by adding a delay of 5 seconds
- Every tab calls getTokenSilently, only one tab will acquire a lock and the other two will wait.
- 5 seconds pass, the first tab is finished, and released the lock
- **both other tabs now acquire the lock and both fire a request to `oauth/token`**

It appears to be happening because both tabs try to acquire a lock at the exact same time, both resulting in not finding an existing lock and both acting as if they are the one acquiring the lock, hence doing the call to oauth/token.

This PR adds a random delay between 10 and 100, using increments of 5, before trying to acquire a lock to prevent this race condition.

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
