### PR TITLE
Ensure to only clear current client cache when logging out

### DIFF
--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -132,7 +132,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('clears the cache', async () => {
+    it('clears the cache for the global clientId', async () => {
       const auth0 = setup();
 
       jest
@@ -141,7 +141,39 @@ describe('Auth0Client', () => {
 
       await auth0.logout();
 
+      expect(auth0['cacheManager']['clear']).toHaveBeenCalledWith(
+        TEST_CLIENT_ID
+      );
+    });
+
+    it('clears the cache for the provided clientId', async () => {
+      const auth0 = setup();
+
+      jest
+        .spyOn(auth0['cacheManager'], 'clear')
+        .mockReturnValueOnce(Promise.resolve());
+
+      await auth0.logout({ clientId: 'client_123' });
+
+      expect(auth0['cacheManager']['clear']).toHaveBeenCalledWith('client_123');
+      expect(auth0['cacheManager']['clear']).not.toHaveBeenCalledWith(
+        TEST_CLIENT_ID
+      );
+    });
+
+    it('clears the cache for all client ids', async () => {
+      const auth0 = setup();
+
+      jest
+        .spyOn(auth0['cacheManager'], 'clear')
+        .mockReturnValueOnce(Promise.resolve());
+
+      await auth0.logout({ clientId: null });
+
       expect(auth0['cacheManager']['clear']).toHaveBeenCalled();
+      expect(auth0['cacheManager']['clear']).not.toHaveBeenCalledWith(
+        TEST_CLIENT_ID
+      );
     });
 
     it('removes authenticated cookie from storage when `options.onRedirect` is set', async () => {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -828,7 +828,11 @@ export class Auth0Client {
   public async logout(options: LogoutOptions = {}): Promise<void> {
     const { openUrl, ...logoutOptions } = patchOpenUrlWithOnRedirect(options);
 
-    await this.cacheManager.clear();
+    if (options.clientId === null) {
+      await this.cacheManager.clear();
+    } else {
+      await this.cacheManager.clear(options.clientId || this.options.clientId);
+    }
 
     this.cookieStorage.remove(this.orgHintCookieName, {
       cookieDomain: this.options.cookieDomain

--- a/src/global.ts
+++ b/src/global.ts
@@ -410,7 +410,7 @@ export interface LogoutUrlOptions {
    *
    * [Read more about how redirecting after logout works](https://auth0.com/docs/logout/guides/redirect-users-after-logout)
    */
-  clientId?: string;
+  clientId?: string | null;
 
   /**
    * Parameters to pass to the logout endpoint. This can be known parameters defined by Auth0 or custom parameters


### PR DESCRIPTION
### Changes

When calling `logout`, we would call `cacheManager.clear()` without specifying any client id, resulting in clearing all data from the cache, including those belonging to other clientId's as the one configured in the current Auth0Client instance.

When using local storage, this results in logging out both `app1.domain.com` and `app2.domain.com` (both using a different clientId), when that might not be intended.

Unless the user sets `clientId` to null, we should only clear the data from the cache that belongs to either the provided `clientId`, or the globally configured `clientId`.

### References

Fixes #1063 

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
