### PR TITLE
[SDK-3620] Release lock on pagehide

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -90,6 +90,7 @@ describe('Auth0Client', () => {
 
     mockWindow.open = jest.fn();
     mockWindow.addEventListener = jest.fn();
+    mockWindow.removeEventListener = jest.fn();
 
     mockWindow.crypto = {
       subtle: {
@@ -1522,7 +1523,8 @@ describe('Auth0Client', () => {
       await getTokenSilently(auth0);
 
       expect(esCookie.remove).toHaveBeenCalledWith(
-        `auth0.${TEST_CLIENT_ID}.organization_hint`, {}
+        `auth0.${TEST_CLIENT_ID}.organization_hint`,
+        {}
       );
     });
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1213,6 +1213,48 @@ describe('Auth0Client', () => {
       expect(releaseLockSpy).toHaveBeenCalledWith(GET_TOKEN_SILENTLY_LOCK_KEY);
     });
 
+    it('should add and remove a pagehide handler', async () => {
+      const auth0 = setup();
+
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+
+      await getTokenSilently(auth0);
+
+      expect(mockWindow.addEventListener).toHaveBeenCalledWith(
+        'pagehide',
+        expect.anything()
+      );
+      expect(mockWindow.removeEventListener).toHaveBeenCalledWith(
+        'pagehide',
+        expect.anything()
+      );
+    });
+
+    it('should release the lock when pagehide handler triggered', async () => {
+      const auth0 = setup();
+
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+
+      mockWindow.addEventListener.mockImplementation((event, handler) => {
+        if (event === 'pagehide') {
+          handler();
+          expect(releaseLockSpy).toHaveBeenCalledWith(
+            GET_TOKEN_SILENTLY_LOCK_KEY
+          );
+        }
+      });
+
+      expect.assertions(1);
+
+      await getTokenSilently(auth0);
+    });
+
     it('should retry acquiring a lock', async () => {
       const auth0 = setup();
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -211,7 +211,6 @@ export default class Auth0Client {
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
   private readonly useRefreshTokensFallback: boolean;
-  private acquiredLock: boolean;
 
   cacheLocation: CacheLocation;
   private worker: Worker;

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -211,6 +211,7 @@ export default class Auth0Client {
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
   private readonly useRefreshTokensFallback: boolean;
+  private acquiredLock: boolean;
 
   cacheLocation: CacheLocation;
   private worker: Worker;
@@ -403,7 +404,9 @@ export default class Auth0Client {
         cookieDomain: this.options.cookieDomain
       });
     } else {
-      this.cookieStorage.remove(this.orgHintCookieName, { cookieDomain: this.options.cookieDomain });
+      this.cookieStorage.remove(this.orgHintCookieName, {
+        cookieDomain: this.options.cookieDomain
+      });
     }
   }
 
@@ -892,6 +895,8 @@ export default class Auth0Client {
       )
     ) {
       try {
+        window.addEventListener('pagehide', this.releaseLockOnPageHide);
+
         // Check the cache a second time, because it may have been populated
         // by a previous call while this call was waiting to acquire the lock.
         if (!ignoreCache) {
@@ -936,6 +941,7 @@ export default class Auth0Client {
         return authResult.access_token;
       } finally {
         await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
+        window.removeEventListener('pagehide', this.releaseLockOnPageHide);
       }
     } else {
       throw new TimeoutError();
@@ -1048,8 +1054,12 @@ export default class Auth0Client {
     }
 
     const postCacheClear = () => {
-      this.cookieStorage.remove(this.orgHintCookieName, { cookieDomain: this.options.cookieDomain });
-      this.cookieStorage.remove(this.isAuthenticatedCookieName, { cookieDomain: this.options.cookieDomain });
+      this.cookieStorage.remove(this.orgHintCookieName, {
+        cookieDomain: this.options.cookieDomain
+      });
+      this.cookieStorage.remove(this.isAuthenticatedCookieName, {
+        cookieDomain: this.options.cookieDomain
+      });
 
       if (localOnly) {
         return;
@@ -1308,4 +1318,16 @@ export default class Auth0Client {
       return entry.access_token;
     }
   }
+
+  /**
+   * Releases any lock acquired by the current page that's not released yet
+   *
+   * Get's called on the `pagehide` event.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event
+   */
+  private releaseLockOnPageHide = async () => {
+    await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
+
+    window.removeEventListener('pagehide', this.releaseLockOnPageHide);
+  };
 }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -894,7 +894,7 @@ export default class Auth0Client {
       )
     ) {
       try {
-        window.addEventListener('pagehide', this.releaseLockOnPageHide);
+        window.addEventListener('pagehide', this._releaseLockOnPageHide);
 
         // Check the cache a second time, because it may have been populated
         // by a previous call while this call was waiting to acquire the lock.
@@ -940,7 +940,7 @@ export default class Auth0Client {
         return authResult.access_token;
       } finally {
         await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
-        window.removeEventListener('pagehide', this.releaseLockOnPageHide);
+        window.removeEventListener('pagehide', this._releaseLockOnPageHide);
       }
     } else {
       throw new TimeoutError();
@@ -1324,9 +1324,9 @@ export default class Auth0Client {
    * Get's called on the `pagehide` event.
    * https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event
    */
-  private releaseLockOnPageHide = async () => {
+  private _releaseLockOnPageHide = async () => {
     await lock.releaseLock(GET_TOKEN_SILENTLY_LOCK_KEY);
 
-    window.removeEventListener('pagehide', this.releaseLockOnPageHide);
+    window.removeEventListener('pagehide', this._releaseLockOnPageHide);
   };
 }


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

When the user refreshes the page before the acquired lock is released, we end up with a lock that isn't instantly cleaned up. This result in the fact that any subsequent call to try and acquire a lock will wait for the previous lock to be released, which can take a while before it get cleaned up (as we can't release it anymore once refreshed the page because of the fact [the library checks for id internally when trying to release a lock](https://github.com/supertokens/browser-tabs-lock/blob/master/index.ts#L226).

To work around this, we will clean up any locks when the `pagehide` event is triggered in between acquiring and releasing the lock. This should only clean up the lock if it's acquired by the current SDK instance, and not from another browser tab.

### References
Fixes #938

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
