### PR TITLE
[SDK-3713] Close MessageChannel after receiving and processing message from worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "rimraf dist && rollup -m -c --environment NODE_ENV:production && npm run test:es-check",
     "build:stats": "npm run build -- --environment WITH_STATS:true && open stats.html",
     "lint:security": "eslint ./src --ext ts --no-eslintrc --config ./.eslintrc.security",
-    "test": "jest --coverage --silent --forceExit",
+    "test": "jest --coverage --silent",
     "test:watch": "jest --coverage --watch",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "test:open:integration": "cypress open",

--- a/src/worker/worker.utils.ts
+++ b/src/worker/worker.utils.ts
@@ -16,6 +16,7 @@ export const sendMessage = (message: WorkerRefreshTokenMessage, to: Worker) =>
       } else {
         resolve(event.data);
       }
+      messageChannel.port1.close();
     };
 
     to.postMessage(message, [messageChannel.port2]);


### PR DESCRIPTION
### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

This fixes the issue where jest detects an open handle on exit. In most instances this would be GC'd eventually if we didn't close it, but it seems that under test it is an issue

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
