### PR TITLE
Release 1.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v1.22.5](https://github.com/auth0/auth0-spa-js/tree/v1.22.5) (2022-10-12)
+
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.4...v1.22.5)
+
+**Fixed**
+
+- Ensure getTokenSilently works when mixing return types [\#1016](https://github.com/auth0/auth0-spa-js/pull/1016) ([frederikprijck](https://github.com/frederikprijck))
+
 ## [v1.22.4](https://github.com/auth0/auth0-spa-js/tree/v1.22.4) (2022-09-08)
 
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.3...v1.22.4)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.22.4",
+  "version": "1.22.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-spa-js",
-      "version": "1.22.4",
+      "version": "1.22.5",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.22.4",
+  "version": "1.22.5",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.22.4';
+export default '1.22.5';


### PR DESCRIPTION
**Fixed**

- Ensure getTokenSilently works when mixing return types [\#1016](https://github.com/auth0/auth0-spa-js/pull/1016) ([frederikprijck](https://github.com/frederikprijck))