### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -119,6 +119,22 @@ cacheFactories.forEach(cacheFactory => {
       expect(await manager.get(key)).toStrictEqual(data);
     });
 
+    it('should return an entry from the cache if no scopes provided', async () => {
+      const data = {
+        ...defaultData,
+        scope: 'read:messages write:messages'
+      };
+
+      await manager.set(data);
+
+      const key = new CacheKey({
+        clientId: TEST_CLIENT_ID,
+        audience: TEST_AUDIENCE
+      });
+
+      expect(await manager.get(key)).toStrictEqual(data);
+    });
+
     it('should return an entry directly from the cache if the key matches exactly', async () => {
       const data = {
         ...defaultData,

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -9,6 +9,7 @@ import {
   CacheEntry,
   CacheKey,
   CACHE_KEY_PREFIX,
+  DecodedToken,
   ICache
 } from '../../src/cache/shared';
 
@@ -595,6 +596,184 @@ cacheFactories.forEach(cacheFactory => {
       expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
         entry3
       );
+    });
+
+    describe('getIdToken', () => {
+      beforeEach(async () => {
+        await manager.clear();
+      });
+
+      it('should read from the id token cache if exists', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: 'read:messages'
+        });
+
+        await manager.setIdToken(
+          defaultData.client_id,
+          defaultData.id_token as string,
+          defaultData.decodedToken as DecodedToken
+        );
+
+        const cacheSpy = jest.spyOn(cache, 'get');
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(cache.get).toHaveBeenCalledWith(
+          new CacheKey(
+            {
+              clientId: TEST_CLIENT_ID
+            },
+            CACHE_KEY_PREFIX,
+            '@@user@@'
+          ).toKey()
+        );
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(result).toBeDefined();
+
+        cacheSpy.mockClear();
+      });
+
+      it('should read from the access token cache if not found in id token cache', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: 'read:messages'
+        });
+
+        await manager.set({
+          ...defaultData,
+          scope: 'read:messages'
+        });
+
+        const cacheSpy = jest.spyOn(cache, 'get');
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(cache.get).toHaveBeenCalledWith(cacheKey.toKey());
+        expect(cache.get).toHaveBeenCalledTimes(2);
+        expect(result).toBeDefined();
+
+        cacheSpy.mockClear();
+      });
+
+      it('should return undefined when nothing found', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: 'read:messages'
+        });
+
+        const cacheSpy = jest.spyOn(cache, 'get').mockImplementation(key => {
+          if (key.indexOf('@@user@@') > -1) {
+            return null;
+          } else {
+            return null;
+          }
+        });
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(cache.get).toHaveBeenCalledWith(
+          new CacheKey(
+            {
+              clientId: TEST_CLIENT_ID
+            },
+            CACHE_KEY_PREFIX,
+            '@@user@@'
+          ).toKey()
+        );
+        expect(cache.get).toHaveBeenCalledWith(cacheKey.toKey());
+        expect(result).toBeUndefined();
+
+        cacheSpy.mockClear();
+      });
+
+      it('should return undefined when no id token in access token cache', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: 'read:messages'
+        });
+
+        await manager.set({
+          ...defaultData,
+          scope: 'read:messages',
+          id_token: undefined
+        });
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined when no decoded token in access token cache', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: 'read:messages'
+        });
+
+        await manager.set({
+          ...defaultData,
+          scope: 'read:messages',
+          decodedToken: undefined
+        });
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('should return undefined if not found in id token cache and no scope set', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE
+        });
+
+        const cacheSpy = jest.spyOn(cache, 'get');
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(cache.get).toHaveBeenCalledWith(
+          new CacheKey(
+            {
+              clientId: TEST_CLIENT_ID
+            },
+            CACHE_KEY_PREFIX,
+            '@@user@@'
+          ).toKey()
+        );
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(result).toBeUndefined();
+
+        cacheSpy.mockClear();
+      });
+      it('should return undefined if not found in id token cache and no audience set', async () => {
+        const cacheKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          scope: 'read:messages'
+        });
+
+        const cacheSpy = jest.spyOn(cache, 'get');
+
+        const result = await manager.getIdToken(cacheKey);
+
+        expect(cache.get).toHaveBeenCalledWith(
+          new CacheKey(
+            {
+              clientId: TEST_CLIENT_ID
+            },
+            CACHE_KEY_PREFIX,
+            '@@user@@'
+          ).toKey()
+        );
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(result).toBeUndefined();
+
+        cacheSpy.mockClear();
+      });
     });
   });
 });

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -1,5 +1,9 @@
 import * as esCookie from 'es-cookie';
