### PR TITLE
[SDK-3637] Configure Jenkins to publish from first-availability branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,11 @@ pipeline {
       }
     }
     stage('Publish to CDN') {
-      when {
-        branch 'master'
+      when { 
+        anyOf { 
+          branch 'first-availability'
+          branch 'master'
+        } 
       }
       steps {
         sshagent(['auth0extensions-ssh-key']) {


### PR DESCRIPTION
### Changes

Ensure Jenkins is configured to publish to CDN from the `first-availability` branch.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
