### PR TITLE
Ensure getTokenSilently works when mixing return types

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1141,6 +1141,33 @@ describe('Auth0Client', () => {
       }
     });
 
+    it('uses the correct response type for subsequent requests that occur before the response', async () => {
+      const auth0 = setup();
+      await loginWithRedirect(auth0);
+      await (auth0 as any).cacheManager.clear();
+
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
+
+      mockFetch.mockResolvedValue(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          expires_in: 86400
+        })
+      );
+
+      const [result1, result2] = await Promise.all([
+        auth0.getTokenSilently(),
+        auth0.getTokenSilently({ detailedResponse: true })
+      ]);
+
+      expect(result1).toEqual(TEST_ACCESS_TOKEN);
+      expect(result2.access_token).toEqual(TEST_ACCESS_TOKEN);
+    });
+
     it('uses the cache for multiple token requests with audience and scope', async () => {
       const auth0 = setup();
       await loginWithRedirect(auth0);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1281,13 +1281,11 @@ export default class Auth0Client {
   private async _getEntryFromCache({
     scope,
     audience,
-    client_id,
-    getDetailedEntry = false
+    client_id
   }: {
     scope: string;
     audience: string;
     client_id: string;
-    getDetailedEntry?: boolean;
   }) {
     const entry = await this.cacheManager.get(
       new CacheKey({


### PR DESCRIPTION
### Changes

When calling `getTokenSilently` multiple times with a different response type (`detailedResponse` being both true and false) would result in incorrect behavior:

```ts
const [result1, result2] = await Promise.all([
  auth0.getTokenSilently(),
  auth0.getTokenSilently({ detailedResponse: true })
]);
```
In the above example, `result2` would be a string, instead of an object containing the detailed response.

With this PR, the above code should correctly set `result1` to a string and `result2` to an object, while respecting the `singlePromise` we use internally.

### References

Closes #857 

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
