### PR TITLE
Release 1.22.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,7 @@ workflows:
             branches:
               only:
                 - master
+                - v1
           requires:
             - browserstack
             - test_gatsby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [v1.22.6](https://github.com/auth0/auth0-spa-js/tree/v1.22.6) (2023-01-12)
+
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.5...v1.22.6)
+
+**Security**
+
+- Bump jsonwebtoken to v9 [\#1065](https://github.com/auth0/auth0-spa-js/pull/1065) ([frederikprijck](https://github.com/frederikprijck))
+
+This patch release is identical to `1.22.5` but has been released to ensure tooling no longer detects a vulnerable version of `jsonwebtoken` being used.
+
+Even though 1.22.5 was not vulnerable for the related [CVE](https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/) because of the fact that `jsonwebtoken` is a devDependency, we are cutting a release to ensure build tools no longer report our SDK as vulnerable to the mentioned CVE.
+
 ## [v1.22.5](https://github.com/auth0/auth0-spa-js/tree/v1.22.5) (2022-10-12)
 
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v1.22.4...v1.22.5)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-spa-js",
-      "version": "1.22.5",
+      "version": "1.22.6",
       "license": "MIT",
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.22.5';
+export default '1.22.6';


### PR DESCRIPTION
**Security**

- Bump jsonwebtoken to v9 [\#1065](https://github.com/auth0/auth0-spa-js/pull/1065) ([frederikprijck](https://github.com/frederikprijck))

This patch release is identical to `1.22.5` but has been released to ensure tooling no longer detects a vulnerable version of `jsonwebtoken` being used.

Even though 1.22.5 was not vulnerable for the related [CVE](https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/) because of the fact that `jsonwebtoken` is a devDependency, we are cutting a release to ensure build tools no longer report our SDK as vulnerable to the mentioned CVE.