### PR TITLE
Ensure cookieDomain is used when using legacy Cookiestorage

### DIFF
--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -682,7 +682,8 @@ describe('Auth0Client', () => {
         `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
         JSON.stringify(TEST_ORG_ID),
         {
-          expires: 1
+          expires: 1,
+          domain: TEST_DOMAIN
         }
       );
 
@@ -702,11 +703,13 @@ describe('Auth0Client', () => {
       await loginWithPopup(auth0);
 
       expect(<jest.Mock>esCookie.remove).toHaveBeenCalledWith(
-        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`, {}
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+        {}
       );
 
       expect(<jest.Mock>esCookie.remove).toHaveBeenCalledWith(
-        `auth0.${TEST_CLIENT_ID}.organization_hint`, {}
+        `auth0.${TEST_CLIENT_ID}.organization_hint`,
+        {}
       );
     });
 

--- a/__tests__/storage.test.ts
+++ b/__tests__/storage.test.ts
@@ -132,7 +132,8 @@ describe('CookieStorageWithLegacySameSite', () => {
       `_legacy_${key}`,
       JSON.stringify(value),
       {
-        expires: options.daysUntilExpire
+        expires: options.daysUntilExpire,
+        domain: options.cookieDomain
       }
     );
   });

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -91,6 +91,10 @@ export const CookieStorageWithLegacySameSite = {
       cookieAttributes.expires = options.daysUntilExpire;
     }
 
+    if (options?.cookieDomain) {
+      cookieAttributes.domain = options.cookieDomain;
+    }
+
     Cookies.set(
       `${LEGACY_PREFIX}${key}`,
       JSON.stringify(value),


### PR DESCRIPTION
### Changes

The cookieDomain was not taken into consideration when saving the legacy cookie, but only when trying to remove it. This resulted in the fact that the legacy cookie is never removed when a cookieDomain was used.

### References

Closes #1070 

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
