### PR TITLE
feat(getTokenWithPopup): Improve popup open error

### DIFF
--- a/__tests__/Auth0Client/getTokenWithPopup.test.ts
+++ b/__tests__/Auth0Client/getTokenWithPopup.test.ts
@@ -8,6 +8,7 @@ import * as scope from '../../src/scope';
 import {
   assertPostFn,
   fetchResponse,
+  setupFailingPopup,
   setupFn,
   setupMessageEventLister
 } from './helpers';
@@ -24,7 +25,7 @@ import {
   TEST_STATE
 } from '../constants';
 
-import { Auth0ClientOptions } from '../../src';
+import { Auth0ClientOptions, PopupOpenError } from '../../src';
 import { DEFAULT_AUTH0_CLIENT } from '../../src/constants';
 import { expect } from '@jest/globals';
 
@@ -214,5 +215,12 @@ describe('Auth0Client', () => {
 
       expect(config.popup.location.href).toMatch(/global-audience/);
     });
+
+    it('should fail if the popup cannot be opened', async () => {
+      const auth0 = setup();
+      setupFailingPopup(mockWindow);
+
+      await expect(auth0.getTokenWithPopup()).rejects.toThrow(PopupOpenError);
+    })
   });
 });

--- a/__tests__/Auth0Client/helpers.ts
+++ b/__tests__/Auth0Client/helpers.ts
@@ -304,6 +304,12 @@ export const setupMessageEventLister = (
   });
 };
 
+export const setupFailingPopup = (
+  mockWindow: any
+) => {
+  mockWindow.open.mockReturnValue(null);
+}
+
 export const loginWithPopupFn = (mockWindow, mockFetch) => {
   return async (
     auth0,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -37,6 +37,7 @@ import {
   AuthenticationError,
   GenericError,
   MissingRefreshTokenError,
+  PopupOpenError,
   TimeoutError
 } from './errors';
 
@@ -361,9 +362,7 @@ export class Auth0Client {
       config.popup = openPopup('');
 
       if (!config.popup) {
-        throw new Error(
-          'Unable to open a popup for loginWithPopup - window.open returned `null`'
-        );
+        throw new PopupOpenError();
       }
     }
 
@@ -625,7 +624,7 @@ export class Auth0Client {
    *
    * If refresh tokens are used, the token endpoint is called directly with the
    * 'refresh_token' grant. If no refresh token is available to make this call,
-   * the SDK will only fall back to using an iframe to the '/authorize' URL if 
+   * the SDK will only fall back to using an iframe to the '/authorize' URL if
    * the `useRefreshTokensFallback` setting has been set to `true`. By default this
    * setting is `false`.
    *

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -66,6 +66,14 @@ export class PopupCancelledError extends GenericError {
   }
 }
 
+export class PopupOpenError extends GenericError {
+  constructor() {
+    super('popup_open', 'Unable to open a popup for loginWithPopup - window.open returned `null`');
+    //https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, PopupOpenError.prototype);
+  }
+}
+
 /**
  * Error thrown when the token exchange results in a `mfa_required` error
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   TimeoutError,
   PopupTimeoutError,
   PopupCancelledError,
+  PopupOpenError,
   MfaRequiredError,
   MissingRefreshTokenError
 } from './errors';


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->
This PR introduces a new error class for the `getTokenWithPopup` method: `PopupOpenError`. This error will be thrown if the method is unable to open the popup (most likely because it has been blocked by the browser).

Having a specific error class makes it much easier to catch the error and do specific error handling (such as explaining to the users how to allow popups on their browser)

This PR should be retro-compatible with all developpers running a string comparison with the error message to detect popup permission issues as it uses the same error message.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
