### PR TITLE
Ensure organization cookie is set when no organization was set

### DIFF
--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -491,6 +491,28 @@ describe('Auth0Client', () => {
       );
     });
 
+    it('stores the organization in a hint cookie when no organization was set but a claim was found', async () => {
+      const auth0 = setup({}, { org_id: TEST_ORG_ID });
+
+      await loginWithRedirect(auth0);
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        `auth0.${TEST_CLIENT_ID}.organization_hint`,
+        JSON.stringify(TEST_ORG_ID),
+        {
+          expires: 1
+        }
+      );
+
+      expect(<jest.Mock>esCookie.set).toHaveBeenCalledWith(
+        `_legacy_auth0.${TEST_CLIENT_ID}.organization_hint`,
+        JSON.stringify(TEST_ORG_ID),
+        {
+          expires: 1
+        }
+      );
+    });
+
     it('removes the organization hint cookie if no organization specified', async () => {
       // TODO: WHAT IS ORG_NAME ?
       const auth0 = setup({});

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1129,7 +1129,7 @@ export class Auth0Client {
       cookieDomain: this.options.cookieDomain
     });
 
-    this._processOrgHint(organization);
+    this._processOrgHint(organization || decodedToken.claims.org_id);
 
     return { ...authResult, decodedToken };
   }


### PR DESCRIPTION
### Changes

Code was incorrectly changed in https://github.com/auth0/auth0-spa-js/pull/1113 that resulted in the cookie for organization to no longer be set when:

- No organization was set in the SDK
- But the user did log in to an Organization in Auth0.

This PR ensures we fallback to the claim when no organization was specified.

### References

https://github.com/auth0/auth0-angular/issues/465

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
