### PR TITLE
Trigger jenkins from beta branch instead of fa

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
     stage('Publish to CDN') {
       when { 
         anyOf { 
-          branch 'first-availability'
+          branch 'beta'
           branch 'master'
         } 
       }


### PR DESCRIPTION
### Changes

Ensure we trigger Jenkins from the beta branch instead of first-availability.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
