### PR TITLE
[SDK-3588] Cache and return id token from memory so that object comparison works

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs
+static/auth0-spa-js.development_old.js

--- a/__tests__/Auth0Client/getUser.test.ts
+++ b/__tests__/Auth0Client/getUser.test.ts
@@ -169,6 +169,28 @@ describe('Auth0Client', () => {
       const secondUser = await auth0.getUser();
 
       expect(user).toBe(secondUser);
+    });
+
+    it('should return a new object from the cache when the user object changes', async () => {
+      const getMock = jest.fn();
+      const cache: ICache = {
+        get: getMock,
+        set: jest.fn(),
+        remove: jest.fn(),
+        allKeys: jest.fn()
+      };
+
+      getMock.mockImplementation((key: string) => {
+        if (key === '@@auth0spajs@@::auth0_client_id::@@user@@') {
+          return { id_token: 'abcd', decodedToken: { user: { sub: '123' } } };
+        }
+      });
+
+      const auth0 = setup({ cache });
+      const user = await auth0.getUser();
+      const secondUser = await auth0.getUser();
+
+      expect(user).toBe(secondUser);
 
       getMock.mockImplementation((key: string) => {
         if (key === '@@auth0spajs@@::auth0_client_id::@@user@@') {
@@ -181,6 +203,18 @@ describe('Auth0Client', () => {
 
       const thirdUser = await auth0.getUser();
       expect(thirdUser).not.toBe(user);
+    });
+
+    it('should return undefined if there is no cache entry', async () => {
+      const cache: ICache = {
+        get: jest.fn(),
+        set: jest.fn(),
+        remove: jest.fn(),
+        allKeys: jest.fn()
+      };
+
+      const auth0 = setup({ cache });
+      await expect(auth0.getUser()).resolves.toBe(undefined);
     });
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -25,7 +25,7 @@ import {
   CacheManager,
   CacheEntry,
   IdTokenEntry,
-  USER_CACHE_KEY
+  CACHE_KEY_ID_TOKEN_SUFFIX
 } from './cache';
 
 import { TransactionManager } from './transaction-manager';
@@ -1001,7 +1001,7 @@ export class Auth0Client {
     const postCacheClear = () => {
       this.cookieStorage.remove(this.orgHintCookieName);
       this.cookieStorage.remove(this.isAuthenticatedCookieName);
-      this.userCache.remove(USER_CACHE_KEY);
+      this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
 
       if (localOnly) {
         return;
@@ -1204,7 +1204,7 @@ export class Auth0Client {
   private async _saveEntryInCache(entry: CacheEntry) {
     const { id_token, decodedToken, ...entryWithoutIdToken } = entry;
 
-    this.userCache.set(USER_CACHE_KEY, {
+    this.userCache.set(CACHE_KEY_ID_TOKEN_SUFFIX, {
       id_token,
       decodedToken
     });
@@ -1229,17 +1229,16 @@ export class Auth0Client {
     );
 
     const currentCache = this.userCache.get<IdTokenEntry>(
-      USER_CACHE_KEY
+      CACHE_KEY_ID_TOKEN_SUFFIX
     ) as IdTokenEntry;
 
     // If the id_token in the cache matches the value we previously cached in memory return the in-memory
     // value so that object comparison will work
-    if (cache.id_token === currentCache?.id_token) {
+    if (cache && cache.id_token === currentCache?.id_token) {
       return currentCache;
-    } else {
-      this.userCache.set(USER_CACHE_KEY, cache);
     }
 
+    this.userCache.set(CACHE_KEY_ID_TOKEN_SUFFIX, cache);
     return cache;
   }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -23,7 +23,9 @@ import {
   LocalStorageCache,
   CacheKey,
   CacheManager,
-  CacheEntry
+  CacheEntry,
+  IdTokenEntry,
+  USER_CACHE_KEY
 } from './cache';
 
 import { TransactionManager } from './transaction-manager';
@@ -171,8 +173,10 @@ export class Auth0Client {
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
   private readonly options: Auth0ClientOptions;
+  private readonly userCache: ICache = new InMemoryCache().enclosedCache;
 
   cacheLocation: CacheLocation;
+
   private worker: Worker;
 
   private readonly defaultOptions: Partial<Auth0ClientOptions> = {
@@ -184,8 +188,7 @@ export class Auth0Client {
   };
 
   constructor(options: Auth0ClientOptions) {
-    
-    this.options = { 
+    this.options = {
       ...this.defaultOptions,
       ...options,
       authorizationParams: {
@@ -247,9 +250,7 @@ export class Auth0Client {
     this.scope = getUniqueScopes(
       'openid',
       this.options.authorizationParams?.scope,
-      this.options.useRefreshTokens ?
-        'offline_access' :
-        ''
+      this.options.useRefreshTokens ? 'offline_access' : ''
     );
 
     this.transactionManager = new TransactionManager(
@@ -1000,6 +1001,7 @@ export class Auth0Client {
     const postCacheClear = () => {
       this.cookieStorage.remove(this.orgHintCookieName);
       this.cookieStorage.remove(this.isAuthenticatedCookieName);
+      this.userCache.remove(USER_CACHE_KEY);
 
       if (localOnly) {
         return;
@@ -1202,6 +1204,11 @@ export class Auth0Client {
   private async _saveEntryInCache(entry: CacheEntry) {
     const { id_token, decodedToken, ...entryWithoutIdToken } = entry;
 
+    this.userCache.set(USER_CACHE_KEY, {
+      id_token,
+      decodedToken
+    });
+
     await this.cacheManager.setIdToken(
       this.options.clientId,
       entry.id_token,
@@ -1220,6 +1227,18 @@ export class Auth0Client {
         scope: this.scope
       })
     );
+
+    const currentCache = this.userCache.get<IdTokenEntry>(
+      USER_CACHE_KEY
+    ) as IdTokenEntry;
+
+    // If the id_token in the cache matches the value we previously cached in memory return the in-memory
+    // value so that object comparison will work
+    if (cache.id_token === currentCache?.id_token) {
+      return currentCache;
+    } else {
+      this.userCache.set(USER_CACHE_KEY, cache);
+    }
 
     return cache;
   }

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -36,7 +36,7 @@ export class CacheManager {
     await this.keyManifest?.add(cacheKey);
   }
 
-  async getIdToken(cacheKey: CacheKey): Promise<IdTokenEntry|undefined> {
+  async getIdToken(cacheKey: CacheKey): Promise<IdTokenEntry | undefined> {
     const entry = await this.cache.get<IdTokenEntry>(
       this.getIdTokenCacheKey(cacheKey.clientId)
     );

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -8,7 +8,8 @@ import {
   CACHE_KEY_PREFIX,
   WrappedCacheEntry,
   DecodedToken,
-  CACHE_KEY_ID_TOKEN_SUFFIX
+  CACHE_KEY_ID_TOKEN_SUFFIX,
+  IdTokenEntry
 } from './shared';
 
 const DEFAULT_EXPIRY_ADJUSTMENT_SECONDS = 0;
@@ -35,13 +36,10 @@ export class CacheManager {
     await this.keyManifest?.add(cacheKey);
   }
 
-  async getIdToken(
-    cacheKey: CacheKey
-  ): Promise<{ id_token: string; decodedToken: DecodedToken }> {
-    let entry = await this.cache.get<{
-      id_token: string;
-      decodedToken: DecodedToken;
-    }>(this.getIdTokenCacheKey(cacheKey.clientId));
+  async getIdToken(cacheKey: CacheKey): Promise<IdTokenEntry> {
+    let entry = await this.cache.get<IdTokenEntry>(
+      this.getIdTokenCacheKey(cacheKey.clientId)
+    );
 
     if (!entry && cacheKey.scope && cacheKey.audience) {
       const entryByScope = await this.get(cacheKey);

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -36,17 +36,21 @@ export class CacheManager {
     await this.keyManifest?.add(cacheKey);
   }
 
-  async getIdToken(cacheKey: CacheKey): Promise<IdTokenEntry> {
-    let entry = await this.cache.get<IdTokenEntry>(
+  async getIdToken(cacheKey: CacheKey): Promise<IdTokenEntry|undefined> {
+    const entry = await this.cache.get<IdTokenEntry>(
       this.getIdTokenCacheKey(cacheKey.clientId)
     );
 
     if (!entry && cacheKey.scope && cacheKey.audience) {
       const entryByScope = await this.get(cacheKey);
 
+      if (!entryByScope) {
+        return;
+      }
+
       return {
-        id_token: entryByScope?.id_token,
-        decodedToken: entryByScope?.decodedToken
+        id_token: entryByScope.id_token,
+        decodedToken: entryByScope.decodedToken
       };
     }
 

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -2,7 +2,6 @@ import { IdToken, User } from '../global';
 
 export const CACHE_KEY_PREFIX = '@@auth0spajs@@';
 export const CACHE_KEY_ID_TOKEN_SUFFIX = '@@user@@';
-export const USER_CACHE_KEY = 'idToken';
 
 export type CacheKeyData = {
   audience?: string;

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -2,6 +2,7 @@ import { IdToken, User } from '../global';
 
 export const CACHE_KEY_PREFIX = '@@auth0spajs@@';
 export const CACHE_KEY_ID_TOKEN_SUFFIX = '@@user@@';
+export const USER_CACHE_KEY = 'idToken';
 
 export type CacheKeyData = {
   audience?: string;
@@ -64,6 +65,11 @@ export class CacheKey {
 export interface DecodedToken {
   claims: IdToken;
   user: User;
+}
+
+export interface IdTokenEntry {
+  id_token: string;
+  decodedToken: DecodedToken;
 }
 
 export type CacheEntry = {

--- a/src/global.ts
+++ b/src/global.ts
@@ -59,11 +59,11 @@ export interface AuthorizationParams {
   acr_values?: string;
 
   /**
-   * The default scope to be used on authentication requests. 
-   * 
+   * The default scope to be used on authentication requests.
+   *
    * This defaults to `profile email` if not set. If you are setting extra scopes and require
    * `profile` and `email` to be included then you must include them in the provided scope.
-   * 
+   *
    * Note: The `openid` scope is **always applied** regardless of this setting.
    */
   scope?: string;


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

Adds an in memory cache that is used to cache the id token internally on `Auth0Client` so that when there are no updates the returned object is the same as previously returned. This will allow dependent SDKs to improve their signals around when the user object has updated.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
