### PR TITLE
[SDK-3630] Increase code coverage

### DIFF
--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -87,6 +87,21 @@ describe('CookieStorageWithLegacySameSite', () => {
     cookieMock = jest.mocked(esCookie);
   });
 
+  it('saves a cookie', () => {
+    const key = 'key';
+    const value = { some: 'value' };
+
+    CookieStorageWithLegacySameSite.save(key, value);
+
+    expect(cookieMock.set).toHaveBeenCalledWith(key, JSON.stringify(value), {});
+
+    expect(cookieMock.set).toHaveBeenCalledWith(
+      `_legacy_${key}`,
+      JSON.stringify(value),
+      {}
+    );
+  });
+
   it('saves object', () => {
     const key = 'key';
     const value = { some: 'value' };

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -121,7 +121,7 @@ export class Auth0Client {
   private readonly isAuthenticatedCookieName: string;
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
-  private readonly options: Auth0ClientOptions;
+  private readonly options: Auth0ClientOptions & { authorizationParams: AuthorizationParams };
   private readonly userCache: ICache = new InMemoryCache().enclosedCache;
 
   cacheLocation: CacheLocation;
@@ -198,7 +198,7 @@ export class Auth0Client {
     // 3. Add `offline_access` if `useRefreshTokens` is enabled
     this.scope = getUniqueScopes(
       'openid',
-      this.options.authorizationParams?.scope,
+      this.options.authorizationParams.scope,
       this.options.useRefreshTokens ? 'offline_access' : ''
     );
 
@@ -256,7 +256,7 @@ export class Auth0Client {
       nonce,
       organizationId,
       leeway: this.options.leeway,
-      max_age: parseNumber(this.options.authorizationParams?.max_age),
+      max_age: parseNumber(this.options.authorizationParams.max_age),
       now
     });
   }
@@ -299,7 +299,7 @@ export class Auth0Client {
       nonce,
       code_challenge,
       authorizationParams?.redirect_uri ||
-        this.options.authorizationParams?.redirect_uri ||
+        this.options.authorizationParams.redirect_uri ||
         fallbackRedirectUri,
       authorizeOptions?.response_mode
     );
@@ -379,7 +379,7 @@ export class Auth0Client {
 
     const organizationId =
       options.authorizationParams?.organization ||
-      this.options.authorizationParams?.organization;
+      this.options.authorizationParams.organization;
 
     await this._requestToken(
       {
@@ -444,7 +444,7 @@ export class Auth0Client {
 
     const organizationId =
       urlOptions.authorizationParams?.organization ||
-      this.options.authorizationParams?.organization;
+      this.options.authorizationParams.organization;
 
     const { url, ...transaction } = await this._prepareAuthorizeUrl(
       urlOptions.authorizationParams
@@ -950,7 +950,7 @@ export class Auth0Client {
 
     const redirect_uri =
       options.authorizationParams?.redirect_uri ||
-      this.options.authorizationParams?.redirect_uri ||
+      this.options.authorizationParams.redirect_uri ||
       window.location.origin;
 
     const timeout =
@@ -1009,7 +1009,7 @@ export class Auth0Client {
   }
 
   private async _getIdTokenFromCache() {
-    const audience = this.options.authorizationParams?.audience || 'default';
+    const audience = this.options.authorizationParams.audience || 'default';
 
     const cache = await this.cacheManager.getIdToken(
       new CacheKey({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -644,7 +644,7 @@ export class Auth0Client {
 
     return singlePromise(
       () => this._getTokenSilently(options),
-      `${this.options.clientId}::${options.authorizationParams?.audience}::${options.authorizationParams?.scope}`
+      `${this.options.clientId}::${options.authorizationParams.audience}::${options.authorizationParams.scope}`
     );
   }
 
@@ -657,8 +657,8 @@ export class Auth0Client {
     // `lock.acquireLock` when the cache is populated.
     if (cacheMode !== 'off') {
       const entry = await this._getEntryFromCache({
-        scope: getTokenOptions.authorizationParams?.scope,
-        audience: getTokenOptions.authorizationParams?.audience || 'default',
+        scope: getTokenOptions.authorizationParams.scope,
+        audience: getTokenOptions.authorizationParams.audience || 'default',
         clientId: this.options.clientId,
         getDetailedEntry: options.detailedResponse
       });
@@ -683,9 +683,9 @@ export class Auth0Client {
         // by a previous call while this call was waiting to acquire the lock.
         if (cacheMode !== 'off') {
           const entry = await this._getEntryFromCache({
-            scope: getTokenOptions.authorizationParams?.scope,
+            scope: getTokenOptions.authorizationParams.scope,
             audience:
-              getTokenOptions.authorizationParams?.audience || 'default',
+              getTokenOptions.authorizationParams.audience || 'default',
             clientId: this.options.clientId,
             getDetailedEntry: options.detailedResponse
           });
@@ -754,8 +754,8 @@ export class Auth0Client {
 
     const cache = await this.cacheManager.get(
       new CacheKey({
-        scope: options.authorizationParams?.scope,
-        audience: options.authorizationParams?.audience || 'default',
+        scope: options.authorizationParams.scope,
+        audience: options.authorizationParams.audience || 'default',
         clientId: this.options.clientId
       })
     );
@@ -785,7 +785,7 @@ export class Auth0Client {
    * Builds a URL to the logout endpoint using the parameters provided as arguments.
    * @param options
    */
-  private _buildLogoutUrl(options: LogoutUrlOptions = {}): string {
+  private _buildLogoutUrl(options: LogoutUrlOptions): string {
     if (options.clientId !== null) {
       options.clientId = options.clientId || this.options.clientId;
     } else {
@@ -840,7 +840,6 @@ export class Auth0Client {
   ): Promise<GetTokenSilentlyResult> {
     const params: AuthorizationParams = {
       ...options.authorizationParams,
-
       prompt: 'none'
     };
 
@@ -891,7 +890,7 @@ export class Auth0Client {
           code: codeResult.code,
           grant_type: 'authorization_code',
           redirect_uri,
-          timeout: options.authorizationParams?.timeout || this.httpTimeoutMs
+          timeout: options.authorizationParams.timeout || this.httpTimeoutMs
         },
         {
           nonceIn
@@ -921,14 +920,14 @@ export class Auth0Client {
       ...options,
       authorizationParams: {
         ...options.authorizationParams,
-        scope: getUniqueScopes(this.scope, options.authorizationParams?.scope)
+        scope: getUniqueScopes(this.scope, options.authorizationParams.scope)
       }
     };
 
     const cache = await this.cacheManager.get(
       new CacheKey({
-        scope: options.authorizationParams?.scope,
-        audience: options.authorizationParams?.audience || 'default',
+        scope: options.authorizationParams.scope,
+        audience: options.authorizationParams.audience || 'default',
         clientId: this.options.clientId
       })
     );
@@ -943,13 +942,13 @@ export class Auth0Client {
       }
 
       throw new MissingRefreshTokenError(
-        options.authorizationParams?.audience || 'default',
-        options.authorizationParams?.scope
+        options.authorizationParams.audience || 'default',
+        options.authorizationParams.scope
       );
     }
 
     const redirect_uri =
-      options.authorizationParams?.redirect_uri ||
+      options.authorizationParams.redirect_uri ||
       this.options.authorizationParams.redirect_uri ||
       window.location.origin;
 
@@ -971,7 +970,7 @@ export class Auth0Client {
         ...tokenResult,
         scope: options.authorizationParams.scope,
         oauthTokenScope: tokenResult.scope,
-        audience: options.authorizationParams?.audience || 'default'
+        audience: options.authorizationParams.audience || 'default'
       };
     } catch (e) {
       if (

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -66,7 +66,7 @@ export const getAuthorizeParams = (
     state,
     nonce,
     redirect_uri:
-      redirect_uri || clientOptions.authorizationParams?.redirect_uri,
+      redirect_uri || clientOptions.authorizationParams.redirect_uri,
     code_challenge,
     code_challenge_method: 'S256'
   };


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

Some of the changes introduced in v2 have dropped the branch code coverage slightly, so I went through the individual cases to try and raise it up some. Each commit batches together related changes to hopefully make it easier to review

- a30a58aa415fc73c4353bb805bd263a660584c9c - adds a new test to cover a previously untested very minor case
- c87b8ef52841d540507e02f86ee9b81ee142d18c - Improves the typing of the internal `Auth0Client.options` in order to correctly state that `this.options.authorizationParams` will exist once the class has been created, also removes the optional chaining use on unreachable codepaths due to this always existing.
- b4c937f6c6312ab0955df3139d10df0268d65811 - Removes optional chaining use in function where the caller has already reconstructed the user provided options object that it is referencing as, again, these codepaths are unreachable.

With these changes the coverage stats are

```
Statements   : 100% ( 804/804 )
Branches     : 99.28% ( 414/417 )
Functions    : 94.64% ( 159/168 )
Lines        : 100% ( 742/742 )
```
### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
