### PR TITLE
chore: Update `.semgrepignore` exclusion manifest

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -3,7 +3,5 @@ __tests__/
 cypress/
 docs/
 static/
-CHANGELOG.md
-DEVELOPMENT.md
-FAQ.md
-README.md
+scripts/prepack.js
+*.md


### PR DESCRIPTION
This PR updates the `.semgrepignore` manifest file to exclude the `scripts/prepack.js` file, which is raising false positives with Semgrep rules.