### PR TITLE
Fix links to apidocs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ For other comprehensive examples, see the [EXAMPLES.md](https://github.com/auth0
 
 Explore API Methods available in auth0-spa-js.
 
-- [Configuration Options](https://auth0.github.io/auth0-spa-js/interfaces/auth0clientoptions.html)
+- [Configuration Options](https://auth0.github.io/auth0-spa-js/interfaces/Auth0ClientOptions.html)
 
-- [Auth0Client](https://auth0.github.io/auth0-spa-js/classes/auth0client.html)
-- [createAuth0Client](https://auth0.github.io/auth0-spa-js/globals.html#createauth0client)
+- [Auth0Client](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html)
+- [createAuth0Client](https://auth0.github.io/auth0-spa-js/functions/createAuth0Client.html)
 
 ## Feedback
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export * from './global';
  * Asynchronously creates the Auth0Client instance and calls `checkSession`.
  *
  * **Note:** There are caveats to using this in a private browser tab, which may not silently authenticae
- * a user on page refresh. Please see [the checkSession docs](https://auth0.github.io/auth0-spa-js/classes/auth0client.html#checksession) for more info.
+ * a user on page refresh. Please see [the checkSession docs](https://auth0.github.io/auth0-spa-js/classes/Auth0Client.html#checksession) for more info.
  *
  * @param options The client options
  * @returns An instance of Auth0Client


### PR DESCRIPTION


### Changes

Links now need to have the correct casing for the function/interface/class. This seems to have changed with the recent regeneration of the docs

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
