### PR TITLE
Fix organization param usage in example docs

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -163,9 +163,9 @@ Log in to an organization by specifying the `organization` parameter when settin
 await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
-  organization: '<MY_ORG_ID>',
   authorizationParams: {
-    redirect_uri: '<MY_CALLBACK_URL>'
+    redirect_uri: '<MY_CALLBACK_URL>',
+    organization: '<MY_ORG_ID>'
   }
 });
 ```


### PR DESCRIPTION
### Changes

Correct Organizations example in `examples.md` to move `organization` param into `authorizationParams` ([per type definitions for the param](https://github.com/auth0/auth0-spa-js/blob/79720c5fe345f194151259a8b05cfe452734c6b5/src/global.ts#L86))

### References

N/A

### Testing

N/A - documentation only change

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines have been run/followed
