### PR TITLE
Do not exclude AuthorizationParams from docs

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -1,8 +1,5 @@
 import { ICache } from './cache';
 
-/**
- * @ignore
- */
 export interface AuthorizationParams {
   /**
    * - `'page'`: displays the UI with a full page view


### PR DESCRIPTION
### Changes

`AuthorizationParams` is a public type, so it should not be excluded from the docs.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