-import { CookieStorage, CookieStorageWithLegacySameSite } from '../src/storage';
+import {
+  CookieStorage,
+  CookieStorageWithLegacySameSite,
+  SessionStorage
+} from '../src/storage';
 import { expect } from '@jest/globals';
 
 jest.mock('es-cookie');
@@ -207,5 +211,57 @@ describe('CookieStorageWithLegacySameSite', () => {
     CookieStorageWithLegacySameSite.remove(key);
     expect(Cookie.remove).toHaveBeenCalledWith(key, {});
     expect(Cookie.remove).toHaveBeenCalledWith(`_legacy_${key}`, {});
+  });
+});
+
+describe('SessionStorage', () => {
+  //let cookieMock;
+
+  beforeEach(() => {
+    //cookieMock = jest.mocked(esCookie);
+  });
+
+  it('returns undefined when there is no object', () => {
+    //const Cookie = cookieMock;
+    const key = 'key';
+
+    jest.mocked(sessionStorage.getItem).mockReturnValue(null);
+
+    const outputValue = SessionStorage.get(key);
+    expect(outputValue).toBeUndefined();
+  });
+
+  it('gets object', () => {
+    const key = 'key';
+    const value = { some: 'value' };
+
+    jest.mocked(sessionStorage.getItem).mockReturnValue(JSON.stringify(value));
+
+    const outputValue = SessionStorage.get(key);
+    expect(outputValue).toMatchObject(value);
+  });
+
+  it('saves an object', () => {
+    const key = 'key';
+    const value = { some: 'value' };
+
+    jest.mocked(sessionStorage.setItem).mockImplementation(() => {});
+
+    SessionStorage.save(key, value);
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      key,
+      JSON.stringify(value)
+    );
+  });
+
+  it('removes an object', () => {
+    const key = 'key';
+
+    jest.mocked(sessionStorage.removeItem).mockImplementation(() => {});
+
+    SessionStorage.remove(key);
+
+    expect(sessionStorage.removeItem).toHaveBeenCalledWith(key);
   });
 });

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -215,14 +215,7 @@ describe('CookieStorageWithLegacySameSite', () => {
 });
 
 describe('SessionStorage', () => {
-  //let cookieMock;
-
-  beforeEach(() => {
-    //cookieMock = jest.mocked(esCookie);
-  });
-
   it('returns undefined when there is no object', () => {
-    //const Cookie = cookieMock;
     const key = 'key';
 
     jest.mocked(sessionStorage.getItem).mockReturnValue(null);

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,8 @@ module.exports = {
     '/node_modules/',
     './cypress',
     './jest.config.js',
-    './__tests__'
+    './__tests__',
+    './src/index.ts'
   ],
   reporters: [
     'default',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -636,7 +636,7 @@ export class Auth0Client {
   public async getTokenSilently(
     options: GetTokenSilentlyOptions = {}
   ): Promise<undefined | string | GetTokenSilentlyVerboseResponse> {
-    let localOptions: GetTokenSilentlyOptions & {
+    const localOptions: GetTokenSilentlyOptions & {
       authorizationParams: AuthorizationParams & { scope: string };
     } = {
       cacheMode: 'on',

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -27,7 +27,8 @@ import {
   CacheManager,
   CacheEntry,
   IdTokenEntry,
-  CACHE_KEY_ID_TOKEN_SUFFIX
+  CACHE_KEY_ID_TOKEN_SUFFIX,
+  DecodedToken
 } from './cache';
 
 import { TransactionManager } from './transaction-manager';
@@ -121,12 +122,12 @@ export class Auth0Client {
   private readonly isAuthenticatedCookieName: string;
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
-  private readonly options: Auth0ClientOptions & { authorizationParams: AuthorizationParams };
+  private readonly options: Auth0ClientOptions & {
+    authorizationParams: AuthorizationParams;
+  };
   private readonly userCache: ICache = new InMemoryCache().enclosedCache;
 
-  cacheLocation: CacheLocation;
-
-  private worker: Worker;
+  private worker?: Worker;
 
   private readonly defaultOptions: Partial<Auth0ClientOptions> = {
     authorizationParams: {
@@ -154,18 +155,19 @@ export class Auth0Client {
       );
     }
 
+    let cacheLocation: CacheLocation | undefined;
     let cache: ICache;
 
     if (options.cache) {
       cache = options.cache;
     } else {
-      this.cacheLocation = options.cacheLocation || CACHE_LOCATION_MEMORY;
+      cacheLocation = options.cacheLocation || CACHE_LOCATION_MEMORY;
 
-      if (!cacheFactory(this.cacheLocation)) {
-        throw new Error(`Invalid cache location "${this.cacheLocation}"`);
+      if (!cacheFactory(cacheLocation)) {
+        throw new Error(`Invalid cache location "${cacheLocation}"`);
       }
 
-      cache = cacheFactory(this.cacheLocation)();
+      cache = cacheFactory(cacheLocation)();
     }
 
     this.httpTimeoutMs = options.httpTimeoutInSeconds
@@ -213,7 +215,7 @@ export class Auth0Client {
       cache,
       !cache.allKeys
         ? new CacheKeyManifest(cache, this.options.clientId)
-        : null,
+        : undefined,
       this.nowProvider
     );
 
@@ -225,7 +227,7 @@ export class Auth0Client {
       typeof window !== 'undefined' &&
       window.Worker &&
       this.options.useRefreshTokens &&
-      this.cacheLocation === CACHE_LOCATION_MEMORY
+      cacheLocation === CACHE_LOCATION_MEMORY
     ) {
       this.worker = new TokenWorker();
     }
@@ -281,7 +283,7 @@ export class Auth0Client {
   ): Promise<{
     scope: string;
     audience: string;
-    redirect_uri: string;
+    redirect_uri?: string;
     nonce: string;
     code_verifier: string;
     state: string;
@@ -300,7 +302,7 @@ export class Auth0Client {
       state,
       nonce,
       code_challenge,
-      authorizationParams?.redirect_uri ||
+      authorizationParams.redirect_uri ||
         this.options.authorizationParams.redirect_uri ||
         fallbackRedirectUri,
       authorizeOptions?.response_mode
@@ -360,7 +362,7 @@ export class Auth0Client {
     }
 
     const params = await this._prepareAuthorizeUrl(
-      options.authorizationParams,
+      options.authorizationParams || {},
       { response_mode: 'web_message' },
       window.location.origin
     );
@@ -389,7 +391,7 @@ export class Auth0Client {
         scope: params.scope,
         code_verifier: params.code_verifier,
         grant_type: 'authorization_code',
-        code: codeResult.code,
+        code: codeResult.code as string,
         redirect_uri: params.redirect_uri
       },
       {
@@ -449,7 +451,7 @@ export class Auth0Client {
       this.options.authorizationParams.organization;
 
     const { url, ...transaction } = await this._prepareAuthorizeUrl(
-      urlOptions.authorizationParams
+      urlOptions.authorizationParams || {}
     );
 
     this.transactionManager.create({
@@ -497,7 +499,7 @@ export class Auth0Client {
     if (error) {
       throw new AuthenticationError(
         error,
-        error_description,
+        error_description || error,
         state,
         transaction.appState
       );
@@ -521,7 +523,7 @@ export class Auth0Client {
         scope: transaction.scope,
         code_verifier: transaction.code_verifier,
         grant_type: 'authorization_code',
-        code,
+        code: code as string,
         ...(redirect_uri ? { redirect_uri } : {})
       },
       { nonceIn, organizationId }
@@ -633,8 +635,10 @@ export class Auth0Client {
    */
   public async getTokenSilently(
     options: GetTokenSilentlyOptions = {}
-  ): Promise<string | GetTokenSilentlyVerboseResponse> {
-    options = {
+  ): Promise<undefined | string | GetTokenSilentlyVerboseResponse> {
+    let localOptions: GetTokenSilentlyOptions & {
+      authorizationParams: AuthorizationParams & { scope: string };
+    } = {
       cacheMode: 'on',
       ...options,
       authorizationParams: {
@@ -645,14 +649,16 @@ export class Auth0Client {
     };
 
     return singlePromise(
-      () => this._getTokenSilently(options),
-      `${this.options.clientId}::${options.authorizationParams.audience}::${options.authorizationParams.scope}`
+      () => this._getTokenSilently(localOptions),
+      `${this.options.clientId}::${localOptions.authorizationParams.audience}::${localOptions.authorizationParams.scope}`
     );
   }
 
   private async _getTokenSilently(
-    options: GetTokenSilentlyOptions
-  ): Promise<string | GetTokenSilentlyVerboseResponse> {
+    options: GetTokenSilentlyOptions & {
+      authorizationParams: AuthorizationParams & { scope: string };
+    }
+  ): Promise<undefined | string | GetTokenSilentlyVerboseResponse> {
     const { cacheMode, ...getTokenOptions } = options;
 
     // Check the cache before acquiring the lock to avoid the latency of
@@ -688,8 +694,7 @@ export class Auth0Client {
         if (cacheMode !== 'off') {
           const entry = await this._getEntryFromCache({
             scope: getTokenOptions.authorizationParams.scope,
-            audience:
-              getTokenOptions.authorizationParams.audience || 'default',
+            audience: getTokenOptions.authorizationParams.audience || 'default',
             clientId: this.options.clientId,
             getDetailedEntry: options.detailedResponse
           });
@@ -741,7 +746,7 @@ export class Auth0Client {
     options: GetTokenWithPopupOptions = {},
     config: PopupConfigOptions = {}
   ) {
-    options = {
+    const localOptions = {
       ...options,
       authorizationParams: {
         ...this.options.authorizationParams,
@@ -755,17 +760,17 @@ export class Auth0Client {
       ...config
     };
 
-    await this.loginWithPopup(options, config);
+    await this.loginWithPopup(localOptions, config);
 
     const cache = await this.cacheManager.get(
       new CacheKey({
-        scope: options.authorizationParams.scope,
-        audience: options.authorizationParams.audience || 'default',
+        scope: localOptions.authorizationParams.scope,
+        audience: localOptions.authorizationParams.audience || 'default',
         clientId: this.options.clientId
       })
     );
 
-    return cache.access_token;
+    return cache!.access_token;
   }
 
   /**
@@ -815,7 +820,7 @@ export class Auth0Client {
    * ```
    *
    * Clears the application session and performs a redirect to `/v2/logout`, using
-   * the parameters provided as arguments, to clear the Auth0 session. 
+   * the parameters provided as arguments, to clear the Auth0 session.
    *
    * If the `federated` option is specified it also clears the Identity Provider session.
    * [Read more about how Logout works at Auth0](https://auth0.com/docs/logout).
@@ -826,13 +831,13 @@ export class Auth0Client {
     const { onRedirect, ...logoutOptions } = options;
 
     await this.cacheManager.clear();
-    
+
     this.cookieStorage.remove(this.orgHintCookieName, {
-        cookieDomain: this.options.cookieDomain
-      });
+      cookieDomain: this.options.cookieDomain
+    });
     this.cookieStorage.remove(this.isAuthenticatedCookieName, {
-        cookieDomain: this.options.cookieDomain
-      });
+      cookieDomain: this.options.cookieDomain
+    });
     this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
 
     const url = this._buildLogoutUrl(logoutOptions);
@@ -845,9 +850,11 @@ export class Auth0Client {
   }
 
   private async _getTokenFromIFrame(
-    options: GetTokenSilentlyOptions
+    options: GetTokenSilentlyOptions & {
+      authorizationParams: AuthorizationParams & { scope: string };
+    }
   ): Promise<GetTokenSilentlyResult> {
-    const params: AuthorizationParams = {
+    const params: AuthorizationParams & { scope: string } = {
       ...options.authorizationParams,
       prompt: 'none'
     };
@@ -896,10 +903,10 @@ export class Auth0Client {
         {
           ...options.authorizationParams,
           code_verifier,
-          code: codeResult.code,
+          code: codeResult.code as string,
           grant_type: 'authorization_code',
           redirect_uri,
-          timeout: options.authorizationParams.timeout || this.httpTimeoutMs
+          timeout: options.authorizationParams?.timeout || this.httpTimeoutMs
         },
         {
           nonceIn
@@ -923,13 +930,13 @@ export class Auth0Client {
   }
 
   private async _getTokenUsingRefreshToken(
-    options: GetTokenSilentlyOptions
+    opts: GetTokenSilentlyOptions
   ): Promise<GetTokenSilentlyResult> {
-    options = {
-      ...options,
+    let options = {
+      ...opts,
       authorizationParams: {
-        ...options.authorizationParams,
-        scope: getUniqueScopes(this.scope, options.authorizationParams.scope)
+        ...opts.authorizationParams,
+        scope: getUniqueScopes(this.scope, opts.authorizationParams?.scope)
       }
     };
 
@@ -999,7 +1006,9 @@ export class Auth0Client {
     }
   }
 
-  private async _saveEntryInCache(entry: CacheEntry) {
+  private async _saveEntryInCache(
+    entry: CacheEntry & { id_token: string; decodedToken: DecodedToken }
+  ) {
     const { id_token, decodedToken, ...entryWithoutIdToken } = entry;
 
     this.userCache.set(CACHE_KEY_ID_TOKEN_SUFFIX, {
@@ -1051,7 +1060,7 @@ export class Auth0Client {
     audience: string;
     clientId: string;
     getDetailedEntry?: boolean;
-  }) {
+  }): Promise<undefined | string | GetTokenSilentlyVerboseResponse> {
     const entry = await this.cacheManager.get(
       new CacheKey({
         scope,
@@ -1063,14 +1072,17 @@ export class Auth0Client {
 
     if (entry && entry.access_token) {
       if (getDetailedEntry) {
-        const { access_token, oauthTokenScope, expires_in } = entry;
+        const { access_token, oauthTokenScope, expires_in } =
+          entry as CacheEntry;
         const cache = await this._getIdTokenFromCache();
-        return {
-          id_token: cache?.id_token,
-          access_token,
-          ...(oauthTokenScope ? { scope: oauthTokenScope } : null),
-          expires_in
-        };
+        return (
+          cache && {
+            id_token: cache.id_token,
+            access_token,
+            ...(oauthTokenScope ? { scope: oauthTokenScope } : null),
+            expires_in
+          }
+        );
       }
 
       return entry.access_token;
@@ -1134,7 +1146,7 @@ export class Auth0Client {
 
 interface BaseRequestTokenOptions {
   audience?: string;
-  scope?: string;
+  scope: string;
   timeout?: number;
   redirect_uri?: string;
 }
@@ -1147,7 +1159,7 @@ interface PKCERequestTokenOptions extends BaseRequestTokenOptions {
 
 interface RefreshTokenRequestTokenOptions extends BaseRequestTokenOptions {
   grant_type: 'refresh_token';
-  refresh_token: string;
+  refresh_token?: string;
 }
 
 interface RequestTokenAdditionalParameters {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -906,7 +906,7 @@ export class Auth0Client {
           code: codeResult.code as string,
           grant_type: 'authorization_code',
           redirect_uri,
-          timeout: options.authorizationParams?.timeout || this.httpTimeoutMs
+          timeout: options.authorizationParams.timeout || this.httpTimeoutMs
         },
         {
           nonceIn
@@ -930,16 +930,10 @@ export class Auth0Client {
   }
 
   private async _getTokenUsingRefreshToken(
-    opts: GetTokenSilentlyOptions
+    options: GetTokenSilentlyOptions & {
+      authorizationParams: AuthorizationParams & { scope: string };
+    }
   ): Promise<GetTokenSilentlyResult> {
-    let options = {
-      ...opts,
-      authorizationParams: {
-        ...opts.authorizationParams,
-        scope: getUniqueScopes(this.scope, opts.authorizationParams?.scope)
-      }
-    };
-
     const cache = await this.cacheManager.get(
       new CacheKey({
         scope: options.authorizationParams.scope,

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -49,24 +49,24 @@ export const cacheFactory = (location: string) => {
 export const getAuthorizeParams = (
   clientOptions: Auth0ClientOptions,
   scope: string,
-  authorizeOptions: AuthorizationParams,
+  authorizationParams: AuthorizationParams,
   state: string,
   nonce: string,
   code_challenge: string,
-  redirect_uri: string,
-  response_mode: string
+  redirect_uri: string | undefined,
+  response_mode: string | undefined
 ): AuthorizeOptions => {
   return {
     client_id: clientOptions.clientId,
     ...clientOptions.authorizationParams,
-    ...authorizeOptions,
-    scope: getUniqueScopes(scope, authorizeOptions?.scope),
+    ...authorizationParams,
+    scope: getUniqueScopes(scope, authorizationParams.scope),
     response_type: 'code',
     response_mode: response_mode || 'query',
     state,
     nonce,
     redirect_uri:
-      redirect_uri || clientOptions.authorizationParams.redirect_uri,
+      redirect_uri || clientOptions.authorizationParams?.redirect_uri,
     code_challenge,
     code_challenge_method: 'S256'
   };

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -47,7 +47,9 @@ export const cacheFactory = (location: string) => {
  * @ignore
  */
 export const getAuthorizeParams = (
-  clientOptions: Auth0ClientOptions,
+  clientOptions: Auth0ClientOptions & {
+    authorizationParams: AuthorizationParams;
+  },
   scope: string,
   authorizationParams: AuthorizationParams,
   state: string,
@@ -66,7 +68,7 @@ export const getAuthorizeParams = (
     state,
     nonce,
     redirect_uri:
-      redirect_uri || clientOptions.authorizationParams?.redirect_uri,
+      redirect_uri || clientOptions.authorizationParams.redirect_uri,
     code_challenge,
     code_challenge_method: 'S256'
   };

--- a/src/cache/cache-localstorage.ts
+++ b/src/cache/cache-localstorage.ts
@@ -1,11 +1,11 @@
-import { ICache, Cacheable, CACHE_KEY_PREFIX } from './shared';
+import { ICache, Cacheable, CACHE_KEY_PREFIX, MaybePromise } from './shared';
 
 export class LocalStorageCache implements ICache {
   public set<T = Cacheable>(key: string, entry: T) {
     localStorage.setItem(key, JSON.stringify(entry));
   }
 
-  public get<T = Cacheable>(key: string) {
+  public get<T = Cacheable>(key: string): MaybePromise<T | undefined> {
     const json = window.localStorage.getItem(key);
 
     if (!json) return;

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -44,7 +44,7 @@ export class CacheManager {
     );
 
     if (!entry && cacheKey.scope && cacheKey.audience) {
-      const entryByScope = (await this.get(cacheKey)) as CacheEntry | undefined;
+      const entryByScope = await this.get(cacheKey);
 
       if (!entryByScope) {
         return;

--- a/src/cache/cache-memory.ts
+++ b/src/cache/cache-memory.ts
@@ -1,4 +1,4 @@
-import { Cacheable, ICache } from './shared';
+import { Cacheable, ICache, MaybePromise } from './shared';
 
 export class InMemoryCache {
   public enclosedCache: ICache = (function () {
@@ -9,7 +9,7 @@ export class InMemoryCache {
         cache[key] = entry;
       },
 
-      get<T = Cacheable>(key: string) {
+      get<T = Cacheable>(key: string): MaybePromise<T | undefined> {
         const cacheEntry = cache[key] as T;
 
         if (!cacheEntry) {

--- a/src/cache/key-manifest.ts
+++ b/src/cache/key-manifest.ts
@@ -39,7 +39,7 @@ export class CacheKeyManifest {
     }
   }
 
-  get(): MaybePromise<KeyManifestEntry> {
+  get(): MaybePromise<KeyManifestEntry | undefined> {
     return this.cache.get<KeyManifestEntry>(this.manifestKey);
   }
 

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -17,7 +17,7 @@ export class CacheKey {
   constructor(
     data: CacheKeyData,
     public prefix: string = CACHE_KEY_PREFIX,
-    public suffix: string = null
+    public suffix?: string
   ) {
     this.clientId = data.clientId;
     this.scope = data.scope;
@@ -98,7 +98,7 @@ export type MaybePromise<T> = Promise<T> | T;
 
 export interface ICache {
   set<T = Cacheable>(key: string, entry: T): MaybePromise<void>;
-  get<T = Cacheable>(key: string): MaybePromise<T | null>;
+  get<T = Cacheable>(key: string): MaybePromise<T | undefined>;
   remove(key: string): MaybePromise<void>;
   allKeys?(): MaybePromise<string[]>;
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -269,7 +269,7 @@ export type CacheLocation = 'memory' | 'localstorage';
 export interface AuthorizeOptions extends AuthorizationParams {
   response_type: string;
   response_mode: string;
-  redirect_uri: string;
+  redirect_uri?: string;
   nonce: string;
   state: string;
   scope: string;

--- a/src/http.ts
+++ b/src/http.ts
@@ -49,7 +49,7 @@ const fetchWithWorker = async (
   scope: string,
   fetchOptions: FetchOptions,
   timeout: number,
-  worker?: Worker,
+  worker: Worker,
   useFormData?: boolean
 ) => {
   return sendMessage(
@@ -93,7 +93,7 @@ export const switchFetch = async (
 
 export async function getJSON<T>(
   url: string,
-  timeout: number,
+  timeout: number | undefined,
   audience: string,
   scope: string,
   options: FetchOptions,

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -172,7 +172,7 @@ export const verify = (options: JWTVerifyOptions) => {
 
   if (decoded.claims.nbf != null && isNumber(decoded.claims.nbf)) {
     const nbfDate = new Date(0);
-    nbfDate.setUTCSeconds((decoded.claims.nbf || 0) - leeway);
+    nbfDate.setUTCSeconds(decoded.claims.nbf - leeway);
     if (now < nbfDate) {
       throw new Error(
         `Not Before time (nbf) claim in the ID token indicates that this token can't be used just yet. Current time (${now}) is before ${nbfDate}`

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -44,7 +44,7 @@ export const decode = (token: string) => {
     throw new Error('ID token could not be decoded');
   }
   const payloadJSON = JSON.parse(urlDecodeB64(payload));
-  const claims: Partial<IdToken> = { __raw: token };
+  const claims: IdToken = { __raw: token };
   const user: any = {};
   Object.keys(payloadJSON).forEach(k => {
     claims[k] = payloadJSON[k];
@@ -55,7 +55,7 @@ export const decode = (token: string) => {
   return {
     encoded: { header, payload, signature },
     header: JSON.parse(urlDecodeB64(header)),
-    claims: claims as IdToken,
+    claims,
     user
   };
 };

--- a/src/promise-utils.ts
+++ b/src/promise-utils.ts
@@ -1,7 +1,10 @@
 const singlePromiseMap: Record<string, Promise<any>> = {};
 
-export const singlePromise = <T>(cb: () => Promise<T>, key: string) => {
-  let promise = singlePromiseMap[key];
+export const singlePromise = <T>(
+  cb: () => Promise<T>,
+  key: string
+): Promise<T> => {
+  let promise: null | Promise<T> = singlePromiseMap[key];
   if (!promise) {
     promise = cb().finally(() => {
       delete singlePromiseMap[key];

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -6,6 +6,6 @@ const dedupe = (arr: string[]) => Array.from(new Set(arr));
 /**
  * @ignore
  */
-export const getUniqueScopes = (...scopes: string[]) => {
-  return dedupe(scopes.join(' ').trim().split(/\s+/)).join(' ');
+export const getUniqueScopes = (...scopes: (string | undefined)[]) => {
+  return dedupe(scopes.filter(Boolean).join(' ').trim().split(/\s+/)).join(' ');
 };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -56,7 +56,7 @@ export const CookieStorage = {
       cookieAttributes.domain = options.cookieDomain;
     }
 
-    Cookies.remove(key ,cookieAttributes);
+    Cookies.remove(key, cookieAttributes);
   }
 } as ClientStorage;
 
@@ -106,7 +106,7 @@ export const CookieStorageWithLegacySameSite = {
       cookieAttributes.domain = options.cookieDomain;
     }
 
-    Cookies.remove(key ,cookieAttributes);
+    Cookies.remove(key, cookieAttributes);
     CookieStorage.remove(key, options);
     CookieStorage.remove(`${LEGACY_PREFIX}${key}`, options);
   }
@@ -124,7 +124,7 @@ export const SessionStorage = {
 
     const value = sessionStorage.getItem(key);
 
-    if (typeof value === 'undefined') {
+    if (value == null) {
       return;
     }
 

--- a/src/transaction-manager.ts
+++ b/src/transaction-manager.ts
@@ -8,7 +8,7 @@ interface Transaction {
   audience: string;
   appState?: any;
   code_verifier: string;
-  redirect_uri: string;
+  redirect_uri?: string;
   organizationId?: string;
   state?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,5 +247,5 @@ export const parseNumber = (value: any): number | undefined => {
   if (typeof value !== 'string') {
     return value;
   }
-  return parseInt(value as string, 10) || undefined;
+  return parseInt(value, 10) || undefined;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,7 +101,7 @@ export const openPopup = (url: string) => {
 
 export const runPopup = (config: PopupConfigOptions) => {
   return new Promise<AuthenticationResult>((resolve, reject) => {
-    let popupEventListener: EventListenerOrEventListenerObject;
+    let popupEventListener: (e: MessageEvent) => void;
 
     // Check each second if the popup is closed triggering a PopupCancelledError
     const popupTimer = setInterval(() => {
@@ -232,7 +232,10 @@ export const getDomain = (domainUrl: string) => {
 /**
  * @ignore
  */
-export const getTokenIssuer = (issuer: string, domainUrl: string) => {
+export const getTokenIssuer = (
+  issuer: string | undefined,
+  domainUrl: string
+) => {
   if (issuer) {
     return issuer.startsWith('https://') ? issuer : `https://${issuer}/`;
   }
@@ -240,9 +243,9 @@ export const getTokenIssuer = (issuer: string, domainUrl: string) => {
   return `${domainUrl}/`;
 };
 
-export const parseNumber = (value: any): number => {
+export const parseNumber = (value: any): number | undefined => {
   if (typeof value !== 'string') {
     return value;
   }
-  return parseInt(value, 10) || undefined;
+  return parseInt(value as string, 10) || undefined;
 };

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -44,8 +44,8 @@ const messageHandler = async ({
 
   try {
     const body = useFormData
-      ? formDataToObject(fetchOptions.body)
-      : JSON.parse(fetchOptions.body);
+      ? formDataToObject(fetchOptions.body as string)
+      : JSON.parse(fetchOptions.body as string);
 
     if (!body.refresh_token && body.grant_type === 'refresh_token') {
       const refreshToken = getRefreshToken(audience, scope);
@@ -65,7 +65,7 @@ const messageHandler = async ({
           });
     }
 
-    let abortController: AbortController;
+    let abortController: AbortController | undefined;
 
     if (typeof AbortController === 'function') {
       abortController = new AbortController();
@@ -125,7 +125,7 @@ const messageHandler = async ({
 // Don't run `addEventListener` in our tests (this is replaced in rollup)
 if (process.env.NODE_ENV === 'test') {
   module.exports = { messageHandler };
-/* c8 ignore next 4  */
+  /* c8 ignore next 4  */
 } else {
   // @ts-ignore
   addEventListener('message', messageHandler);

--- a/src/worker/worker.types.ts
+++ b/src/worker/worker.types.ts
@@ -8,8 +8,8 @@ export type WorkerRefreshTokenMessage = {
   fetchUrl: string;
   fetchOptions: FetchOptions;
   useFormData?: boolean;
-  auth?: {
-    audience?: string;
-    scope?: string;
+  auth: {
+    audience: string;
+    scope: string;
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,13 @@
     "declarationDir": "./dist/typings",
     "moduleResolution": "node",
     "noImplicitAny": true,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
   },
   "exclude": ["./__tests__", "./dist/typings", "**/__mocks__/**"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,6 +2,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noImplicitAny": false,
-    "target": "es6"
+    "target": "es6",
+
+    "noImplicitThis": false,
+    "alwaysStrict": false,
+    "strictBindCallApply": false,
+    "strictNullChecks": false,
+    "strictFunctionTypes": false,
+    "strictPropertyInitialization": false,
   }
 }


### PR DESCRIPTION
### Changes

First pass at enabling TS strict mode. It looks like we might need to organize our internal types vs external types better. E.g. internally we always have an `authorizationParams` as well as a `authorizationParams.scope`. However, both are optional on all public API's, we just set a default for scope.

As those shouldn't impact our public API, we should be fine doing that in a couple of follow up PRs,or just as we see fit.

This also made the coverage drop, had to add a couple of missing tests for scenario's that shouldnt happen, but are supported by our API / types.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
