### PR TITLE
Support Organization Name

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -165,7 +165,7 @@ await createAuth0Client({
   clientId: '<AUTH0_CLIENT_ID>',
   authorizationParams: {
     redirect_uri: '<MY_CALLBACK_URL>',
-    organization: '<MY_ORG_ID>'
+    organization: '<MY_ORG_ID_OR_NAME>'
   }
 });
 ```
@@ -176,14 +176,14 @@ You can also specify the organization when logging in:
 // Using a redirect
 await client.loginWithRedirect({
   authorizationParams: {
-    organization: '<MY_ORG_ID>'
+    organization: '<MY_ORG_ID_OR_NAME>'
   }
 });
 
 // Using a popup window
 await client.loginWithPopup({
   authorizationParams: {
-    organization: '<MY_ORG_ID>'
+    organization: '<MY_ORG_ID_OR_NAME>'
   }
 });
 ```

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1954,7 +1954,10 @@ describe('Auth0Client', () => {
     });
 
     it('stores the org_id in a hint cookie if returned in the ID token claims', async () => {
-      const auth0 = setup({}, { org_id: TEST_ORG_ID });
+      const auth0 = setup(
+        { authorizationParams: { organization: TEST_ORG_ID } },
+        { org_id: TEST_ORG_ID }
+      );
 
       jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
         access_token: TEST_ACCESS_TOKEN,

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1983,7 +1983,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('removes organization hint cookie if no org claim was returned in the ID token', async () => {
+    it('removes organization hint cookie if no organization was specified', async () => {
       const auth0 = setup({});
 
       jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -559,7 +559,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls `tokenVerifier.verify` with the organization id', async () => {
+    it('calls `tokenVerifier.verify` with the organization', async () => {
       const auth0 = setup({
         authorizationParams: { organization: 'org_123' }
       });
@@ -573,7 +573,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls `tokenVerifier.verify` with the organization id given in the login method', async () => {
+    it('calls `tokenVerifier.verify` with the organization given in the login method', async () => {
       const auth0 = setup();
       await loginWithPopup(auth0, {
         authorizationParams: { organization: 'org_123' }

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -561,14 +561,14 @@ describe('Auth0Client', () => {
 
     it('calls `tokenVerifier.verify` with the organization id', async () => {
       const auth0 = setup({
-        authorizationParams: { organization: 'test_org_123' }
+        authorizationParams: { organization: 'org_123' }
       });
 
       await loginWithPopup(auth0);
 
       expect(tokenVerifier).toHaveBeenCalledWith(
         expect.objectContaining({
-          organizationId: 'test_org_123'
+          organization: 'org_123'
         })
       );
     });
@@ -576,12 +576,12 @@ describe('Auth0Client', () => {
     it('calls `tokenVerifier.verify` with the organization id given in the login method', async () => {
       const auth0 = setup();
       await loginWithPopup(auth0, {
-        authorizationParams: { organization: 'test_org_123' }
+        authorizationParams: { organization: 'org_123' }
       });
 
       expect(tokenVerifier).toHaveBeenCalledWith(
         expect.objectContaining({
-          organizationId: 'test_org_123'
+          organization: 'org_123'
         })
       );
     });
@@ -682,7 +682,10 @@ describe('Auth0Client', () => {
 
     it('saves organization hint cookie in storage', async () => {
       const auth0 = setup(
-        { cookieDomain: TEST_DOMAIN },
+        {
+          cookieDomain: TEST_DOMAIN,
+          authorizationParams: { organization: TEST_ORG_ID }
+        },
         { org_id: TEST_ORG_ID }
       );
 

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -454,20 +454,23 @@ describe('Auth0Client', () => {
 
     it('calls `tokenVerifier.verify` with the global organization id', async () => {
       const auth0 = setup({
-        authorizationParams: { organization: 'test_org_123' }
+        authorizationParams: { organization: 'org_123' }
       });
 
       await loginWithRedirect(auth0);
 
       expect(tokenVerifier).toHaveBeenCalledWith(
         expect.objectContaining({
-          organizationId: 'test_org_123'
+          organization: 'org_123'
         })
       );
     });
 
     it('stores the organization ID in a hint cookie', async () => {
-      const auth0 = setup({}, { org_id: TEST_ORG_ID });
+      const auth0 = setup(
+        { authorizationParams: { organization: TEST_ORG_ID } },
+        { org_id: TEST_ORG_ID }
+      );
 
       await loginWithRedirect(auth0);
 
@@ -506,7 +509,7 @@ describe('Auth0Client', () => {
 
     it('calls `tokenVerifier.verify` with the specific organization id', async () => {
       const auth0 = setup({
-        authorizationParams: { organization: 'test_org_123' }
+        authorizationParams: { organization: 'org_123' }
       });
 
       await loginWithRedirect(auth0, {
@@ -514,7 +517,7 @@ describe('Auth0Client', () => {
       });
       expect(tokenVerifier).toHaveBeenCalledWith(
         expect.objectContaining({
-          organizationId: 'test_org_456'
+          organization: 'test_org_456'
         })
       );
     });

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -452,7 +452,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls `tokenVerifier.verify` with the global organization id', async () => {
+    it('calls `tokenVerifier.verify` with the global organization', async () => {
       const auth0 = setup({
         authorizationParams: { organization: 'org_123' }
       });
@@ -466,7 +466,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('stores the organization ID in a hint cookie', async () => {
+    it('stores the organization in a hint cookie', async () => {
       const auth0 = setup(
         { authorizationParams: { organization: TEST_ORG_ID } },
         { org_id: TEST_ORG_ID }
@@ -491,7 +491,8 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('removes the org hint cookie if no org_id claim in the ID token', async () => {
+    it('removes the organization hint cookie if no organization specified', async () => {
+      // TODO: WHAT IS ORG_NAME ?
       const auth0 = setup({});
 
       await loginWithRedirect(auth0);
@@ -507,7 +508,7 @@ describe('Auth0Client', () => {
       );
     });
 
-    it('calls `tokenVerifier.verify` with the specific organization id', async () => {
+    it('calls `tokenVerifier.verify` with the specific organization', async () => {
       const auth0 = setup({
         authorizationParams: { organization: 'org_123' }
       });

--- a/__tests__/jwt.test.ts
+++ b/__tests__/jwt.test.ts
@@ -153,14 +153,62 @@ describe('jwt', () => {
   });
 
   it('verifies correctly with an organization ID', async () => {
-    const org_id = 'test_org_123';
+    const org_id = 'org_123';
 
     const id_token = await createJWT({ ...DEFAULT_PAYLOAD, org_id });
 
     const { encoded, header, claims } = verify({
       ...verifyOptions,
       id_token,
-      organizationId: org_id
+      organization: org_id
+    });
+
+    expect({ encoded, header, payload: claims }).toMatchObject(
+      verifier.decode(id_token)
+    );
+  });
+
+  it('verifies correctly with an organization Name', async () => {
+    const org_name = 'my-org';
+
+    const id_token = await createJWT({ ...DEFAULT_PAYLOAD, org_name });
+
+    const { encoded, header, claims } = verify({
+      ...verifyOptions,
+      id_token,
+      organization: org_name
+    });
+
+    expect({ encoded, header, payload: claims }).toMatchObject(
+      verifier.decode(id_token)
+    );
+  });
+
+  it('verifies correctly with an organization Name in wrong case', async () => {
+    const org_name = 'my-org';
+
+    const id_token = await createJWT({ ...DEFAULT_PAYLOAD, org_name });
+
+    const { encoded, header, claims } = verify({
+      ...verifyOptions,
+      id_token,
+      organization: 'My-org'
+    });
+
+    expect({ encoded, header, payload: claims }).toMatchObject(
+      verifier.decode(id_token)
+    );
+  });
+
+  it('verifies correctly with an organization Name surrounded by whitespace', async () => {
+    const org_name = 'my-org';
+
+    const id_token = await createJWT({ ...DEFAULT_PAYLOAD, org_name });
+
+    const { encoded, header, claims } = verify({
+      ...verifyOptions,
+      id_token,
+      organization: '  my-org  '
     });
 
     expect({ encoded, header, payload: claims }).toMatchObject(
@@ -369,26 +417,49 @@ describe('jwt', () => {
     ).not.toThrow();
   });
 
-  it('validate org_id is present when organizationId is provided', async () => {
+  it('validate org_id is present when organization id is provided', async () => {
     const id_token = await createJWT({ ...DEFAULT_PAYLOAD });
 
     expect(() =>
-      verify({ ...verifyOptions, id_token, organizationId: 'test_org_123' })
+      verify({ ...verifyOptions, id_token, organization: 'org_123' })
     ).toThrow(
       'Organization ID (org_id) claim must be a string present in the ID token'
     );
   });
 
-  it('validate org_id matches the claim when organizationId is provided', async () => {
+  it('validate org_id matches the claim when organization id is provided', async () => {
     const id_token = await createJWT({
       ...DEFAULT_PAYLOAD,
       org_id: 'test_org_456'
     });
 
     expect(() =>
-      verify({ ...verifyOptions, id_token, organizationId: 'test_org_123' })
+      verify({ ...verifyOptions, id_token, organization: 'org_123' })
     ).toThrow(
-      'Organization ID (org_id) claim mismatch in the ID token; expected "test_org_123", found "test_org_456"'
+      'Organization ID (org_id) claim mismatch in the ID token; expected "org_123", found "test_org_456"'
+    );
+  });
+
+  it('validate org_name is present when organization name is provided', async () => {
+    const id_token = await createJWT({ ...DEFAULT_PAYLOAD });
+
+    expect(() =>
+      verify({ ...verifyOptions, id_token, organization: 'my-org' })
+    ).toThrow(
+      'Organization Name (org_name) claim must be a string present in the ID token'
+    );
+  });
+
+  it('validate org_id matches the claim when organization id is provided', async () => {
+    const id_token = await createJWT({
+      ...DEFAULT_PAYLOAD,
+      org_name: 'my-other-org'
+    });
+
+    expect(() =>
+      verify({ ...verifyOptions, id_token, organization: 'my-org' })
+    ).toThrow(
+      'Organization Name (org_name) claim mismatch in the ID token; expected "my-org", found "my-other-org"'
     );
   });
 });

--- a/src/global.ts
+++ b/src/global.ts
@@ -82,10 +82,9 @@ export interface AuthorizationParams {
    *
    * This will specify an `organization` parameter in your user's login request.
    *
-   * - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token
-   * - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.
+   * - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+   * - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token. The validation is case-insensitive.
    *
-   * The validation is case-insensitive.
    */
   organization?: string;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -78,10 +78,14 @@ export interface AuthorizationParams {
   connection?: string;
 
   /**
-   * The Id of an organization to log in to.
+   * The organization to log in to.
    *
-   * This will specify an `organization` parameter in your user's login request and will add a step to validate
-   * the `org_id` claim in your user's ID Token.
+   * This will specify an `organization` parameter in your user's login request.
+   *
+   * - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token
+   * - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.
+   *
+   * The validation is case-insensitive.
    */
   organization?: string;
 
@@ -551,7 +555,7 @@ export interface JWTVerifyOptions {
   nonce?: string;
   leeway?: number;
   max_age?: number;
-  organizationId?: string;
+  organization?: string;
   now?: number;
 }
 
@@ -593,6 +597,7 @@ export interface IdToken {
   cnf?: string;
   sid?: string;
   org_id?: string;
+  org_name?: string;
   [key: string]: any;
 }
 

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -194,7 +194,7 @@ export const verify = (options: JWTVerifyOptions) => {
   }
 
   if (options.organization) {
-    const org = options.organization.trim().toLowerCase();
+    const org = options.organization.trim();
     if (org.startsWith('org_')) {
       const orgId = org;
       if (!decoded.claims.org_id) {
@@ -207,7 +207,7 @@ export const verify = (options: JWTVerifyOptions) => {
         );
       }
     } else {
-      const orgName = org;
+      const orgName = org.toLowerCase();
       // TODO should we verify if there is an `org_id` claim?
       if (!decoded.claims.org_name) {
         throw new Error(

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -193,15 +193,31 @@ export const verify = (options: JWTVerifyOptions) => {
     }
   }
 
-  if (options.organizationId) {
-    if (!decoded.claims.org_id) {
-      throw new Error(
-        'Organization ID (org_id) claim must be a string present in the ID token'
-      );
-    } else if (options.organizationId !== decoded.claims.org_id) {
-      throw new Error(
-        `Organization ID (org_id) claim mismatch in the ID token; expected "${options.organizationId}", found "${decoded.claims.org_id}"`
-      );
+  if (options.organization) {
+    const org = options.organization.trim().toLowerCase();
+    if (org.startsWith('org_')) {
+      const orgId = org;
+      if (!decoded.claims.org_id) {
+        throw new Error(
+          'Organization ID (org_id) claim must be a string present in the ID token'
+        );
+      } else if (orgId !== decoded.claims.org_id) {
+        throw new Error(
+          `Organization ID (org_id) claim mismatch in the ID token; expected "${orgId}", found "${decoded.claims.org_id}"`
+        );
+      }
+    } else {
+      const orgName = org;
+      // TODO should we verify if there is an `org_id` claim?
+      if (!decoded.claims.org_name) {
+        throw new Error(
+          'Organization Name (org_name) claim must be a string present in the ID token'
+        );
+      } else if (orgName !== decoded.claims.org_name) {
+        throw new Error(
+          `Organization Name (org_name) claim mismatch in the ID token; expected "${orgName}", found "${decoded.claims.org_name}"`
+        );
+      }
     }
   }
 

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -213,9 +213,9 @@ export const verify = (options: JWTVerifyOptions) => {
         throw new Error(
           'Organization Name (org_name) claim must be a string present in the ID token'
         );
-      } else if (orgName !== decoded.claims.org_name) {
+      } else if (orgName !== decoded.claims.org_name.toLowerCase()) {
         throw new Error(
-          `Organization Name (org_name) claim mismatch in the ID token; expected "${orgName}", found "${decoded.claims.org_name}"`
+          `Organization Name (org_name) claim mismatch in the ID token; expected "${orgName}", found "${decoded.claims.org_name.toLowerCase()}"`
         );
       }
     }

--- a/src/transaction-manager.ts
+++ b/src/transaction-manager.ts
@@ -9,7 +9,7 @@ interface Transaction {
   appState?: any;
   code_verifier: string;
   redirect_uri?: string;
-  organizationId?: string;
+  organization?: string;
   state?: string;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -224,7 +224,7 @@
             v-model="organization"
             class="form-control"
             id="organization"
-            data-cy="organizationId"
+            data-cy="organization"
           />
           <div class="form-check mt-3">
             <input


### PR DESCRIPTION
### Changes

Adds support for the organization name by extending the ID Token validation as follows:

If organization is set and has the org_ prefix, we expect an org_id claim
If organization is set and does not have the org_ prefix, we expect an org_name claim

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
