### PR TITLE
Add meaning of isAuthenticated to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -102,9 +102,9 @@ new Auth0Client({
 ## Why is isAuthenticated returning true when there are no tokens available to call an API?
 As long as the SDK has an id token, you are considered authenticated, because it knows who you are. It might be that there isn't a valid access token and you are unable to call an API, the SDK still knows who you are because of the id token.
 
-Authentication is about who u are (id token), not what you can do (access token). The latter is authorization, which is also why you pass the access token to the API in the Authorization header.
+Authentication is about who you are (id token), not what you can do (access token). The latter is authorization, which is also why you pass the access token to the API in the Authorization header.
 
-So even when the refresh token fails, or `getTokenSilently` returning nothing, that doesn't impact the existence of the id token, and as a consequence of that, the authentication state. So it's expected for isAuthenticated to stay true in that case.
+So even when the refresh token fails, or `getTokenSilently` returns nothing, that doesn't impact the existence of the id token, and as a consequence of that, the authentication state. So it's expected for isAuthenticated to stay true in that case.
 
 On top of that, the SDK can have multiple access tokens and multiple refresh tokens (e.g. when using multiple audience and scope combinations to call multiple API's), but only one id token.
 If there are multiple access and refresh tokens, and one of the refresh tokens fails, it doesnt mean the other access tokens or refresh tokens are invalid and they might still be perfectly usable.

--- a/FAQ.md
+++ b/FAQ.md
@@ -100,11 +100,11 @@ new Auth0Client({
 ```
 
 ## Why is isAuthenticated returning true when there are no tokens available to call an API?
-As long as the SDK has an id token, you are considered authenticated, because it knows who you are. It might be that there isn't a valid access token and you are unable to call an API, we still know who you are because of the id token.
+As long as the SDK has an id token, you are considered authenticated, because it knows who you are. It might be that there isn't a valid access token and you are unable to call an API, the SDK still knows who you are because of the id token.
 
 Authentication is about who u are (id token), not what you can do (access token). The latter is authorization, which is also why you pass the access token to the API in the Authorization header.
 
 So even when the refresh token fails, or `getTokenSilently` returning nothing, that doesn't impact the existence of the id token, and as a consequence of that, the authentication state. So it's expected for isAuthenticated to stay true in that case.
 
 On top of that, the SDK can have multiple access tokens and multiple refresh tokens (e.g. when using multiple audience and scope combinations to call multiple API's), but only one id token.
-If we have multiple access and refresh tokens, and one of the refresh tokens fails, it doesnt mean the other access tokens or refresh tokens are invalid and they might still be perfectly usable.
+If there are multiple access and refresh tokens, and one of the refresh tokens fails, it doesnt mean the other access tokens or refresh tokens are invalid and they might still be perfectly usable.

--- a/FAQ.md
+++ b/FAQ.md
@@ -107,4 +107,4 @@ Authentication is about who you are (id token), not what you can do (access toke
 So even when the refresh token fails, or `getTokenSilently` returns nothing, that doesn't impact the existence of the id token, and as a consequence of that, the authentication state. So it's expected for isAuthenticated to stay true in that case.
 
 On top of that, the SDK can have multiple access tokens and multiple refresh tokens (e.g. when using multiple audience and scope combinations to call multiple API's), but only one id token.
-If there are multiple access and refresh tokens, and one of the refresh tokens fails, it doesnt mean the other access tokens or refresh tokens are invalid and they might still be perfectly usable.
+If there are multiple access and refresh tokens, and one of the refresh tokens fails, it doesn't mean the other access tokens or refresh tokens are invalid, they might still be perfectly usable.

--- a/FAQ.md
+++ b/FAQ.md
@@ -137,7 +137,7 @@ If you want to use a CDN bundle together with import maps, you will need to use 
 ```
 
 ## Why is isAuthenticated returning true when there are no tokens available to call an API?
-As long as the SDK has an id token, you are considered authenticated, because it knows who you are. It might be that there isn't a valid access token and you are unable to call an API, the SDK still knows who you are because of the id token.
+As long as the SDK has an id token, you are considered authenticated, because it knows who you are. It might be that there isn't a valid access token and you are unable to call an API, but the SDK still knows who you are because of the id token.
 
 Authentication is about who you are (id token), not what you can do (access token). The latter is authorization, which is also why you pass the access token to the API in the Authorization header.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -98,3 +98,13 @@ new Auth0Client({
   useCookiesForTransaction: true
 });
 ```
+
+## Why is isAuthenticated returning true when there are no tokens available to call an API?
+As long as the SDK has an id token, you are considered authenticated, because it knows who you are. It might be that there isn't a valid access token and you are unable to call an API, we still know who you are because of the id token.
+
+Authentication is about who u are (id token), not what you can do (access token). The latter is authorization, which is also why you pass the access token to the API in the Authorization header.
+
+So even when the refresh token fails, or `getTokenSilently` returning nothing, that doesn't impact the existence of the id token, and as a consequence of that, the authentication state. So it's expected for isAuthenticated to stay true in that case.
+
+On top of that, the SDK can have multiple access tokens and multiple refresh tokens (e.g. when using multiple audience and scope combinations to call multiple API's), but only one id token.
+If we have multiple access and refresh tokens, and one of the refresh tokens fails, it doesnt mean the other access tokens or refresh tokens are invalid and they might still be perfectly usable.


### PR DESCRIPTION
### Changes

With v2, the meaning of isAuthenticated has been corrected to only look at the id token.
This has been called out to be confusing, and we want to improve the experience by calling this out in our FAQ.

### References

https://github.com/auth0/auth0-react/issues/464

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
