### PR TITLE
Correctly expose missing_refresh_token error from worker

### DIFF
--- a/__tests__/http.test.ts
+++ b/__tests__/http.test.ts
@@ -1,4 +1,4 @@
-import { MfaRequiredError } from '../src/errors';
+import { MfaRequiredError, MissingRefreshTokenError } from '../src/errors';
 import { switchFetch, getJSON } from '../src/http';
 import { expect } from '@jest/globals';
 
@@ -46,5 +46,18 @@ describe('getJson', () => {
     await expect(
       getJSON('https://test.com/', null, null, null, {}, undefined)
     ).rejects.toHaveProperty('mfa_token', '1234');
+  });
+
+  it('throws MissingRefreshTokenError when missing_refresh_token is returned', async () => {
+    mockUnfetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve({ error: 'missing_refresh_token' })
+      })
+    );
+
+    await expect(
+      getJSON('https://test.com/', null, null, null, {}, undefined)
+    ).rejects.toBeInstanceOf(MissingRefreshTokenError);
   });
 });

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -165,6 +165,7 @@ describe('token worker', () => {
       }
     });
 
+    expect(response.json.error).toBe('missing_refresh_token');
     expect(response.json.error_description).toContain(
       MISSING_REFRESH_TOKEN_ERROR_MESSAGE
     );

--- a/src/http.ts
+++ b/src/http.ts
@@ -5,7 +5,11 @@ import {
 
 import { sendMessage } from './worker/worker.utils';
 import { FetchOptions } from './global';
-import { GenericError, MfaRequiredError } from './errors';
+import {
+  GenericError,
+  MfaRequiredError,
+  MissingRefreshTokenError
+} from './errors';
 
 export const createAbortController = () => new AbortController();
 
@@ -140,6 +144,10 @@ export async function getJSON<T>(
 
     if (error === 'mfa_required') {
       throw new MfaRequiredError(error, errorMessage, data.mfa_token);
+    }
+
+    if (error === 'missing_refresh_token') {
+      throw new MissingRefreshTokenError(audience, scope);
     }
 
     throw new GenericError(error || 'request_error', errorMessage);

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -116,6 +116,7 @@ const messageHandler = async ({
     port.postMessage({
       ok: false,
       json: {
+        error: error.error,
         error_description: error.message
       }
     });


### PR DESCRIPTION
### Changes

When the worker is used, and a missing_refresh_token is thrown, the error code and error type was lost during serialization.

This PR ensures it doesnt get lost and people can correctly handle these errors.

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
