### PR TITLE
Release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v2.0.3](https://github.com/auth0/auth0-spa-js/tree/v2.0.3) (2023-02-04)
+[Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v2.0.2...v2.0.3)
+
+**Fixed**
+- Ensure cookieDomain is used when using legacy Cookiestorage [\#1071](https://github.com/auth0/auth0-spa-js/pull/1071) ([frederikprijck](https://github.com/frederikprijck))
+- Ensure to only clear current client cache when logging out [\#1068](https://github.com/auth0/auth0-spa-js/pull/1068) ([frederikprijck](https://github.com/frederikprijck))
+
 ## [v2.0.2](https://github.com/auth0/auth0-spa-js/tree/v2.0.2) (2023-01-12)
 
 [Full Changelog](https://github.com/auth0/auth0-spa-js/compare/v2.0.1...v2.0.2)

--- a/docs/classes/Auth0Client.html
+++ b/docs/classes/Auth0Client.html
@@ -23,7 +23,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">Auth0Client</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L114">Auth0Client.ts:114</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L114">Auth0Client.ts:114</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -60,7 +60,7 @@
 <h5>options: <a href="../interfaces/Auth0ClientOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">Auth0ClientOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="Auth0Client.html" class="tsd-signature-type" data-tsd-kind="Class">Auth0Client</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L141">Auth0Client.ts:141</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L141">Auth0Client.ts:141</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="checkSession" class="tsd-anchor"></a>
@@ -92,7 +92,7 @@ and handle the possible <code>login_required</code> error <a href="https://githu
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> options: <a href="../interfaces/GetTokenSilentlyOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">GetTokenSilentlyOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L564">Auth0Client.ts:564</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L564">Auth0Client.ts:564</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="getIdTokenClaims" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get<wbr/>Id<wbr/>Token<wbr/>Claims</span><a href="#getIdTokenClaims" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -104,7 +104,7 @@ and handle the possible <code>login_required</code> error <a href="https://githu
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/IdToken.html" class="tsd-signature-type" data-tsd-kind="Interface">IdToken</a><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L428">Auth0Client.ts:428</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L428">Auth0Client.ts:428</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="getTokenSilently" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get<wbr/>Token<wbr/>Silently</span><a href="#getTokenSilently" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -119,7 +119,7 @@ and handle the possible <code>login_required</code> error <a href="https://githu
 <h5>options: <a href="../interfaces/GetTokenSilentlyOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">GetTokenSilentlyOptions</a><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span><br/><span>    </span>detailedResponse<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">true</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../types/GetTokenSilentlyVerboseResponse.html" class="tsd-signature-type" data-tsd-kind="Type alias">GetTokenSilentlyVerboseResponse</a><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L589">Auth0Client.ts:589</a></li></ul></aside></li>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L589">Auth0Client.ts:589</a></li></ul></aside></li>
 <li class="tsd-signature tsd-anchor-link" id="getTokenSilently.getTokenSilently-2">get<wbr/>Token<wbr/>Silently<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">?: </span><a href="../interfaces/GetTokenSilentlyOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">GetTokenSilentlyOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span><a href="#getTokenSilently.getTokenSilently-2" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></li>
 <li class="tsd-description">
 <div class="tsd-comment tsd-typography"><p>Fetches a new access token and returns it.</p>
@@ -131,7 +131,7 @@ and handle the possible <code>login_required</code> error <a href="https://githu
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> options: <a href="../interfaces/GetTokenSilentlyOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">GetTokenSilentlyOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L598">Auth0Client.ts:598</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L598">Auth0Client.ts:598</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="getTokenWithPopup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get<wbr/>Token<wbr/>With<wbr/>Popup</span><a href="#getTokenWithPopup" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -153,7 +153,7 @@ results will be valid according to their expiration times.</p>
 <h5>config: <a href="../interfaces/PopupConfigOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">PopupConfigOptions</a><span class="tsd-signature-symbol"> = {}</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L743">Auth0Client.ts:743</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L743">Auth0Client.ts:743</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="getUser" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get<wbr/>User</span><a href="#getUser" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -173,7 +173,7 @@ from the <code>id_token</code>).</p>
 <h4>TUser<span class="tsd-signature-symbol"> extends </span><a href="User.html" class="tsd-signature-type" data-tsd-kind="Class">User</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">TUser</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></section>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type" data-tsd-kind="Type parameter">TUser</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L415">Auth0Client.ts:415</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L415">Auth0Client.ts:415</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="handleRedirectCallback" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>handle<wbr/>Redirect<wbr/>Callback</span><a href="#handleRedirectCallback" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -196,7 +196,7 @@ will be valid according to their expiration times.</p>
 <h5>url: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = window.location.href</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../interfaces/RedirectLoginResult.html" class="tsd-signature-type" data-tsd-kind="Interface">RedirectLoginResult</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">TAppState</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L480">Auth0Client.ts:480</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L480">Auth0Client.ts:480</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="isAuthenticated" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>is<wbr/>Authenticated</span><a href="#isAuthenticated" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -209,7 +209,7 @@ otherwise returns <code>false</code>.</p>
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L783">Auth0Client.ts:783</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L783">Auth0Client.ts:783</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="loginWithPopup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>login<wbr/>With<wbr/>Popup</span><a href="#loginWithPopup" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -234,7 +234,7 @@ otherwise the popup will be blocked in most browsers.</p>
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> config: <a href="../interfaces/PopupConfigOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">PopupConfigOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L348">Auth0Client.ts:348</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L348">Auth0Client.ts:348</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="loginWithRedirect" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>login<wbr/>With<wbr/>Redirect</span><a href="#loginWithRedirect" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -258,7 +258,7 @@ parameters will be auto-generated.</p>
 <h5>options: <a href="../interfaces/RedirectLoginOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">RedirectLoginOptions</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type" data-tsd-kind="Type parameter">TAppState</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> = {}</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L445">Auth0Client.ts:445</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L445">Auth0Client.ts:445</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="logout" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>logout</span><a href="#logout" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -278,7 +278,7 @@ the parameters provided as arguments, to clear the Auth0 session.</p>
 <h5>options: <a href="../interfaces/LogoutOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LogoutOptions</a><span class="tsd-signature-symbol"> = {}</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/Auth0Client.ts#L828">Auth0Client.ts:828</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/Auth0Client.ts#L828">Auth0Client.ts:828</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/AuthenticationError.html
+++ b/docs/classes/AuthenticationError.html
@@ -26,7 +26,7 @@ Authentication API&#39;s Standard Error Responses: <a href="https://auth0.com/do
 <ul class="tsd-hierarchy">
 <li><span class="target">AuthenticationError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L25">errors.ts:25</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L25">errors.ts:25</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -68,31 +68,31 @@ Authentication API&#39;s Standard Error Responses: <a href="https://auth0.com/do
 <h4 class="tsd-returns-title">Returns <a href="AuthenticationError.html" class="tsd-signature-type" data-tsd-kind="Class">AuthenticationError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L26">errors.ts:26</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L26">errors.ts:26</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="appState" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>app<wbr/>State</span><a href="#appState" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">app<wbr/>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = null</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L30">errors.ts:30</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L30">errors.ts:30</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error</span><a href="#error" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error">error</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error_description">error_description</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="state" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>state</span><a href="#state" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">state<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L29">errors.ts:29</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L29">errors.ts:29</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a id="fromPayload" class="tsd-anchor"></a>
@@ -113,7 +113,7 @@ Authentication API&#39;s Standard Error Responses: <a href="https://auth0.com/do
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#fromPayload">fromPayload</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/CacheKey.html
+++ b/docs/classes/CacheKey.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">CacheKey</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L12">cache/shared.ts:12</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L12">cache/shared.ts:12</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -62,34 +62,34 @@
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> suffix: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="CacheKey.html" class="tsd-signature-type" data-tsd-kind="Class">CacheKey</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L17">cache/shared.ts:17</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L17">cache/shared.ts:17</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="audience" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>audience</span><a href="#audience" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">audience<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L15">cache/shared.ts:15</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L15">cache/shared.ts:15</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="clientId" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>client<wbr/>Id</span><a href="#clientId" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">client<wbr/>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L13">cache/shared.ts:13</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L13">cache/shared.ts:13</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="prefix" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>prefix</span><a href="#prefix" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">prefix<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = CACHE_KEY_PREFIX</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L19">cache/shared.ts:19</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L19">cache/shared.ts:19</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="scope" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>scope</span><a href="#scope" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">scope<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L14">cache/shared.ts:14</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L14">cache/shared.ts:14</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="suffix" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>suffix</span><a href="#suffix" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">suffix<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L20">cache/shared.ts:20</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L20">cache/shared.ts:20</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="toKey" class="tsd-anchor"></a>
@@ -103,7 +103,7 @@
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L31">cache/shared.ts:31</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L31">cache/shared.ts:31</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="fromCacheEntry" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <span>from<wbr/>Cache<wbr/>Entry</span><a href="#fromCacheEntry" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -122,7 +122,7 @@
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="CacheKey.html" class="tsd-signature-type" data-tsd-kind="Class">CacheKey</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L53">cache/shared.ts:53</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L53">cache/shared.ts:53</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="fromKey" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagStatic">Static</code> <span>from<wbr/>Key</span><a href="#fromKey" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -141,7 +141,7 @@
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="CacheKey.html" class="tsd-signature-type" data-tsd-kind="Class">CacheKey</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L42">cache/shared.ts:42</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L42">cache/shared.ts:42</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/GenericError.html
+++ b/docs/classes/GenericError.html
@@ -31,7 +31,7 @@
 <li><a href="MfaRequiredError.html" class="tsd-signature-type" data-tsd-kind="Class">MfaRequiredError</a></li>
 <li><a href="MissingRefreshTokenError.html" class="tsd-signature-type" data-tsd-kind="Class">MissingRefreshTokenError</a></li></ul></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L4">errors.ts:4</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L4">errors.ts:4</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -67,19 +67,19 @@
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Overrides Error.constructor</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="error" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error</span><a href="#error" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="fromPayload" class="tsd-anchor"></a>
@@ -99,7 +99,7 @@
 <h5>error_<wbr/>description<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/InMemoryCache.html
+++ b/docs/classes/InMemoryCache.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">InMemoryCache</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-memory.ts#L3">cache/cache-memory.ts:3</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-memory.ts#L3">cache/cache-memory.ts:3</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -48,7 +48,7 @@
 <h3 class="tsd-anchor-link"><span>enclosed<wbr/>Cache</span><a href="#enclosedCache" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">enclosed<wbr/>Cache<span class="tsd-signature-symbol">:</span> <a href="../interfaces/ICache.html" class="tsd-signature-type" data-tsd-kind="Interface">ICache</a><span class="tsd-signature-symbol"> = ...</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-memory.ts#L4">cache/cache-memory.ts:4</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-memory.ts#L4">cache/cache-memory.ts:4</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/LocalStorageCache.html
+++ b/docs/classes/LocalStorageCache.html
@@ -24,7 +24,7 @@
 <ul class="tsd-hierarchy">
 <li><a href="../interfaces/ICache.html" class="tsd-signature-type" data-tsd-kind="Interface">ICache</a></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-localstorage.ts#L3">cache/cache-localstorage.ts:3</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-localstorage.ts#L3">cache/cache-localstorage.ts:3</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -59,7 +59,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h4><aside class="tsd-sources">
 <p>Implementation of <a href="../interfaces/ICache.html">ICache</a>.<a href="../interfaces/ICache.html#allKeys">allKeys</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-localstorage.ts#L26">cache/cache-localstorage.ts:26</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-localstorage.ts#L26">cache/cache-localstorage.ts:26</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="get" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get</span><a href="#get" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -78,7 +78,7 @@
 <h4 class="tsd-returns-title">Returns <a href="../types/MaybePromise.html" class="tsd-signature-type" data-tsd-kind="Type alias">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <p>Implementation of <a href="../interfaces/ICache.html">ICache</a>.<a href="../interfaces/ICache.html#get">get</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-localstorage.ts#L8">cache/cache-localstorage.ts:8</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-localstorage.ts#L8">cache/cache-localstorage.ts:8</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="remove" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>remove</span><a href="#remove" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -92,7 +92,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4><aside class="tsd-sources">
 <p>Implementation of <a href="../interfaces/ICache.html">ICache</a>.<a href="../interfaces/ICache.html#remove">remove</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-localstorage.ts#L22">cache/cache-localstorage.ts:22</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-localstorage.ts#L22">cache/cache-localstorage.ts:22</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class"><a id="set" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set</span><a href="#set" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
@@ -113,7 +113,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4><aside class="tsd-sources">
 <p>Implementation of <a href="../interfaces/ICache.html">ICache</a>.<a href="../interfaces/ICache.html#set">set</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/cache-localstorage.ts#L4">cache/cache-localstorage.ts:4</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/cache-localstorage.ts#L4">cache/cache-localstorage.ts:4</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/MfaRequiredError.html
+++ b/docs/classes/MfaRequiredError.html
@@ -25,7 +25,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">MfaRequiredError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L72">errors.ts:72</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L72">errors.ts:72</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -64,7 +64,7 @@
 <h4 class="tsd-returns-title">Returns <a href="MfaRequiredError.html" class="tsd-signature-type" data-tsd-kind="Class">MfaRequiredError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L73">errors.ts:73</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L73">errors.ts:73</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error" class="tsd-anchor"></a>
@@ -72,18 +72,18 @@
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error">error</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error_description">error_description</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="mfa_token" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>mfa_<wbr/>token</span><a href="#mfa_token" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">mfa_<wbr/>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L76">errors.ts:76</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L76">errors.ts:76</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a id="fromPayload" class="tsd-anchor"></a>
@@ -104,7 +104,7 @@
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#fromPayload">fromPayload</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/MissingRefreshTokenError.html
+++ b/docs/classes/MissingRefreshTokenError.html
@@ -25,7 +25,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">MissingRefreshTokenError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L87">errors.ts:87</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L87">errors.ts:87</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -63,31 +63,31 @@
 <h4 class="tsd-returns-title">Returns <a href="MissingRefreshTokenError.html" class="tsd-signature-type" data-tsd-kind="Class">MissingRefreshTokenError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L88">errors.ts:88</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L88">errors.ts:88</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="audience" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>audience</span><a href="#audience" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">audience<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L88">errors.ts:88</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L88">errors.ts:88</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error</span><a href="#error" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error">error</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error_description">error_description</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="scope" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>scope</span><a href="#scope" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">scope<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L88">errors.ts:88</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L88">errors.ts:88</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a id="fromPayload" class="tsd-anchor"></a>
@@ -108,7 +108,7 @@
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#fromPayload">fromPayload</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/PopupCancelledError.html
+++ b/docs/classes/PopupCancelledError.html
@@ -25,7 +25,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">PopupCancelledError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L61">errors.ts:61</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L61">errors.ts:61</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -60,7 +60,7 @@
 <h4 class="tsd-returns-title">Returns <a href="PopupCancelledError.html" class="tsd-signature-type" data-tsd-kind="Class">PopupCancelledError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L62">errors.ts:62</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L62">errors.ts:62</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error" class="tsd-anchor"></a>
@@ -68,18 +68,18 @@
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error">error</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error_description">error_description</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="popup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>popup</span><a href="#popup" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L62">errors.ts:62</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L62">errors.ts:62</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a id="fromPayload" class="tsd-anchor"></a>
@@ -100,7 +100,7 @@
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#fromPayload">fromPayload</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/PopupTimeoutError.html
+++ b/docs/classes/PopupTimeoutError.html
@@ -25,7 +25,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">PopupTimeoutError</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L53">errors.ts:53</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L53">errors.ts:53</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -60,7 +60,7 @@
 <h4 class="tsd-returns-title">Returns <a href="PopupTimeoutError.html" class="tsd-signature-type" data-tsd-kind="Class">PopupTimeoutError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="TimeoutError.html">TimeoutError</a>.<a href="TimeoutError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L54">errors.ts:54</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L54">errors.ts:54</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error" class="tsd-anchor"></a>
@@ -68,18 +68,18 @@
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="TimeoutError.html">TimeoutError</a>.<a href="TimeoutError.html#error">error</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="TimeoutError.html">TimeoutError</a>.<a href="TimeoutError.html#error_description">error_description</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="popup" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>popup</span><a href="#popup" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">popup<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Window</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L54">errors.ts:54</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L54">errors.ts:54</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a id="fromPayload" class="tsd-anchor"></a>
@@ -100,7 +100,7 @@
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Inherited from <a href="TimeoutError.html">TimeoutError</a>.<a href="TimeoutError.html#fromPayload">fromPayload</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/TimeoutError.html
+++ b/docs/classes/TimeoutError.html
@@ -28,7 +28,7 @@ when network requests to the Auth server timeout.</p>
 <ul class="tsd-hierarchy">
 <li><a href="PopupTimeoutError.html" class="tsd-signature-type" data-tsd-kind="Class">PopupTimeoutError</a></li></ul></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L42">errors.ts:42</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L42">errors.ts:42</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -57,7 +57,7 @@ when network requests to the Auth server timeout.</p>
 <h4 class="tsd-returns-title">Returns <a href="TimeoutError.html" class="tsd-signature-type" data-tsd-kind="Class">TimeoutError</a></h4><aside class="tsd-sources">
 <p>Overrides <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#constructor">constructor</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L43">errors.ts:43</a></li></ul></aside></li></ul></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L43">errors.ts:43</a></li></ul></aside></li></ul></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error" class="tsd-anchor"></a>
@@ -65,13 +65,13 @@ when network requests to the Auth server timeout.</p>
 <div class="tsd-signature">error<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error">error</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><a id="error_description" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>error_<wbr/>description</span><a href="#error_description" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error_<wbr/>description<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#error_description">error_description</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L5">errors.ts:5</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a id="fromPayload" class="tsd-anchor"></a>
@@ -92,7 +92,7 @@ when network requests to the Auth server timeout.</p>
 <h4 class="tsd-returns-title">Returns <a href="GenericError.html" class="tsd-signature-type" data-tsd-kind="Class">GenericError</a></h4><aside class="tsd-sources">
 <p>Inherited from <a href="GenericError.html">GenericError</a>.<a href="GenericError.html#fromPayload">fromPayload</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/errors.ts#L10">errors.ts:10</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/classes/User.html
+++ b/docs/classes/User.html
@@ -23,7 +23,7 @@
 <h4 class="tsd-before-signature">Indexable</h4>
 <div class="tsd-signature"><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></div></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L581">global.ts:581</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L581">global.ts:581</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -70,102 +70,102 @@
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>address</span><a href="#address" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">address<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L599">global.ts:599</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L599">global.ts:599</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="birthdate" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>birthdate</span><a href="#birthdate" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">birthdate<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L594">global.ts:594</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L594">global.ts:594</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="email" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>email</span><a href="#email" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">email<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L591">global.ts:591</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L591">global.ts:591</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="email_verified" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>email_<wbr/>verified</span><a href="#email_verified" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">email_<wbr/>verified<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L592">global.ts:592</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L592">global.ts:592</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="family_name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>family_<wbr/>name</span><a href="#family_name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">family_<wbr/>name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L584">global.ts:584</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L584">global.ts:584</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="gender" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>gender</span><a href="#gender" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">gender<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L593">global.ts:593</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L593">global.ts:593</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="given_name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>given_<wbr/>name</span><a href="#given_name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">given_<wbr/>name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L583">global.ts:583</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L583">global.ts:583</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="locale" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>locale</span><a href="#locale" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">locale<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L596">global.ts:596</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L596">global.ts:596</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="middle_name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>middle_<wbr/>name</span><a href="#middle_name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">middle_<wbr/>name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L585">global.ts:585</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L585">global.ts:585</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>name</span><a href="#name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L582">global.ts:582</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L582">global.ts:582</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="nickname" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>nickname</span><a href="#nickname" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">nickname<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L586">global.ts:586</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L586">global.ts:586</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="phone_number" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>phone_<wbr/>number</span><a href="#phone_number" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">phone_<wbr/>number<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L597">global.ts:597</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L597">global.ts:597</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="phone_number_verified" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>phone_<wbr/>number_<wbr/>verified</span><a href="#phone_number_verified" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">phone_<wbr/>number_<wbr/>verified<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L598">global.ts:598</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L598">global.ts:598</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="picture" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>picture</span><a href="#picture" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">picture<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L589">global.ts:589</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L589">global.ts:589</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="preferred_username" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>preferred_<wbr/>username</span><a href="#preferred_username" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">preferred_<wbr/>username<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L587">global.ts:587</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L587">global.ts:587</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="profile" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>profile</span><a href="#profile" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">profile<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L588">global.ts:588</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L588">global.ts:588</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="sub" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>sub</span><a href="#sub" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">sub<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L601">global.ts:601</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L601">global.ts:601</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="updated_at" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>updated_<wbr/>at</span><a href="#updated_at" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">updated_<wbr/>at<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L600">global.ts:600</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L600">global.ts:600</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="website" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>website</span><a href="#website" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">website<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L590">global.ts:590</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L590">global.ts:590</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class"><a id="zoneinfo" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>zoneinfo</span><a href="#zoneinfo" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">zoneinfo<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L595">global.ts:595</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L595">global.ts:595</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/createAuth0Client.html
+++ b/docs/functions/createAuth0Client.html
@@ -34,7 +34,7 @@ a user on page refresh. Please see <a href="https://auth0.github.io/auth0-spa-js
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="../classes/Auth0Client.html" class="tsd-signature-type" data-tsd-kind="Class">Auth0Client</a><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/index.ts#L17">index.ts:17</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/index.ts#L17">index.ts:17</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/Auth0ClientOptions.html
+++ b/docs/interfaces/Auth0ClientOptions.html
@@ -22,7 +22,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">Auth0ClientOptions</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L117">global.ts:117</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L117">global.ts:117</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -69,7 +69,7 @@
 <li class="tsd-parameter">
 <h5>version<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L197">global.ts:197</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L197">global.ts:197</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="authorizationParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>authorization<wbr/>Params</span><a href="#authorizationParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">authorization<wbr/>Params<span class="tsd-signature-symbol">?:</span> <a href="AuthorizationParams.html" class="tsd-signature-type" data-tsd-kind="Interface">AuthorizationParams</a></div>
@@ -78,7 +78,7 @@ defined by Auth0 or custom parameters that you define.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from BaseLoginOptions.authorizationParams</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L114">global.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L114">global.ts:114</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="authorizeTimeoutInSeconds" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>authorize<wbr/>Timeout<wbr/>In<wbr/>Seconds</span><a href="#authorizeTimeoutInSeconds" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">authorize<wbr/>Timeout<wbr/>In<wbr/>Seconds<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -86,14 +86,14 @@ defined by Auth0 or custom parameters that you define.</p>
 Defaults to 60s.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L186">global.ts:186</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L186">global.ts:186</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cache" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cache</span><a href="#cache" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cache<span class="tsd-signature-symbol">?:</span> <a href="ICache.html" class="tsd-signature-type" data-tsd-kind="Interface">ICache</a></div>
 <div class="tsd-comment tsd-typography"><p>Specify a custom cache implementation to use for token storage and retrieval. This setting takes precedence over <code>cacheLocation</code> if they are both specified.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L150">global.ts:150</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L150">global.ts:150</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cacheLocation" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cache<wbr/>Location</span><a href="#cacheLocation" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cache<wbr/>Location<span class="tsd-signature-symbol">?:</span> <a href="../types/CacheLocation.html" class="tsd-signature-type" data-tsd-kind="Type alias">CacheLocation</a></div>
@@ -102,14 +102,14 @@ The default setting is <code>memory</code>.</p>
 <p>Read more about <a href="https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options">changing storage options in the Auth0 docs</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L145">global.ts:145</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L145">global.ts:145</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientId" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>client<wbr/>Id</span><a href="#clientId" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">client<wbr/>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The Client ID found on your Application settings page</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L131">global.ts:131</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L131">global.ts:131</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cookieDomain" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cookie<wbr/>Domain</span><a href="#cookieDomain" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cookie<wbr/>Domain<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -121,7 +121,7 @@ on page load.</p>
 top-level domain and prefixed with a <code>.</code> (eg: <code>.example.com</code>).</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L243">global.ts:243</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L243">global.ts:243</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="domain" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>domain</span><a href="#domain" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
@@ -130,21 +130,21 @@ top-level domain and prefixed with a <code>.</code> (eg: <code>.example.com</cod
 (when using <a href="https://auth0.com/docs/custom-domains">custom domains</a>)</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L123">global.ts:123</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L123">global.ts:123</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="httpTimeoutInSeconds" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>http<wbr/>Timeout<wbr/>In<wbr/>Seconds</span><a href="#httpTimeoutInSeconds" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">http<wbr/>Timeout<wbr/>In<wbr/>Seconds<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
 <div class="tsd-comment tsd-typography"><p>Specify the timeout for HTTP calls using <code>fetch</code>. The default is 10 seconds.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L191">global.ts:191</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L191">global.ts:191</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="issuer" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>issuer</span><a href="#issuer" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">issuer<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The issuer to be used for validation of JWTs, optionally defaults to the domain above</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L127">global.ts:127</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L127">global.ts:127</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="leeway" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>leeway</span><a href="#leeway" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">leeway<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -153,7 +153,7 @@ Typically, this value is no more than a minute or two at maximum.
 Defaults to 60s.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L137">global.ts:137</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L137">global.ts:137</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="legacySameSiteCookie" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>legacy<wbr/>Same<wbr/>Site<wbr/>Cookie</span><a href="#legacySameSiteCookie" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">legacy<wbr/>Same<wbr/>Site<wbr/>Cookie<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -165,7 +165,7 @@ See <a href="https://www.chromium.org/updates/same-site/incompatible-clients">ht
 Defaults to true</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L211">global.ts:211</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L211">global.ts:211</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="nowProvider" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>now<wbr/>Provider</span><a href="#nowProvider" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">now<wbr/>Provider<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -181,7 +181,7 @@ Defaults to true</p>
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L258">global.ts:258</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L258">global.ts:258</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="sessionCheckExpiryDays" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>session<wbr/>Check<wbr/>Expiry<wbr/>Days</span><a href="#sessionCheckExpiryDays" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">session<wbr/>Check<wbr/>Expiry<wbr/>Days<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -189,7 +189,7 @@ Defaults to true</p>
 Defaults to 1.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L230">global.ts:230</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L230">global.ts:230</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="useCookiesForTransactions" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>use<wbr/>Cookies<wbr/>For<wbr/>Transactions</span><a href="#useCookiesForTransactions" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">use<wbr/>Cookies<wbr/>For<wbr/>Transactions<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -201,7 +201,7 @@ the user is going through the authentication flow on the authorization server.</
 may end up spanning across multiple tabs (e.g. magic links) or you cannot otherwise rely on session storage being available.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L224">global.ts:224</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L224">global.ts:224</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="useFormData" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>use<wbr/>Form<wbr/>Data</span><a href="#useFormData" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">use<wbr/>Form<wbr/>Data<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -210,7 +210,7 @@ may end up spanning across multiple tabs (e.g. magic links) or you cannot otherw
 please verify that your Auth0 Rules continue to work as intended.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L251">global.ts:251</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L251">global.ts:251</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="useRefreshTokens" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>use<wbr/>Refresh<wbr/>Tokens</span><a href="#useRefreshTokens" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">use<wbr/>Refresh<wbr/>Tokens<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -219,7 +219,7 @@ The default setting is <code>false</code>.</p>
 <p><strong>Note</strong>: Use of refresh tokens must be enabled by an administrator on your Auth0 client application.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L158">global.ts:158</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L158">global.ts:158</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="useRefreshTokensFallback" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>use<wbr/>Refresh<wbr/>Tokens<wbr/>Fallback</span><a href="#useRefreshTokensFallback" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">use<wbr/>Refresh<wbr/>Tokens<wbr/>Fallback<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -234,7 +234,7 @@ In situations like this you can disable the iframe fallback and handle the faile
 </code></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L180">global.ts:180</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L180">global.ts:180</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/AuthorizationParams.html
+++ b/docs/interfaces/AuthorizationParams.html
@@ -23,7 +23,7 @@
 <h4 class="tsd-before-signature">Indexable</h4>
 <div class="tsd-signature"><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></div></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L3">global.ts:3</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L3">global.ts:3</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -52,14 +52,14 @@
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>acr_<wbr/>values</span><a href="#acr_values" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">acr_<wbr/>values<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L56">global.ts:56</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L56">global.ts:56</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="audience" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>audience</span><a href="#audience" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">audience<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The default audience to be used for requesting API access.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L71">global.ts:71</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L71">global.ts:71</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="connection" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>connection</span><a href="#connection" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">connection<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -68,7 +68,7 @@ If null, it will redirect to the Auth0 Login Page and show
 the Login Widget.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L78">global.ts:78</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L78">global.ts:78</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="display" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>display</span><a href="#display" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">display<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">&quot;page&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;popup&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;touch&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;wap&quot;</span></div>
@@ -80,21 +80,21 @@ the Login Widget.</p>
 </ul>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L10">global.ts:10</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L10">global.ts:10</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="id_token_hint" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>id_<wbr/>token_<wbr/>hint</span><a href="#id_token_hint" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">id_<wbr/>token_<wbr/>hint<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>Previously issued ID Token.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L36">global.ts:36</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L36">global.ts:36</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="invitation" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>invitation</span><a href="#invitation" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">invitation<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The Id of an invitation to accept. This is available from the user invitation URL that is given when participating in a user invitation flow.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L91">global.ts:91</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L91">global.ts:91</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="login_hint" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>login_<wbr/>hint</span><a href="#login_hint" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">login_<wbr/>hint<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -104,7 +104,7 @@ to pre-fill the email box or select the right session for sign-in.</p>
 <p>This currently only affects the classic Lock experience.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L54">global.ts:54</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L54">global.ts:54</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="max_age" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>max_<wbr/>age</span><a href="#max_age" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">max_<wbr/>age<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
@@ -113,7 +113,7 @@ If the last time the user authenticated is greater than this value,
 the user must be reauthenticated.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L25">global.ts:25</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L25">global.ts:25</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="organization" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>organization</span><a href="#organization" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">organization<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -122,7 +122,7 @@ the user must be reauthenticated.</p>
 the <code>org_id</code> claim in your user&#39;s ID Token.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L86">global.ts:86</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L86">global.ts:86</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="prompt" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>prompt</span><a href="#prompt" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">prompt<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">&quot;none&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;login&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;consent&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;select_account&quot;</span></div>
@@ -134,7 +134,7 @@ the <code>org_id</code> claim in your user&#39;s ID Token.</p>
 </ul>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L18">global.ts:18</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L18">global.ts:18</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="redirect_uri" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>redirect_<wbr/>uri</span><a href="#redirect_uri" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">redirect_<wbr/>uri<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -145,7 +145,7 @@ settings. If not provided here, it should be provided in the other
 methods that provide authentication.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L100">global.ts:100</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L100">global.ts:100</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="scope" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>scope</span><a href="#scope" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">scope<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -155,7 +155,7 @@ methods that provide authentication.</p>
 <p>Note: The <code>openid</code> scope is <strong>always applied</strong> regardless of this setting.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L66">global.ts:66</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L66">global.ts:66</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="screen_hint" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>screen_<wbr/>hint</span><a href="#screen_hint" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">screen_<wbr/>hint<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -165,7 +165,7 @@ this by passing &#39;signup&#39; to show the signup page instead.</p>
 <p>This only affects the New Universal Login Experience.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L45">global.ts:45</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L45">global.ts:45</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="ui_locales" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>ui_<wbr/>locales</span><a href="#ui_locales" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">ui_<wbr/>locales<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -173,7 +173,7 @@ this by passing &#39;signup&#39; to show the signup page instead.</p>
 For example: <code>&#39;fr-CA fr en&#39;</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L31">global.ts:31</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L31">global.ts:31</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/DecodedToken.html
+++ b/docs/interfaces/DecodedToken.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">DecodedToken</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L64">cache/shared.ts:64</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L64">cache/shared.ts:64</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -37,12 +37,12 @@
 <h3 class="tsd-anchor-link"><span>claims</span><a href="#claims" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">claims<span class="tsd-signature-symbol">:</span> <a href="IdToken.html" class="tsd-signature-type" data-tsd-kind="Interface">IdToken</a></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L65">cache/shared.ts:65</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L65">cache/shared.ts:65</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="user" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>user</span><a href="#user" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">user<span class="tsd-signature-symbol">:</span> <a href="../classes/User.html" class="tsd-signature-type" data-tsd-kind="Class">User</a></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L66">cache/shared.ts:66</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L66">cache/shared.ts:66</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/GetTokenSilentlyOptions.html
+++ b/docs/interfaces/GetTokenSilentlyOptions.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">GetTokenSilentlyOptions</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L340">global.ts:340</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L340">global.ts:340</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -63,7 +63,7 @@ Auth0 Application&#39;s settings.</p>
 <div class="tsd-comment tsd-typography"><p>The scope that was used in the authentication request</p>
 </div></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L352">global.ts:352</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L352">global.ts:352</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cacheMode" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cache<wbr/>Mode</span><a href="#cacheMode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cache<wbr/>Mode<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">&quot;on&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;off&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;cache-only&quot;</span></div>
@@ -73,7 +73,7 @@ When <code>cache-only</code>, only reads from the cache and never sends a reques
 Defaults to <code>on</code>, where it both reads from the cache and sends a request to Auth0 as needed.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L347">global.ts:347</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L347">global.ts:347</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="detailedResponse" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>detailed<wbr/>Response</span><a href="#detailedResponse" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">detailed<wbr/>Response<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -82,7 +82,7 @@ Defaults to <code>on</code>, where it both reads from the cache and sends a requ
 <p>The default is <code>false</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L391">global.ts:391</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L391">global.ts:391</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="timeoutInSeconds" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>timeout<wbr/>In<wbr/>Seconds</span><a href="#timeoutInSeconds" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">timeout<wbr/>In<wbr/>Seconds<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -90,7 +90,7 @@ Defaults to <code>on</code>, where it both reads from the cache and sends a requ
 Defaults to 60s.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L383">global.ts:383</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L383">global.ts:383</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/GetTokenWithPopupOptions.html
+++ b/docs/interfaces/GetTokenWithPopupOptions.html
@@ -22,7 +22,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">GetTokenWithPopupOptions</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L394">global.ts:394</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L394">global.ts:394</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -43,7 +43,7 @@ defined by Auth0 or custom parameters that you define.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from <a href="PopupLoginOptions.html">PopupLoginOptions</a>.<a href="PopupLoginOptions.html#authorizationParams">authorizationParams</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L114">global.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L114">global.ts:114</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cacheMode" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cache<wbr/>Mode</span><a href="#cacheMode" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cache<wbr/>Mode<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">&quot;on&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;off&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;cache-only&quot;</span></div>
@@ -52,7 +52,7 @@ When <code>cache-only</code>, only reads from the cache and never sends a reques
 Defaults to <code>on</code>, where it both reads from the cache and sends a request to Auth0 as needed.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L400">global.ts:400</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L400">global.ts:400</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/ICache.html
+++ b/docs/interfaces/ICache.html
@@ -24,7 +24,7 @@
 <ul class="tsd-hierarchy">
 <li><a href="../classes/LocalStorageCache.html" class="tsd-signature-type" data-tsd-kind="Class">LocalStorageCache</a></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L99">cache/shared.ts:99</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L99">cache/shared.ts:99</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -46,7 +46,7 @@
 <li class="tsd-description">
 <h4 class="tsd-returns-title">Returns <a href="../types/MaybePromise.html" class="tsd-signature-type" data-tsd-kind="Type alias">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L103">cache/shared.ts:103</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L103">cache/shared.ts:103</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="get" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get</span><a href="#get" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
@@ -64,7 +64,7 @@
 <h5>key: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="../types/MaybePromise.html" class="tsd-signature-type" data-tsd-kind="Type alias">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L101">cache/shared.ts:101</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L101">cache/shared.ts:101</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="remove" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>remove</span><a href="#remove" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
@@ -77,7 +77,7 @@
 <h5>key: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="../types/MaybePromise.html" class="tsd-signature-type" data-tsd-kind="Type alias">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L102">cache/shared.ts:102</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L102">cache/shared.ts:102</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="set" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set</span><a href="#set" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
@@ -97,7 +97,7 @@
 <h5>entry: <span class="tsd-signature-type" data-tsd-kind="Type parameter">T</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="../types/MaybePromise.html" class="tsd-signature-type" data-tsd-kind="Type alias">MaybePromise</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L100">cache/shared.ts:100</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L100">cache/shared.ts:100</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/IdToken.html
+++ b/docs/interfaces/IdToken.html
@@ -23,7 +23,7 @@
 <h4 class="tsd-before-signature">Indexable</h4>
 <div class="tsd-signature"><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></div></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L540">global.ts:540</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L540">global.ts:540</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -75,187 +75,187 @@
 <h3 class="tsd-anchor-link"><span>__raw</span><a href="#__raw" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">__raw<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L541">global.ts:541</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L541">global.ts:541</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="acr" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>acr</span><a href="#acr" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">acr<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L572">global.ts:572</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L572">global.ts:572</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="address" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>address</span><a href="#address" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">address<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L559">global.ts:559</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L559">global.ts:559</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="amr" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>amr</span><a href="#amr" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">amr<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L573">global.ts:573</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L573">global.ts:573</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="at_hash" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>at_<wbr/>hash</span><a href="#at_hash" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">at_<wbr/>hash<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L570">global.ts:570</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L570">global.ts:570</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="aud" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>aud</span><a href="#aud" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">aud<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L562">global.ts:562</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L562">global.ts:562</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="auth_time" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>auth_<wbr/>time</span><a href="#auth_time" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">auth_<wbr/>time<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L569">global.ts:569</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L569">global.ts:569</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="azp" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>azp</span><a href="#azp" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">azp<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L567">global.ts:567</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L567">global.ts:567</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="birthdate" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>birthdate</span><a href="#birthdate" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">birthdate<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L554">global.ts:554</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L554">global.ts:554</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="c_hash" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>c_<wbr/>hash</span><a href="#c_hash" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">c_<wbr/>hash<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L571">global.ts:571</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L571">global.ts:571</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cnf" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cnf</span><a href="#cnf" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cnf<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L575">global.ts:575</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L575">global.ts:575</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="email" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>email</span><a href="#email" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">email<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L551">global.ts:551</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L551">global.ts:551</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="email_verified" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>email_<wbr/>verified</span><a href="#email_verified" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">email_<wbr/>verified<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L552">global.ts:552</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L552">global.ts:552</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="exp" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>exp</span><a href="#exp" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">exp<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L563">global.ts:563</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L563">global.ts:563</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="family_name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>family_<wbr/>name</span><a href="#family_name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">family_<wbr/>name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L544">global.ts:544</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L544">global.ts:544</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="gender" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>gender</span><a href="#gender" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">gender<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L553">global.ts:553</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L553">global.ts:553</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="given_name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>given_<wbr/>name</span><a href="#given_name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">given_<wbr/>name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L543">global.ts:543</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L543">global.ts:543</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="iat" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>iat</span><a href="#iat" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">iat<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L565">global.ts:565</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L565">global.ts:565</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="iss" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>iss</span><a href="#iss" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">iss<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L561">global.ts:561</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L561">global.ts:561</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="jti" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>jti</span><a href="#jti" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">jti<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L566">global.ts:566</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L566">global.ts:566</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="locale" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>locale</span><a href="#locale" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">locale<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L556">global.ts:556</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L556">global.ts:556</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="middle_name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>middle_<wbr/>name</span><a href="#middle_name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">middle_<wbr/>name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L545">global.ts:545</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L545">global.ts:545</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>name</span><a href="#name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L542">global.ts:542</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L542">global.ts:542</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="nbf" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>nbf</span><a href="#nbf" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">nbf<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L564">global.ts:564</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L564">global.ts:564</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="nickname" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>nickname</span><a href="#nickname" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">nickname<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L546">global.ts:546</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L546">global.ts:546</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="nonce" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>nonce</span><a href="#nonce" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">nonce<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L568">global.ts:568</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L568">global.ts:568</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="org_id" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>org_<wbr/>id</span><a href="#org_id" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">org_<wbr/>id<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L577">global.ts:577</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L577">global.ts:577</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="phone_number" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>phone_<wbr/>number</span><a href="#phone_number" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">phone_<wbr/>number<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L557">global.ts:557</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L557">global.ts:557</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="phone_number_verified" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>phone_<wbr/>number_<wbr/>verified</span><a href="#phone_number_verified" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">phone_<wbr/>number_<wbr/>verified<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L558">global.ts:558</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L558">global.ts:558</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="picture" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>picture</span><a href="#picture" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">picture<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L549">global.ts:549</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L549">global.ts:549</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="preferred_username" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>preferred_<wbr/>username</span><a href="#preferred_username" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">preferred_<wbr/>username<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L547">global.ts:547</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L547">global.ts:547</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="profile" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>profile</span><a href="#profile" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">profile<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L548">global.ts:548</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L548">global.ts:548</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="sid" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>sid</span><a href="#sid" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">sid<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L576">global.ts:576</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L576">global.ts:576</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="sub_jwk" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>sub_<wbr/>jwk</span><a href="#sub_jwk" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">sub_<wbr/>jwk<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L574">global.ts:574</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L574">global.ts:574</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="updated_at" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>updated_<wbr/>at</span><a href="#updated_at" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">updated_<wbr/>at<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L560">global.ts:560</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L560">global.ts:560</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="website" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>website</span><a href="#website" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">website<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L550">global.ts:550</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L550">global.ts:550</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="zoneinfo" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>zoneinfo</span><a href="#zoneinfo" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">zoneinfo<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L555">global.ts:555</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L555">global.ts:555</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/LogoutOptions.html
+++ b/docs/interfaces/LogoutOptions.html
@@ -22,7 +22,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">LogoutOptions</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L448">global.ts:448</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L448">global.ts:448</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -39,7 +39,7 @@
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="clientId" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>client<wbr/>Id</span><a href="#clientId" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
-<div class="tsd-signature">client<wbr/>Id<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
+<div class="tsd-signature">client<wbr/>Id<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The <code>clientId</code> of your application.</p>
 <p>If this property is not set, then the <code>clientId</code> that was used during initialization of the SDK is sent to the logout endpoint.</p>
 <p>If this property is set to <code>null</code>, then no client ID value is sent to the logout endpoint.</p>
@@ -47,7 +47,7 @@
 </div><aside class="tsd-sources">
 <p>Inherited from <a href="LogoutUrlOptions.html">LogoutUrlOptions</a>.<a href="LogoutUrlOptions.html#clientId">clientId</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L413">global.ts:413</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L413">global.ts:413</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="logoutParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>logout<wbr/>Params</span><a href="#logoutParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">logout<wbr/>Params<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span>federated<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>returnTo<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>[key: <span class="tsd-signature-type">string</span>]<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -79,7 +79,7 @@ the account level in the Auth0 dashboard.</p>
 </div></li></ul></div><aside class="tsd-sources">
 <p>Inherited from <a href="LogoutUrlOptions.html">LogoutUrlOptions</a>.<a href="LogoutUrlOptions.html#logoutParams">logoutParams</a></p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L419">global.ts:419</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L419">global.ts:419</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="onRedirect" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on<wbr/>Redirect</span><a href="#onRedirect" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on<wbr/>Redirect<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -104,7 +104,7 @@ the account level in the Auth0 dashboard.</p>
 <h5>url: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L460">global.ts:460</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L460">global.ts:460</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="openUrl" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>open<wbr/>Url</span><a href="#openUrl" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">open<wbr/>Url<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -115,7 +115,7 @@ the account level in the Auth0 dashboard.</p>
 </code></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L474">global.ts:474</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L474">global.ts:474</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/LogoutUrlOptions.html
+++ b/docs/interfaces/LogoutUrlOptions.html
@@ -22,7 +22,7 @@
 <ul class="tsd-hierarchy">
 <li><a href="LogoutOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LogoutOptions</a></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L403">global.ts:403</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L403">global.ts:403</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -37,14 +37,14 @@
 <h2>Properties</h2>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientId" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>client<wbr/>Id</span><a href="#clientId" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
-<div class="tsd-signature">client<wbr/>Id<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
+<div class="tsd-signature">client<wbr/>Id<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The <code>clientId</code> of your application.</p>
 <p>If this property is not set, then the <code>clientId</code> that was used during initialization of the SDK is sent to the logout endpoint.</p>
 <p>If this property is set to <code>null</code>, then no client ID value is sent to the logout endpoint.</p>
 <p><a href="https://auth0.com/docs/logout/guides/redirect-users-after-logout">Read more about how redirecting after logout works</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L413">global.ts:413</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L413">global.ts:413</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="logoutParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>logout<wbr/>Params</span><a href="#logoutParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">logout<wbr/>Params<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span>federated<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>returnTo<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>[key: <span class="tsd-signature-type">string</span>]<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -75,7 +75,7 @@ the account level in the Auth0 dashboard.</p>
 <p><a href="https://auth0.com/docs/logout/guides/redirect-users-after-logout">Read more about how redirecting after logout works</a></p>
 </div></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L419">global.ts:419</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L419">global.ts:419</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/PopupConfigOptions.html
+++ b/docs/interfaces/PopupConfigOptions.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">PopupConfigOptions</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L325">global.ts:325</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L325">global.ts:325</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -41,7 +41,7 @@ will create its own. This may be useful for platforms like iOS that have
 security restrictions around when popups can be invoked (e.g. from a user click event)</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L337">global.ts:337</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L337">global.ts:337</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="timeoutInSeconds" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>timeout<wbr/>In<wbr/>Seconds</span><a href="#timeoutInSeconds" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">timeout<wbr/>In<wbr/>Seconds<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -49,7 +49,7 @@ security restrictions around when popups can be invoked (e.g. from a user click 
 throwing a timeout error. Defaults to 60s</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L330">global.ts:330</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L330">global.ts:330</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/PopupLoginOptions.html
+++ b/docs/interfaces/PopupLoginOptions.html
@@ -24,7 +24,7 @@
 <ul class="tsd-hierarchy">
 <li><a href="GetTokenWithPopupOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">GetTokenWithPopupOptions</a></li></ul></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L323">global.ts:323</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L323">global.ts:323</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -44,7 +44,7 @@ defined by Auth0 or custom parameters that you define.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from BaseLoginOptions.authorizationParams</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L114">global.ts:114</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L114">global.ts:114</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/RedirectLoginOptions.html
+++ b/docs/interfaces/RedirectLoginOptions.html
@@ -27,7 +27,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">RedirectLoginOptions</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L280">global.ts:280</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L280">global.ts:280</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -49,7 +49,7 @@
 <div class="tsd-comment tsd-typography"><p>Used to store state before doing the redirect</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L285">global.ts:285</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L285">global.ts:285</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited"><a id="authorizationParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>authorization<wbr/>Params</span><a href="#authorizationParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">authorization<wbr/>Params<span class="tsd-signature-symbol">?:</span> <a href="AuthorizationParams.html" class="tsd-signature-type" data-tsd-kind="Interface">AuthorizationParams</a></div>
@@ -58,14 +58,14 @@ defined by Auth0 or custom parameters that you define.</p>
 </div><aside class="tsd-sources">
 <p>Inherited from BaseLoginOptions.authorizationParams</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L114">global.ts:114</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L114">global.ts:114</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="fragment" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>fragment</span><a href="#fragment" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">fragment<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>Used to add to the URL fragment before redirecting</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L289">global.ts:289</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L289">global.ts:289</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="onRedirect" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>on<wbr/>Redirect</span><a href="#onRedirect" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">on<wbr/>Redirect<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -90,7 +90,7 @@ defined by Auth0 or custom parameters that you define.</p>
 <h5>url: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L301">global.ts:301</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L301">global.ts:301</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="openUrl" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>open<wbr/>Url</span><a href="#openUrl" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">open<wbr/>Url<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -113,7 +113,7 @@ defined by Auth0 or custom parameters that you define.</p>
 <h5>url: <span class="tsd-signature-type">string</span></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L313">global.ts:313</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L313">global.ts:313</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/RedirectLoginResult.html
+++ b/docs/interfaces/RedirectLoginResult.html
@@ -25,7 +25,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">RedirectLoginResult</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L316">global.ts:316</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L316">global.ts:316</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -43,7 +43,7 @@
 <div class="tsd-comment tsd-typography"><p>State stored when the redirect request was made</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L320">global.ts:320</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L320">global.ts:320</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/CacheEntry.html
+++ b/docs/types/CacheEntry.html
@@ -38,7 +38,7 @@
 <li class="tsd-parameter">
 <h5>scope<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L74">cache/shared.ts:74</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L74">cache/shared.ts:74</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/CacheKeyData.html
+++ b/docs/types/CacheKeyData.html
@@ -26,7 +26,7 @@
 <li class="tsd-parameter">
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L6">cache/shared.ts:6</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L6">cache/shared.ts:6</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/CacheLocation.html
+++ b/docs/types/CacheLocation.html
@@ -19,7 +19,7 @@
 <div class="tsd-comment tsd-typography"><p>The possible locations where tokens can be stored</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L264">global.ts:264</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L264">global.ts:264</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/Cacheable.html
+++ b/docs/types/Cacheable.html
@@ -17,7 +17,7 @@
 <h1>Type alias Cacheable</h1></div>
 <div class="tsd-signature">Cacheable<span class="tsd-signature-symbol">:</span> <a href="WrappedCacheEntry.html" class="tsd-signature-type" data-tsd-kind="Type alias">WrappedCacheEntry</a><span class="tsd-signature-symbol"> | </span><a href="KeyManifestEntry.html" class="tsd-signature-type" data-tsd-kind="Type alias">KeyManifestEntry</a></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L95">cache/shared.ts:95</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L95">cache/shared.ts:95</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/GetTokenSilentlyVerboseResponse.html
+++ b/docs/types/GetTokenSilentlyVerboseResponse.html
@@ -17,7 +17,7 @@
 <h1>Type alias GetTokenSilentlyVerboseResponse</h1></div>
 <div class="tsd-signature">Get<wbr/>Token<wbr/>Silently<wbr/>Verbose<wbr/>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Omit</span><span class="tsd-signature-symbol">&lt;</span><a href="TokenEndpointResponse.html" class="tsd-signature-type" data-tsd-kind="Type alias">TokenEndpointResponse</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;refresh_token&quot;</span><span class="tsd-signature-symbol">&gt;</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L616">global.ts:616</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L616">global.ts:616</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/KeyManifestEntry.html
+++ b/docs/types/KeyManifestEntry.html
@@ -22,7 +22,7 @@
 <li class="tsd-parameter">
 <h5>keys<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L91">cache/shared.ts:91</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L91">cache/shared.ts:91</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/MaybePromise.html
+++ b/docs/types/MaybePromise.html
@@ -22,7 +22,7 @@
 <li>
 <h4>T</h4></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L97">cache/shared.ts:97</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L97">cache/shared.ts:97</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/TokenEndpointResponse.html
+++ b/docs/types/TokenEndpointResponse.html
@@ -30,7 +30,7 @@
 <li class="tsd-parameter">
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> scope<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/global.ts#L500">global.ts:500</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/global.ts#L500">global.ts:500</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/types/WrappedCacheEntry.html
+++ b/docs/types/WrappedCacheEntry.html
@@ -24,7 +24,7 @@
 <li class="tsd-parameter">
 <h5>expires<wbr/>At<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/275d845/src/cache/shared.ts#L86">cache/shared.ts:86</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/auth0-spa-js/blob/cf01c72/src/cache/shared.ts#L86">cache/shared.ts:86</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-spa-js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-spa-js",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@auth0/component-cdn-uploader": "github:auth0/component-cdn-uploader#v2.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "@auth0/auth0-spa-js",
   "description": "Auth0 SDK for Single Page Applications using Authorization Code Grant Flow with PKCE",
   "license": "MIT",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "dist/lib/auth0-spa-js.cjs.js",
   "types": "dist/typings/index.d.ts",
   "module": "dist/auth0-spa-js.production.esm.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '2.0.2';
+export default '2.0.3';


### PR DESCRIPTION

**Fixed**
- Ensure cookieDomain is used when using legacy Cookiestorage [\#1071](https://github.com/auth0/auth0-spa-js/pull/1071) ([frederikprijck](https://github.com/frederikprijck))
- Ensure to only clear current client cache when logging out [\#1068](https://github.com/auth0/auth0-spa-js/pull/1068) ([frederikprijck](https://github.com/frederikprijck))
