### PR TITLE
feat: distinguish between missing and invalid state

### DIFF
--- a/__tests__/Auth0Client/handleRedirectCallback.test.ts
+++ b/__tests__/Auth0Client/handleRedirectCallback.test.ts
@@ -30,6 +30,7 @@ import {
 } from '../constants';
 
 import { DEFAULT_AUTH0_CLIENT } from '../../src/constants';
+import { GenericError } from '../../src';
 
 jest.mock('es-cookie');
 jest.mock('../../src/jwt');
@@ -204,6 +205,9 @@ describe('Auth0Client', () => {
 
       expect(error).toBeDefined();
       expect(error.message).toBe('Invalid state');
+      expect(error.error).toBe('missing_transaction');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(GenericError);
     });
 
     it('returns the transactions appState', async () => {
@@ -269,8 +273,9 @@ describe('Auth0Client', () => {
 
     it('should fail with an error if the state in the transaction does not match the request', async () => {
       const auth0 = setup();
+      let error;
 
-      await expect(async () => {
+      try {
         await loginWithRedirect(
           auth0,
           {},
@@ -281,7 +286,15 @@ describe('Auth0Client', () => {
             }
           }
         );
-      }).rejects.toEqual(new Error('Invalid state'));
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeDefined();
+      expect(error.message).toBe('Invalid state');
+      expect(error.error).toBe('state_mismatch');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(GenericError);
     });
 
     it('should not validate the state if there is no state in the transaction', async () => {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -493,7 +493,7 @@ export class Auth0Client {
     const transaction = this.transactionManager.get();
 
     if (!transaction) {
-      throw new Error('Invalid state');
+      throw new GenericError('missing_transaction', 'Invalid state');
     }
 
     this.transactionManager.remove();
@@ -512,7 +512,7 @@ export class Auth0Client {
       !transaction.code_verifier ||
       (transaction.state && transaction.state !== state)
     ) {
-      throw new Error('Invalid state');
+      throw new GenericError('state_mismatch', 'Invalid state');
     }
 
     const organizationId = transaction.organizationId;


### PR DESCRIPTION
### Changes

Our SDK does not allow to distinguish between missing transaction, or invalid state.
This PR allows to differentiate between those two situations in a non breaking way.

### References

#1097 

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
