### PR TITLE
Make TransactionManager use CookieDomain

### DIFF
--- a/__tests__/transaction-manager.test.ts
+++ b/__tests__/transaction-manager.test.ts
@@ -1,5 +1,5 @@
 import { TransactionManager } from '../src/transaction-manager';
-import { SessionStorage } from '../src/storage';
+import { CookieStorage, SessionStorage } from '../src/storage';
 import { TEST_CLIENT_ID, TEST_STATE } from './constants';
 import { expect } from '@jest/globals';
 
@@ -81,4 +81,36 @@ describe('transaction manager', () => {
       expect(sessionStorage.removeItem).toHaveBeenCalledWith(transactionKey());
     });
   });
+  
+ describe('CookieStorage usage', () => {
+    it("`create` saves the transaction in the storage with the provided domain", () => {
+      CookieStorage.save = jest.fn();
+      const cookieDomain = "vanity.auth.com";
+      tm = new TransactionManager(CookieStorage, TEST_CLIENT_ID, cookieDomain);
+      tm.create(transaction);
+
+      expect(CookieStorage.save).toHaveBeenCalledWith(
+        transactionKey(),
+        expect.anything(),
+        {
+          daysUntilExpire: 1,
+          cookieDomain: cookieDomain
+        }
+      );
+    });
+
+    it("`remove` deletes the transaction in the storage with the provided domain", () => {
+      CookieStorage.remove = jest.fn();
+      const cookieDomain = "vanity.auth.com";
+      tm = new TransactionManager(CookieStorage, TEST_CLIENT_ID, cookieDomain);
+      tm.remove();
+
+      expect(CookieStorage.remove).toHaveBeenCalledWith(
+        transactionKey(),
+        {
+          cookieDomain: cookieDomain
+        }
+      );
+    });    
+  });  
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -207,7 +207,8 @@ export class Auth0Client {
 
     this.transactionManager = new TransactionManager(
       transactionStorage,
-      this.options.clientId
+      this.options.clientId,
+      this.options.cookieDomain,
     );
 
     this.nowProvider = this.options.nowProvider || DEFAULT_NOW_PROVIDER;

--- a/src/transaction-manager.ts
+++ b/src/transaction-manager.ts
@@ -17,7 +17,7 @@ export class TransactionManager {
   private transaction: Transaction | undefined;
   private storageKey: string;
 
-  constructor(private storage: ClientStorage, private clientId: string) {
+  constructor(private storage: ClientStorage, private clientId: string, private cookieDomain?: string) {
     this.storageKey = `${TRANSACTION_STORAGE_KEY_PREFIX}.${this.clientId}`;
     this.transaction = this.storage.get(this.storageKey);
   }
@@ -26,7 +26,8 @@ export class TransactionManager {
     this.transaction = transaction;
 
     this.storage.save(this.storageKey, transaction, {
-      daysUntilExpire: 1
+      daysUntilExpire: 1,
+      cookieDomain: this.cookieDomain,
     });
   }
 
@@ -36,6 +37,8 @@ export class TransactionManager {
 
   public remove() {
     delete this.transaction;
-    this.storage.remove(this.storageKey);
+    this.storage.remove(this.storageKey, {
+      cookieDomain: this.cookieDomain
+    });
   }
 }


### PR DESCRIPTION
…orage

<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

Modified the TransactionManager class to receive an optional `cookieDomain?: string` parameter.
When the Auth0 application is created, in the Auth0ClientOptions the user can pass `cookieDomain`. The changes reflect the fact the currently the TransactionManager ignores that option. With this change the TransactionManager, when instantiated with CookieStorage, will use the cookieDomain parameter.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread
- Issue - https://github.com/auth0/auth0-spa-js/issues/1104

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [X] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [X] This change has been tested on the latest version of the platform/language

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All code quality tools/guidelines have been run/followed
