### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   NODE_VERSION: 18
@@ -31,6 +30,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Build package
         uses: ./.github/actions/build
@@ -42,32 +42,3 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish release to CDN
-        run: ccu --trace
-
-  publish-gh:
-    needs: publish-npm # Don't publish to GitHub Packages until NPM is done
-
-    name: 'GitHub Packages'
-    runs-on: ubuntu-latest
-    environment: release
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Build package
-        uses: ./.github/actions/build
-        with:
-          node: ${{ env.NODE_VERSION }}
-
-      - name: Publish release to GitHub Packages
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

- Removed releasing to GH Packages as we haven't done that before.
- Added registry-url to setup-node as that's required in order for the `NODE_AUTH_TOKEN` to be used, see 
  - https://github.com/actions/setup-node/blob/main/src/main.ts#L59-L61
  - https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
- Added dependabot config for npm
- Remove publish to CDN as that's not possible on GitHub Actions

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
