### PR TITLE
Publish beta tag instead of fa to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ workflows:
           requires:
             - build
       - ship/node-publish:
-          publish-command: npm publish --tag fa
+          publish-command: npm publish --tag beta
           context:
             - publish-npm
             - publish-gh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ workflows:
             branches:
               only:
                 - master
-                - first-availability
+                - beta
           requires:
             - browserstack
             - test_gatsby


### PR DESCRIPTION
### Changes

Publish to npm using the beta tag instead of the fa tag. Also ensure it gets triggered from the beta branch instead of fa.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
