### PR TITLE
fix typo: "thw" -> "the"

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -31,7 +31,7 @@ auth0.logout({
 
 ## Calling an API
 
-Retrieve an access token to pass along in the `Authorization` header using thw `getTokenSilently` API.
+Retrieve an access token to pass along in the `Authorization` header using the `getTokenSilently` API.
 
 ```html
 <button id="call-api">Call an API</button>


### PR DESCRIPTION
### Changes

Fix typo in docs ("thw" -> "the")

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines have been run/followed
