### PR TITLE
[DO NOT MERGE] Testing GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   CACHE_KEY: '${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}'
   IMPORT_STATEMENT: |
     import './auth0';


### PR DESCRIPTION
Test PR to update node to 20. 

However, because of `pull_request_target`, the GitHub Actions are executed against Node 18, and will only execute against node 20 after merging this PR. This means we wont catch any things that break in this PR, but only on master.

This would be resolved with #1126.