### PR TITLE
Do not use version specific auth0Client in tests

### DIFF
--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -159,7 +159,9 @@ describe('Auth0Client', () => {
 
       expect(window.location.assign).not.toHaveBeenCalled();
       expect(onRedirect).toHaveBeenCalledWith(
-        'https://auth0_domain/v2/logout?client_id=auth0_client_id&auth0Client=eyJuYW1lIjoiYXV0aDAtc3BhLWpzIiwidmVyc2lvbiI6IjEuMjIuMiJ9'
+        expect.stringContaining(
+          'https://auth0_domain/v2/logout?client_id=auth0_client_id'
+        )
       );
     });
 
@@ -209,7 +211,7 @@ describe('Auth0Client', () => {
       await auth0.logout({ clientId: null });
 
       expect(window.location.assign).toHaveBeenCalledWith(
-        'https://auth0_domain/v2/logout?&auth0Client=eyJuYW1lIjoiYXV0aDAtc3BhLWpzIiwidmVyc2lvbiI6IjEuMjIuMiJ9'
+        expect.stringContaining('https://auth0_domain/v2/logout')
       );
     });
 
@@ -218,7 +220,9 @@ describe('Auth0Client', () => {
       await auth0.logout({ clientId: 'my-client-id' });
 
       expect(window.location.assign).toHaveBeenCalledWith(
-        'https://auth0_domain/v2/logout?client_id=my-client-id&auth0Client=eyJuYW1lIjoiYXV0aDAtc3BhLWpzIiwidmVyc2lvbiI6IjEuMjIuMiJ9'
+        expect.stringContaining(
+          'https://auth0_domain/v2/logout?client_id=my-client-id'
+        )
       );
     });
   });

--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -213,6 +213,10 @@ describe('Auth0Client', () => {
       expect(window.location.assign).toHaveBeenCalledWith(
         expect.stringContaining('https://auth0_domain/v2/logout')
       );
+
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expect.not.stringContaining('client_id')
+      );
     });
 
     it('correctly handles a different clientId value', async () => {


### PR DESCRIPTION
### Changes

Once we would bump the version, 3 tests will break because they expect a certain value for auth0Client, which is version specific. Updated the tests to remove the auth0Client part and use `expect.stringContaining`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
