### PR TITLE
Change buildAuthorizeUrlOptions to not accept appState and onRedirect

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -75,7 +75,8 @@ import {
   User,
   IdToken,
   GetTokenSilentlyVerboseResponse,
-  TokenEndpointResponse
+  TokenEndpointResponse,
+  BuildAuthorizeUrlOptions
 } from './global';
 
 // @ts-ignore
@@ -365,24 +366,25 @@ export class Auth0Client {
    * @param options
    */
   public async buildAuthorizeUrl(
-    options: RedirectLoginOptions = {}
+    options: BuildAuthorizeUrlOptions = {}
   ): Promise<string> {
     const { url } = await this._prepareAuthorizeUrl(options);
 
     return url;
   }
 
-  private async _prepareAuthorizeUrl(options: RedirectLoginOptions): Promise<{
+  private async _prepareAuthorizeUrl(
+    options: BuildAuthorizeUrlOptions
+  ): Promise<{
     scope: string;
     audience: string;
     redirect_uri: string;
     nonce: string;
     code_verifier: string;
-    appState: any;
     state: string;
     url: string;
   }> {
-    const { appState, authorizationParams } = options;
+    const { authorizationParams } = options;
 
     const state = encode(createRandomString());
     const nonce = encode(createRandomString());
@@ -404,7 +406,6 @@ export class Auth0Client {
     return {
       nonce,
       code_verifier,
-      appState,
       scope: params.scope,
       audience: params.audience || 'default',
       redirect_uri: params.redirect_uri,
@@ -576,7 +577,7 @@ export class Auth0Client {
   public async loginWithRedirect<TAppState = any>(
     options: RedirectLoginOptions<TAppState> = {}
   ) {
-    const { onRedirect, ...urlOptions } = options;
+    const { onRedirect, appState, ...urlOptions } = options;
 
     const organizationId =
       urlOptions.authorizationParams?.organization ||
@@ -586,6 +587,7 @@ export class Auth0Client {
 
     this.transactionManager.create({
       ...transaction,
+      appState,
       ...(organizationId && { organizationId })
     });
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -303,6 +303,13 @@ export interface RedirectLoginOptions<TAppState = any>
   onRedirect?: (url: string) => Promise<void>;
 }
 
+export interface BuildAuthorizeUrlOptions extends BaseLoginOptions {
+  /**
+   * Used to add to the URL fragment before redirecting
+   */
+  fragment?: string;
+}
+
 export interface RedirectLoginResult<TAppState = any> {
   /**
    * State stored when the redirect request was made


### PR DESCRIPTION
### Changes

`buildAuthorizeUrl` accepts an object of type `RedirectLoginOptions`, which contains properties such as `appState` and `onRedirect`, which are meaningless when calling `buildAuthorizeUrl`.

This PR updates `buildAuthorizeUrl` to ensure it has it's own type, and does not accept any `appState` or `onRedirect` anymore.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
