### PR TITLE
Ensure AMR claim is set to an array of strings

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -588,7 +588,7 @@ export interface IdToken {
   at_hash?: string;
   c_hash?: string;
   acr?: string;
-  amr?: string;
+  amr?: string[];
   sub_jwk?: string;
   cnf?: string;
   sid?: string;


### PR DESCRIPTION
### Changes

The AMR claims should be an array of strings and not a string, see: https://www.rfc-editor.org/rfc/rfc8176.html#section-1

### References

Closes #1110 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
