### PR TITLE
[MRRT] Save organization in tokenset

### DIFF
--- a/__tests__/Auth0Client/checkSession.test.ts
+++ b/__tests__/Auth0Client/checkSession.test.ts
@@ -187,7 +187,7 @@ describe('Auth0Client', () => {
         if (key === `auth0.${TEST_CLIENT_ID}.organization_hint`) {
           return JSON.stringify(TEST_ORG_ID);
         }
-        return null;
+        return undefined;
       });
 
       await checkSession(auth0);

--- a/__tests__/Auth0Client/checkSession.test.ts
+++ b/__tests__/Auth0Client/checkSession.test.ts
@@ -180,9 +180,15 @@ describe('Auth0Client', () => {
         state: TEST_STATE
       });
 
-      (<jest.Mock>esCookie.get)
-        .mockReturnValueOnce(JSON.stringify(true))
-        .mockReturnValueOnce(JSON.stringify(TEST_ORG_ID));
+      (<jest.Mock>esCookie.get).mockImplementation((key) => {
+        if (key === `auth0.${TEST_CLIENT_ID}.is.authenticated`) {
+          return true;
+        }
+        if (key === `auth0.${TEST_CLIENT_ID}.organization_hint`) {
+          return JSON.stringify(TEST_ORG_ID);
+        }
+        return null;
+      });
 
       await checkSession(auth0);
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -969,31 +969,30 @@ describe('Auth0Client', () => {
           supported: true
         }
       ].forEach(({ name, userAgent, supported }) =>
-        it(`refreshes the token ${
-          supported ? 'with' : 'without'
-        } the worker, when ${name}`, async () => {
-          const originalUserAgent = window.navigator.userAgent;
+        it(`refreshes the token ${supported ? 'with' : 'without'
+          } the worker, when ${name}`, async () => {
+            const originalUserAgent = window.navigator.userAgent;
 
-          Object.defineProperty(window.navigator, 'userAgent', {
-            value: userAgent,
-            configurable: true
-          });
+            Object.defineProperty(window.navigator, 'userAgent', {
+              value: userAgent,
+              configurable: true
+            });
 
-          const auth0 = setup({
-            useRefreshTokens: true,
-            cacheLocation: 'memory'
-          });
+            const auth0 = setup({
+              useRefreshTokens: true,
+              cacheLocation: 'memory'
+            });
 
-          if (supported) {
-            expect((<any>auth0).worker).toBeDefined();
-          } else {
-            expect((<any>auth0).worker).toBeUndefined();
-          }
+            if (supported) {
+              expect((<any>auth0).worker).toBeDefined();
+            } else {
+              expect((<any>auth0).worker).toBeUndefined();
+            }
 
-          Object.defineProperty(window.navigator, 'userAgent', {
-            value: originalUserAgent
-          });
-        })
+            Object.defineProperty(window.navigator, 'userAgent', {
+              value: originalUserAgent
+            });
+          })
       );
     });
 
@@ -2053,7 +2052,7 @@ describe('Auth0Client', () => {
         if (key === `auth0.${TEST_CLIENT_ID}.organization_hint`) {
           return JSON.stringify(TEST_ORG_ID);
         }
-        return null;
+        return undefined;
       });
       await getTokenSilently(auth0);
 

--- a/__tests__/Auth0Client/getUser.test.ts
+++ b/__tests__/Auth0Client/getUser.test.ts
@@ -102,7 +102,7 @@ describe('Auth0Client', () => {
       getMock.mockImplementation((key: string) => {
         if (
           key ===
-          '@@auth0spajs@@::auth0_client_id::default::openid profile email::<no_org>'
+          '@@auth0spajs@@::auth0_client_id::default::openid profile email'
         ) {
           return {
             body: { id_token: 'abc', decodedToken: { user: { sub: '123' } } }
@@ -117,7 +117,7 @@ describe('Auth0Client', () => {
         '@@auth0spajs@@::auth0_client_id::@@user@@'
       );
       expect(cache.get).toBeCalledWith(
-        '@@auth0spajs@@::auth0_client_id::default::openid profile email::<no_org>'
+        '@@auth0spajs@@::auth0_client_id::default::openid profile email'
       );
       expect(user?.sub).toBe('123');
     });

--- a/__tests__/Auth0Client/getUser.test.ts
+++ b/__tests__/Auth0Client/getUser.test.ts
@@ -102,7 +102,7 @@ describe('Auth0Client', () => {
       getMock.mockImplementation((key: string) => {
         if (
           key ===
-          '@@auth0spajs@@::auth0_client_id::default::openid profile email'
+          '@@auth0spajs@@::auth0_client_id::default::openid profile email::<no_org>'
         ) {
           return {
             body: { id_token: 'abc', decodedToken: { user: { sub: '123' } } }
@@ -117,7 +117,7 @@ describe('Auth0Client', () => {
         '@@auth0spajs@@::auth0_client_id::@@user@@'
       );
       expect(cache.get).toBeCalledWith(
-        '@@auth0spajs@@::auth0_client_id::default::openid profile email'
+        '@@auth0spajs@@::auth0_client_id::default::openid profile email::<no_org>'
       );
       expect(user?.sub).toBe('123');
     });

--- a/__tests__/Auth0Client/handleRedirectCallback.test.ts
+++ b/__tests__/Auth0Client/handleRedirectCallback.test.ts
@@ -232,7 +232,7 @@ describe('Auth0Client', () => {
 
       const result = await loginWithRedirect(auth0, { appState });
 
-      expect((http.switchFetch as jest.Mock).mock.calls[0][6]).toEqual(40000);
+      expect((http.switchFetch as jest.Mock).mock.calls[0][7]).toEqual(40000);
       expect(result).toBeDefined();
       expect(result.appState).toEqual(appState);
     });

--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -157,7 +157,7 @@ describe('Auth0Client', () => {
 
       expect(mockWindow.open).toHaveBeenCalled();
 
-      expect((http.switchFetch as jest.Mock).mock.calls[0][6]).toEqual(60000);
+      expect((http.switchFetch as jest.Mock).mock.calls[0][7]).toEqual(60000);
 
       // prettier-ignore
       const url = (utils.runPopup as jest.Mock).mock.calls[0][0].popup.location.href;

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_AUTH0_CLIENT,
-  DEFAULT_ORGANIZATION,
+  MISSING_ORGANIZATION,
   DEFAULT_SILENT_TOKEN_RETRY_COUNT
 } from '../src/constants';
 
@@ -134,7 +134,7 @@ describe('oauthToken', () => {
         },
         auth: {
           audience: '__test_audience__',
-          organization: DEFAULT_ORGANIZATION,
+          organization: MISSING_ORGANIZATION,
           scope: '__test_scope__'
         },
         timeout: 10000

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_AUTH0_CLIENT,
+  DEFAULT_ORGANIZATION,
   DEFAULT_SILENT_TOKEN_RETRY_COUNT
 } from '../src/constants';
 
@@ -133,7 +134,7 @@ describe('oauthToken', () => {
         },
         auth: {
           audience: '__test_audience__',
-          organization: '<no_org>',
+          organization: DEFAULT_ORGANIZATION,
           scope: '__test_scope__'
         },
         timeout: 10000

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_AUTH0_CLIENT,
-  MISSING_ORGANIZATION,
+  NO_ORG,
   DEFAULT_SILENT_TOKEN_RETRY_COUNT
 } from '../src/constants';
 
@@ -134,7 +134,7 @@ describe('oauthToken', () => {
         },
         auth: {
           audience: '__test_audience__',
-          organization: MISSING_ORGANIZATION,
+          organization: NO_ORG,
           scope: '__test_scope__'
         },
         timeout: 10000

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -133,6 +133,7 @@ describe('oauthToken', () => {
         },
         auth: {
           audience: '__test_audience__',
+          organization: '<no_org>',
           scope: '__test_scope__'
         },
         timeout: 10000

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -22,7 +22,8 @@ import {
   dayInSeconds,
   nowSeconds,
   TEST_REFRESH_TOKEN,
-  TEST_ORG_ID
+  TEST_ORG_ID,
+  TEST_NO_ORG
 } from '../constants';
 import { InMemoryAsyncCacheNoKeys } from './shared';
 
@@ -32,14 +33,14 @@ const defaultKey = new CacheKey({
   clientId: TEST_CLIENT_ID,
   audience: TEST_AUDIENCE,
   scope: TEST_SCOPES,
-  organization: TEST_ORG_ID
+  organization: TEST_NO_ORG
 });
 
 const defaultData: CacheEntry = {
   client_id: TEST_CLIENT_ID,
   audience: TEST_AUDIENCE,
   scope: TEST_SCOPES,
-  organization: TEST_ORG_ID,
+  organization: TEST_NO_ORG,
   id_token: TEST_ID_TOKEN,
   access_token: TEST_ACCESS_TOKEN,
   expires_in: dayInSeconds,
@@ -116,7 +117,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
-        organization: TEST_ORG_ID,
+        organization: TEST_NO_ORG,
         scope: 'read:messages'
       });
 
@@ -134,7 +135,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
-        organization: TEST_ORG_ID,
+        organization: TEST_NO_ORG,
       });
 
       expect(await manager.get(key)).toStrictEqual(data);
@@ -151,7 +152,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
-        organization: TEST_ORG_ID,
+        organization: TEST_NO_ORG,
         scope: 'read:messages write:messages'
       });
 
@@ -207,7 +208,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
-        organization: TEST_ORG_ID,
+        organization: TEST_NO_ORG,
         scope: 'read:messages read:actions'
       });
 
@@ -227,7 +228,7 @@ cacheFactories.forEach(cacheFactory => {
           new CacheKey({
             clientId: TEST_CLIENT_ID,
             audience: TEST_AUDIENCE,
-            organization: TEST_ORG_ID,
+            organization: TEST_NO_ORG,
             scope: TEST_SCOPES
           }),
           60
@@ -243,6 +244,88 @@ cacheFactories.forEach(cacheFactory => {
       cache.remove(defaultKey.toKey());
       expect(await manager.get(defaultKey)).toBeFalsy();
       expect(cacheSpy).toHaveBeenCalledWith(defaultKey.toKey());
+    });
+
+    it('should include organization in the cache key', async () => {
+      const cacheKey = new CacheKey({
+        clientId: TEST_CLIENT_ID,
+        audience: TEST_AUDIENCE,
+        scope: TEST_SCOPES,
+        organization: TEST_ORG_ID
+      });
+
+      expect(cacheKey.toKey()).toContain(TEST_ORG_ID);
+    });
+
+    it('should retrieve cache entry using organization', async () => {
+      const data = { ...defaultData, organization: TEST_ORG_ID };
+
+      await manager.set(data);
+
+      const cacheKey = new CacheKey({
+        clientId: TEST_CLIENT_ID,
+        audience: TEST_AUDIENCE,
+        scope: TEST_SCOPES,
+        organization: TEST_ORG_ID
+      });
+
+      const result = await manager.get(cacheKey);
+
+      expect(result).toStrictEqual(data);
+    });
+
+    it('should not retrieve cache entry if organization does not match', async () => {
+      const data = { ...defaultData, organization: TEST_ORG_ID };
+
+      await manager.set(data);
+
+      const cacheKey = new CacheKey({
+        clientId: TEST_CLIENT_ID,
+        audience: TEST_AUDIENCE,
+        scope: TEST_SCOPES,
+        organization: 'different-org'
+      });
+
+      const result = await manager.get(cacheKey);
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should not retrieve cache entry if organization is not set', async () => {
+      const data = { ...defaultData, organization: TEST_ORG_ID };
+
+      await manager.set(data);
+
+      const cacheKey = new CacheKey({
+        clientId: TEST_CLIENT_ID,
+        audience: TEST_AUDIENCE,
+        scope: TEST_SCOPES
+      });
+
+      const result = await manager.get(cacheKey);
+
+      expect(result).toBeFalsy();
+    });
+
+    it('should update cache entry when organization changes', async () => {
+      const data = { ...defaultData };
+
+      await manager.set(data);
+
+      const updatedData = { ...defaultData, organization: 'new-org' };
+
+      await manager.set(updatedData);
+
+      const cacheKey = new CacheKey({
+        clientId: TEST_CLIENT_ID,
+        audience: TEST_AUDIENCE,
+        scope: TEST_SCOPES,
+        organization: 'new-org'
+      });
+
+      const result = await manager.get(cacheKey);
+
+      expect(result).toStrictEqual(updatedData);
     });
 
     describe('when refresh tokens are used', () => {
@@ -631,7 +714,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
-          organization: TEST_ORG_ID,
+          organization: TEST_NO_ORG,
           scope: 'read:messages'
         });
 
@@ -664,7 +747,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
-          organization: TEST_ORG_ID,
+          organization: TEST_NO_ORG,
           scope: 'read:messages'
         });
 
@@ -688,7 +771,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
-          organization: TEST_ORG_ID,
+          organization: TEST_NO_ORG,
           scope: 'read:messages'
         });
 
@@ -721,7 +804,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
-          organization: TEST_ORG_ID,
+          organization: TEST_NO_ORG,
           scope: 'read:messages'
         });
 
@@ -740,7 +823,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
-          organization: TEST_ORG_ID,
+          organization: TEST_NO_ORG,
           scope: 'read:messages'
         });
 
@@ -759,7 +842,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
-          organization: TEST_ORG_ID,
+          organization: TEST_NO_ORG,
         });
 
         const cacheSpy = jest.spyOn(cache, 'get');

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -21,7 +21,8 @@ import {
   TEST_SCOPES,
   dayInSeconds,
   nowSeconds,
-  TEST_REFRESH_TOKEN
+  TEST_REFRESH_TOKEN,
+  TEST_ORG_ID
 } from '../constants';
 import { InMemoryAsyncCacheNoKeys } from './shared';
 
@@ -30,13 +31,15 @@ import { expect } from '@jest/globals';
 const defaultKey = new CacheKey({
   clientId: TEST_CLIENT_ID,
   audience: TEST_AUDIENCE,
-  scope: TEST_SCOPES
+  scope: TEST_SCOPES,
+  organization: TEST_ORG_ID
 });
 
 const defaultData: CacheEntry = {
   client_id: TEST_CLIENT_ID,
   audience: TEST_AUDIENCE,
   scope: TEST_SCOPES,
+  organization: TEST_ORG_ID,
   id_token: TEST_ID_TOKEN,
   access_token: TEST_ACCESS_TOKEN,
   expires_in: dayInSeconds,
@@ -113,6 +116,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
+        organization: TEST_ORG_ID,
         scope: 'read:messages'
       });
 
@@ -129,7 +133,8 @@ cacheFactories.forEach(cacheFactory => {
 
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
-        audience: TEST_AUDIENCE
+        audience: TEST_AUDIENCE,
+        organization: TEST_ORG_ID,
       });
 
       expect(await manager.get(key)).toStrictEqual(data);
@@ -146,6 +151,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
+        organization: TEST_ORG_ID,
         scope: 'read:messages write:messages'
       });
 
@@ -166,7 +172,7 @@ cacheFactories.forEach(cacheFactory => {
 
       expect(
         await manager.get(
-          new CacheKey({ clientId: 'test', audience: 'test', scope: 'test' })
+          new CacheKey({ clientId: 'test', audience: 'test', scope: 'test', organization: 'test' })
         )
       ).not.toBeDefined();
 
@@ -201,6 +207,7 @@ cacheFactories.forEach(cacheFactory => {
       const key = new CacheKey({
         clientId: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
+        organization: TEST_ORG_ID,
         scope: 'read:messages read:actions'
       });
 
@@ -220,6 +227,7 @@ cacheFactories.forEach(cacheFactory => {
           new CacheKey({
             clientId: TEST_CLIENT_ID,
             audience: TEST_AUDIENCE,
+            organization: TEST_ORG_ID,
             scope: TEST_SCOPES
           }),
           60
@@ -623,6 +631,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
+          organization: TEST_ORG_ID,
           scope: 'read:messages'
         });
 
@@ -655,6 +664,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
+          organization: TEST_ORG_ID,
           scope: 'read:messages'
         });
 
@@ -678,6 +688,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
+          organization: TEST_ORG_ID,
           scope: 'read:messages'
         });
 
@@ -710,6 +721,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
+          organization: TEST_ORG_ID,
           scope: 'read:messages'
         });
 
@@ -728,6 +740,7 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
           audience: TEST_AUDIENCE,
+          organization: TEST_ORG_ID,
           scope: 'read:messages'
         });
 
@@ -745,7 +758,8 @@ cacheFactories.forEach(cacheFactory => {
       it('should return undefined if not found in id token cache and no scope set', async () => {
         const cacheKey = new CacheKey({
           clientId: TEST_CLIENT_ID,
-          audience: TEST_AUDIENCE
+          audience: TEST_AUDIENCE,
+          organization: TEST_ORG_ID,
         });
 
         const cacheSpy = jest.spyOn(cache, 'get');

--- a/__tests__/cache/cache.test.ts
+++ b/__tests__/cache/cache.test.ts
@@ -13,7 +13,8 @@ import {
   TEST_ACCESS_TOKEN,
   dayInSeconds,
   nowSeconds,
-  TEST_AUDIENCE
+  TEST_AUDIENCE,
+  TEST_ORG_ID
 } from '../constants';
 import { InMemoryAsyncCacheNoKeys } from './shared';
 import { expect } from '@jest/globals';
@@ -31,6 +32,7 @@ const defaultEntry: CacheEntry = {
   client_id: TEST_CLIENT_ID,
   audience: TEST_AUDIENCE,
   scope: TEST_SCOPES,
+  organization: TEST_ORG_ID,
   id_token: TEST_ID_TOKEN,
   access_token: TEST_ACCESS_TOKEN,
   expires_in: dayInSeconds,
@@ -127,6 +129,7 @@ cacheFactories.forEach(cacheFactory => {
       const data = {
         client_id: TEST_CLIENT_ID,
         audience: TEST_AUDIENCE,
+        organization: TEST_ORG_ID,
         scope: 'the_scope the_scope2 the_scope3',
         id_token: TEST_ID_TOKEN,
         access_token: TEST_ACCESS_TOKEN,

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -1,5 +1,5 @@
 import version from '../src/version';
-import { DEFAULT_SCOPE } from '../src/constants';
+import { DEFAULT_ORGANIZATION, DEFAULT_SCOPE } from '../src/constants';
 
 export const TEST_AUTH0_CLIENT_QUERY_STRING = `&auth0Client=${encodeURIComponent(
   btoa(
@@ -33,7 +33,7 @@ export const TEST_USER_ID = 'user-id';
 export const TEST_USER_EMAIL = 'user@email.com';
 export const TEST_APP_STATE = { bestPet: 'dog' };
 export const TEST_ORG_ID = 'org_id_123';
-export const TEST_NO_ORG = '<no_org>';
+export const TEST_NO_ORG = DEFAULT_ORGANIZATION;
 
 export const nowSeconds = () => Math.floor(Date.now() / 1000);
 export const dayInSeconds = 86400;

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -33,6 +33,7 @@ export const TEST_USER_ID = 'user-id';
 export const TEST_USER_EMAIL = 'user@email.com';
 export const TEST_APP_STATE = { bestPet: 'dog' };
 export const TEST_ORG_ID = 'org_id_123';
+export const TEST_NO_ORG = '<no_org>';
 
 export const nowSeconds = () => Math.floor(Date.now() / 1000);
 export const dayInSeconds = 86400;

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -1,5 +1,5 @@
 import version from '../src/version';
-import { MISSING_ORGANIZATION, DEFAULT_SCOPE } from '../src/constants';
+import { NO_ORG, DEFAULT_SCOPE } from '../src/constants';
 
 export const TEST_AUTH0_CLIENT_QUERY_STRING = `&auth0Client=${encodeURIComponent(
   btoa(
@@ -33,7 +33,7 @@ export const TEST_USER_ID = 'user-id';
 export const TEST_USER_EMAIL = 'user@email.com';
 export const TEST_APP_STATE = { bestPet: 'dog' };
 export const TEST_ORG_ID = 'org_id_123';
-export const TEST_NO_ORG = MISSING_ORGANIZATION;
+export const TEST_NO_ORG = NO_ORG;
 
 export const nowSeconds = () => Math.floor(Date.now() / 1000);
 export const dayInSeconds = 86400;

--- a/__tests__/constants.ts
+++ b/__tests__/constants.ts
@@ -1,5 +1,5 @@
 import version from '../src/version';
-import { DEFAULT_ORGANIZATION, DEFAULT_SCOPE } from '../src/constants';
+import { MISSING_ORGANIZATION, DEFAULT_SCOPE } from '../src/constants';
 
 export const TEST_AUTH0_CLIENT_QUERY_STRING = `&auth0Client=${encodeURIComponent(
   btoa(
@@ -33,7 +33,7 @@ export const TEST_USER_ID = 'user-id';
 export const TEST_USER_EMAIL = 'user@email.com';
 export const TEST_APP_STATE = { bestPet: 'dog' };
 export const TEST_ORG_ID = 'org_id_123';
-export const TEST_NO_ORG = DEFAULT_ORGANIZATION;
+export const TEST_NO_ORG = MISSING_ORGANIZATION;
 
 export const nowSeconds = () => Math.floor(Date.now() / 1000);
 export const dayInSeconds = 86400;

--- a/__tests__/http.test.ts
+++ b/__tests__/http.test.ts
@@ -15,7 +15,7 @@ describe('switchFetch', () => {
       })
     );
     jest.spyOn(window, 'clearTimeout');
-    await switchFetch('https://test.com/', null, null, {}, undefined);
+    await switchFetch('https://test.com/', null, null, null, {}, undefined);
     expect(clearTimeout).toBeCalledTimes(1);
   });
 });
@@ -30,7 +30,7 @@ describe('getJson', () => {
     );
 
     await expect(
-      getJSON('https://test.com/', null, null, null, {}, undefined)
+      getJSON('https://test.com/', null, null, null, null, {}, undefined)
     ).rejects.toBeInstanceOf(MfaRequiredError);
   });
 
@@ -44,7 +44,7 @@ describe('getJson', () => {
     );
 
     await expect(
-      getJSON('https://test.com/', null, null, null, {}, undefined)
+      getJSON('https://test.com/', null, null, null, null, {}, undefined)
     ).rejects.toHaveProperty('mfa_token', '1234');
   });
 
@@ -57,7 +57,7 @@ describe('getJson', () => {
     );
 
     await expect(
-      getJSON('https://test.com/', null, null, null, {}, undefined)
+      getJSON('https://test.com/', null, null, null, null, {}, undefined)
     ).rejects.toBeInstanceOf(MissingRefreshTokenError);
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -102,6 +102,7 @@ type GetTokenSilentlyResult = TokenEndpointResponse & {
   scope: string;
   oauthTokenScope?: string;
   audience: string;
+  organization: string;
 };
 
 /**
@@ -290,6 +291,7 @@ export class Auth0Client {
   ): Promise<{
     scope: string;
     audience: string;
+    organization: string;
     redirect_uri?: string;
     nonce: string;
     code_verifier: string;
@@ -322,6 +324,7 @@ export class Auth0Client {
       code_verifier,
       scope: params.scope,
       audience: params.audience || 'default',
+      organization: params.organization || '<no_org>',
       redirect_uri: params.redirect_uri,
       state,
       url
@@ -678,7 +681,7 @@ export class Auth0Client {
       const entry = await this._getEntryFromCache({
         scope: getTokenOptions.authorizationParams.scope,
         audience: getTokenOptions.authorizationParams.audience || 'default',
-        organization: getTokenOptions.authorizationParams.organization || orgHint || 'default',
+        organization: getTokenOptions.authorizationParams.organization || orgHint || '<no_org>',
         clientId: this.options.clientId
       });
 
@@ -706,7 +709,7 @@ export class Auth0Client {
           const entry = await this._getEntryFromCache({
             scope: getTokenOptions.authorizationParams.scope,
             audience: getTokenOptions.authorizationParams.audience || 'default',
-            organization: getTokenOptions.authorizationParams.organization || orgHint || 'default',
+            organization: getTokenOptions.authorizationParams.organization || orgHint || '<no_org>',
             clientId: this.options.clientId
           });
 
@@ -774,7 +777,7 @@ export class Auth0Client {
       new CacheKey({
         scope: localOptions.authorizationParams.scope,
         audience: localOptions.authorizationParams.audience || 'default',
-        organization: localOptions.authorizationParams.organization || orgHint || 'default',
+        organization: localOptions.authorizationParams.organization || orgHint || '<no_org>',
         clientId: this.options.clientId
       })
     );
@@ -931,7 +934,8 @@ export class Auth0Client {
         ...tokenResult,
         scope: scope,
         oauthTokenScope: tokenResult.scope,
-        audience: audience
+        audience: audience,
+        organization: params.organization || '<no_org>',
       };
     } catch (e) {
       if (e.error === 'login_required') {
@@ -953,7 +957,7 @@ export class Auth0Client {
       new CacheKey({
         scope: options.authorizationParams.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || 'default',
+        organization: options.authorizationParams.organization || orgHint || '<no_org>',
         clientId: this.options.clientId
       })
     );
@@ -969,7 +973,8 @@ export class Auth0Client {
 
       throw new MissingRefreshTokenError(
         options.authorizationParams.audience || 'default',
-        options.authorizationParams.scope
+        options.authorizationParams.scope,
+        options.authorizationParams.organization || orgHint || '<no_org>',
       );
     }
 
@@ -996,7 +1001,8 @@ export class Auth0Client {
         ...tokenResult,
         scope: options.authorizationParams.scope,
         oauthTokenScope: tokenResult.scope,
-        audience: options.authorizationParams.audience || 'default'
+        audience: options.authorizationParams.audience || 'default',
+        organization: options.authorizationParams.organization || orgHint || '<no_org>',
       };
     } catch (e) {
       if (
@@ -1038,7 +1044,7 @@ export class Auth0Client {
   private async _getIdTokenFromCache() {
     const audience = this.options.authorizationParams.audience || 'default';
     const orgHint = this.cookieStorage.get<string>(this.orgHintCookieName);
-    const organization = this.options.authorizationParams.organization || orgHint || 'default';
+    const organization = this.options.authorizationParams.organization || orgHint || '<no_org>';
 
     const cache = await this.cacheManager.getIdToken(
       new CacheKey({
@@ -1071,7 +1077,7 @@ export class Auth0Client {
   }: {
     scope: string;
     audience: string;
-    organization?: string;
+    organization: string;
     clientId: string;
   }): Promise<undefined | GetTokenSilentlyVerboseResponse> {
     const entry = await this.cacheManager.get(
@@ -1125,6 +1131,7 @@ export class Auth0Client {
         auth0Client: this.options.auth0Client,
         useFormData: this.options.useFormData,
         timeout: this.httpTimeoutMs,
+        organization,
         ...options
       },
       this.worker
@@ -1141,7 +1148,7 @@ export class Auth0Client {
       decodedToken,
       scope: options.scope,
       audience: options.audience || 'default',
-      organization: options.organization || organization || 'default',
+      organization: options.organization || organization || '<no_org>',
       ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null),
       client_id: this.options.clientId
     });
@@ -1214,8 +1221,8 @@ export class Auth0Client {
       subject_token: options.subject_token,
       subject_token_type: options.subject_token_type,
       scope: getUniqueScopes(options.scope, this.scope),
-      audience: this.options.authorizationParams.audience
-    });
+      audience: this.options.authorizationParams.audience,
+    }, { organization: this.options.authorizationParams.organization });
   }
 }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -58,7 +58,7 @@ import {
   INVALID_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_NOW_PROVIDER,
   DEFAULT_FETCH_TIMEOUT_MS,
-  DEFAULT_ORGANIZATION
+  MISSING_ORGANIZATION
 } from './constants';
 
 import {
@@ -680,7 +680,7 @@ export class Auth0Client {
       const entry = await this._getEntryFromCache({
         scope: getTokenOptions.authorizationParams.scope,
         audience: getTokenOptions.authorizationParams.audience || 'default',
-        organization: getTokenOptions.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
+        organization: getTokenOptions.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
         clientId: this.options.clientId
       });
 
@@ -708,7 +708,7 @@ export class Auth0Client {
           const entry = await this._getEntryFromCache({
             scope: getTokenOptions.authorizationParams.scope,
             audience: getTokenOptions.authorizationParams.audience || 'default',
-            organization: getTokenOptions.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
+            organization: getTokenOptions.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
             clientId: this.options.clientId
           });
 
@@ -776,7 +776,7 @@ export class Auth0Client {
       new CacheKey({
         scope: localOptions.authorizationParams.scope,
         audience: localOptions.authorizationParams.audience || 'default',
-        organization: localOptions.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
+        organization: localOptions.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
         clientId: this.options.clientId
       })
     );
@@ -956,7 +956,7 @@ export class Auth0Client {
       new CacheKey({
         scope: options.authorizationParams.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
+        organization: options.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
         clientId: this.options.clientId
       })
     );
@@ -973,7 +973,7 @@ export class Auth0Client {
       throw new MissingRefreshTokenError(
         options.authorizationParams.audience || 'default',
         options.authorizationParams.scope,
-        options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
+        options.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
       );
     }
 
@@ -1001,7 +1001,7 @@ export class Auth0Client {
         scope: options.authorizationParams.scope,
         oauthTokenScope: tokenResult.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
+        organization: options.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
       };
     } catch (e) {
       if (
@@ -1042,19 +1042,12 @@ export class Auth0Client {
 
   private async _getIdTokenFromCache() {
     const audience = this.options.authorizationParams.audience || 'default';
-    let orgHint;
 
-    if (typeof document !== 'undefined') {
-      orgHint = this.cookieStorage.get<string>(this.orgHintCookieName);
-    }
-
-    const organization = this.options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION;
     const cache = await this.cacheManager.getIdToken(
       new CacheKey({
         clientId: this.options.clientId,
         audience,
-        scope: this.scope,
-        organization
+        scope: this.scope
       })
     );
 
@@ -1151,7 +1144,7 @@ export class Auth0Client {
       decodedToken,
       scope: options.scope,
       audience: options.audience || 'default',
-      organization: organization || DEFAULT_ORGANIZATION,
+      organization: organization || MISSING_ORGANIZATION,
       ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null),
       client_id: this.options.clientId
     });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -57,7 +57,8 @@ import {
   DEFAULT_AUTH0_CLIENT,
   INVALID_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_NOW_PROVIDER,
-  DEFAULT_FETCH_TIMEOUT_MS
+  DEFAULT_FETCH_TIMEOUT_MS,
+  DEFAULT_ORGANIZATION
 } from './constants';
 
 import {
@@ -679,7 +680,7 @@ export class Auth0Client {
       const entry = await this._getEntryFromCache({
         scope: getTokenOptions.authorizationParams.scope,
         audience: getTokenOptions.authorizationParams.audience || 'default',
-        organization: getTokenOptions.authorizationParams.organization || orgHint || '<no_org>',
+        organization: getTokenOptions.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
         clientId: this.options.clientId
       });
 
@@ -707,7 +708,7 @@ export class Auth0Client {
           const entry = await this._getEntryFromCache({
             scope: getTokenOptions.authorizationParams.scope,
             audience: getTokenOptions.authorizationParams.audience || 'default',
-            organization: getTokenOptions.authorizationParams.organization || orgHint || '<no_org>',
+            organization: getTokenOptions.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
             clientId: this.options.clientId
           });
 
@@ -775,7 +776,7 @@ export class Auth0Client {
       new CacheKey({
         scope: localOptions.authorizationParams.scope,
         audience: localOptions.authorizationParams.audience || 'default',
-        organization: localOptions.authorizationParams.organization || orgHint || '<no_org>',
+        organization: localOptions.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
         clientId: this.options.clientId
       })
     );
@@ -955,7 +956,7 @@ export class Auth0Client {
       new CacheKey({
         scope: options.authorizationParams.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || '<no_org>',
+        organization: options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
         clientId: this.options.clientId
       })
     );
@@ -972,7 +973,7 @@ export class Auth0Client {
       throw new MissingRefreshTokenError(
         options.authorizationParams.audience || 'default',
         options.authorizationParams.scope,
-        options.authorizationParams.organization || orgHint || '<no_org>',
+        options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
       );
     }
 
@@ -1000,7 +1001,7 @@ export class Auth0Client {
         scope: options.authorizationParams.scope,
         oauthTokenScope: tokenResult.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || '<no_org>',
+        organization: options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION,
       };
     } catch (e) {
       if (
@@ -1044,12 +1045,10 @@ export class Auth0Client {
     let orgHint;
 
     if (typeof document !== 'undefined') {
-      orgHint = this.cookieStorage.get<string>(
-        this.orgHintCookieName
-      );
+      orgHint = this.cookieStorage.get<string>(this.orgHintCookieName);
     }
 
-    const organization = this.options.authorizationParams.organization || orgHint || '<no_org>';
+    const organization = this.options.authorizationParams.organization || orgHint || DEFAULT_ORGANIZATION;
     const cache = await this.cacheManager.getIdToken(
       new CacheKey({
         clientId: this.options.clientId,
@@ -1152,7 +1151,7 @@ export class Auth0Client {
       decodedToken,
       scope: options.scope,
       audience: options.audience || 'default',
-      organization: options.organization || organization || '<no_org>',
+      organization: organization || DEFAULT_ORGANIZATION,
       ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null),
       client_id: this.options.clientId
     });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -102,7 +102,7 @@ type GetTokenSilentlyResult = TokenEndpointResponse & {
   scope: string;
   oauthTokenScope?: string;
   audience: string;
-  organization: string;
+  organization?: string;
 };
 
 /**
@@ -311,8 +311,8 @@ export class Auth0Client {
       nonce,
       code_challenge,
       authorizationParams.redirect_uri ||
-        this.options.authorizationParams.redirect_uri ||
-        fallbackRedirectUri,
+      this.options.authorizationParams.redirect_uri ||
+      fallbackRedirectUri,
       authorizeOptions?.response_mode
     );
 
@@ -933,7 +933,7 @@ export class Auth0Client {
         scope: scope,
         oauthTokenScope: tokenResult.scope,
         audience: audience,
-        organization: params.organization || '<no_org>',
+        organization: params.organization,
       };
     } catch (e) {
       if (e.error === 'login_required') {
@@ -1044,11 +1044,11 @@ export class Auth0Client {
     let orgHint;
 
     if (typeof document !== 'undefined') {
-      orgHint = this.cookieStorage.get(
+      orgHint = this.cookieStorage.get<string>(
         this.orgHintCookieName
-      ) as string;
+      );
     }
-  
+
     const organization = this.options.authorizationParams.organization || orgHint || '<no_org>';
     const cache = await this.cacheManager.getIdToken(
       new CacheKey({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -291,7 +291,6 @@ export class Auth0Client {
   ): Promise<{
     scope: string;
     audience: string;
-    organization: string;
     redirect_uri?: string;
     nonce: string;
     code_verifier: string;
@@ -324,7 +323,6 @@ export class Auth0Client {
       code_verifier,
       scope: params.scope,
       audience: params.audience || 'default',
-      organization: params.organization || '<no_org>',
       redirect_uri: params.redirect_uri,
       state,
       url
@@ -1043,9 +1041,15 @@ export class Auth0Client {
 
   private async _getIdTokenFromCache() {
     const audience = this.options.authorizationParams.audience || 'default';
-    const orgHint = this.cookieStorage.get<string>(this.orgHintCookieName);
-    const organization = this.options.authorizationParams.organization || orgHint || '<no_org>';
+    let orgHint;
 
+    if (typeof document !== 'undefined') {
+      orgHint = this.cookieStorage.get(
+        this.orgHintCookieName
+      ) as string;
+    }
+  
+    const organization = this.options.authorizationParams.organization || orgHint || '<no_org>';
     const cache = await this.cacheManager.getIdToken(
       new CacheKey({
         clientId: this.options.clientId,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -58,7 +58,7 @@ import {
   INVALID_REFRESH_TOKEN_ERROR_MESSAGE,
   DEFAULT_NOW_PROVIDER,
   DEFAULT_FETCH_TIMEOUT_MS,
-  MISSING_ORGANIZATION
+  NO_ORG
 } from './constants';
 
 import {
@@ -586,7 +586,7 @@ export class Auth0Client {
 
     try {
       await this.getTokenSilently(options);
-    } catch (_) {}
+    } catch (_) { }
   }
 
   /**
@@ -680,7 +680,7 @@ export class Auth0Client {
       const entry = await this._getEntryFromCache({
         scope: getTokenOptions.authorizationParams.scope,
         audience: getTokenOptions.authorizationParams.audience || 'default',
-        organization: getTokenOptions.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
+        organization: getTokenOptions.authorizationParams.organization || orgHint || NO_ORG,
         clientId: this.options.clientId
       });
 
@@ -708,7 +708,7 @@ export class Auth0Client {
           const entry = await this._getEntryFromCache({
             scope: getTokenOptions.authorizationParams.scope,
             audience: getTokenOptions.authorizationParams.audience || 'default',
-            organization: getTokenOptions.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
+            organization: getTokenOptions.authorizationParams.organization || orgHint || NO_ORG,
             clientId: this.options.clientId
           });
 
@@ -776,7 +776,7 @@ export class Auth0Client {
       new CacheKey({
         scope: localOptions.authorizationParams.scope,
         audience: localOptions.authorizationParams.audience || 'default',
-        organization: localOptions.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
+        organization: localOptions.authorizationParams.organization || orgHint || NO_ORG,
         clientId: this.options.clientId
       })
     );
@@ -956,7 +956,7 @@ export class Auth0Client {
       new CacheKey({
         scope: options.authorizationParams.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
+        organization: options.authorizationParams.organization || orgHint || NO_ORG,
         clientId: this.options.clientId
       })
     );
@@ -973,7 +973,7 @@ export class Auth0Client {
       throw new MissingRefreshTokenError(
         options.authorizationParams.audience || 'default',
         options.authorizationParams.scope,
-        options.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
+        options.authorizationParams.organization || orgHint || NO_ORG,
       );
     }
 
@@ -1001,7 +1001,7 @@ export class Auth0Client {
         scope: options.authorizationParams.scope,
         oauthTokenScope: tokenResult.scope,
         audience: options.authorizationParams.audience || 'default',
-        organization: options.authorizationParams.organization || orgHint || MISSING_ORGANIZATION,
+        organization: options.authorizationParams.organization || orgHint || NO_ORG,
       };
     } catch (e) {
       if (
@@ -1144,7 +1144,7 @@ export class Auth0Client {
       decodedToken,
       scope: options.scope,
       audience: options.audience || 'default',
-      organization: organization || MISSING_ORGANIZATION,
+      organization: organization || NO_ORG,
       ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null),
       client_id: this.options.clientId
     });

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,7 @@ export async function oauthToken(
     `${baseUrl}/oauth/token`,
     timeout,
     audience || 'default',
-    organization || 'default',
+    organization || '<no_org>',
     scope,
     {
       method: 'POST',

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { TokenEndpointOptions, TokenEndpointResponse } from './global';
-import { DEFAULT_AUTH0_CLIENT, MISSING_ORGANIZATION } from './constants';
+import { DEFAULT_AUTH0_CLIENT, NO_ORG } from './constants';
 import { getJSON } from './http';
 import { createQueryParams } from './utils';
 
@@ -24,7 +24,7 @@ export async function oauthToken(
     `${baseUrl}/oauth/token`,
     timeout,
     audience || 'default',
-    organization || MISSING_ORGANIZATION,
+    organization || NO_ORG,
     scope,
     {
       method: 'POST',

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ export async function oauthToken(
     baseUrl,
     timeout,
     audience,
+    organization,
     scope,
     auth0Client,
     useFormData,
@@ -23,6 +24,7 @@ export async function oauthToken(
     `${baseUrl}/oauth/token`,
     timeout,
     audience || 'default',
+    organization || 'default',
     scope,
     {
       method: 'POST',

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { TokenEndpointOptions, TokenEndpointResponse } from './global';
-import { DEFAULT_AUTH0_CLIENT, DEFAULT_ORGANIZATION } from './constants';
+import { DEFAULT_AUTH0_CLIENT, MISSING_ORGANIZATION } from './constants';
 import { getJSON } from './http';
 import { createQueryParams } from './utils';
 
@@ -24,7 +24,7 @@ export async function oauthToken(
     `${baseUrl}/oauth/token`,
     timeout,
     audience || 'default',
-    organization || DEFAULT_ORGANIZATION,
+    organization || MISSING_ORGANIZATION,
     scope,
     {
       method: 'POST',

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { TokenEndpointOptions, TokenEndpointResponse } from './global';
-import { DEFAULT_AUTH0_CLIENT } from './constants';
+import { DEFAULT_AUTH0_CLIENT, DEFAULT_ORGANIZATION } from './constants';
 import { getJSON } from './http';
 import { createQueryParams } from './utils';
 
@@ -24,7 +24,7 @@ export async function oauthToken(
     `${baseUrl}/oauth/token`,
     timeout,
     audience || 'default',
-    organization || '<no_org>',
+    organization || DEFAULT_ORGANIZATION,
     scope,
     {
       method: 'POST',

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -43,7 +43,7 @@ export class CacheManager {
       this.getIdTokenCacheKey(cacheKey.clientId)
     );
 
-    if (!entry && cacheKey.scope && cacheKey.audience && cacheKey.organization) {
+    if (!entry && cacheKey.scope && cacheKey.audience) {
       const entryByScope = await this.get(cacheKey);
 
       if (!entryByScope) {

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -118,7 +118,8 @@ export class CacheManager {
     const cacheKey = new CacheKey({
       clientId: entry.client_id,
       scope: entry.scope,
-      audience: entry.audience
+      audience: entry.audience,
+      organization: entry.organization
     });
 
     const wrappedEntry = await this.wrapCacheEntry(entry);
@@ -203,6 +204,7 @@ export class CacheManager {
         cacheKey.prefix === CACHE_KEY_PREFIX &&
         cacheKey.clientId === keyToMatch.clientId &&
         cacheKey.audience === keyToMatch.audience &&
+        cacheKey.organization === keyToMatch.organization &&
         hasAllScopes
       );
     })[0];

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -43,7 +43,7 @@ export class CacheManager {
       this.getIdTokenCacheKey(cacheKey.clientId)
     );
 
-    if (!entry && cacheKey.scope && cacheKey.audience) {
+    if (!entry && cacheKey.scope && cacheKey.audience && cacheKey.organization) {
       const entryByScope = await this.get(cacheKey);
 
       if (!entryByScope) {

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -6,6 +6,7 @@ export const CACHE_KEY_ID_TOKEN_SUFFIX = '@@user@@';
 export type CacheKeyData = {
   audience?: string;
   scope?: string;
+  organization?: string;
   clientId: string;
 };
 
@@ -13,6 +14,7 @@ export class CacheKey {
   public clientId: string;
   public scope?: string;
   public audience?: string;
+  public organization?: string;
 
   constructor(
     data: CacheKeyData,
@@ -22,6 +24,7 @@ export class CacheKey {
     this.clientId = data.clientId;
     this.scope = data.scope;
     this.audience = data.audience;
+    this.organization = data.organization;
   }
 
   /**
@@ -29,7 +32,7 @@ export class CacheKey {
    * @returns A string representation of the key
    */
   toKey(): string {
-    return [this.prefix, this.clientId, this.audience, this.scope, this.suffix]
+    return [this.prefix, this.clientId, this.audience, this.scope, this.organization, this.suffix]
       .filter(Boolean)
       .join('::');
   }
@@ -40,9 +43,9 @@ export class CacheKey {
    * @returns An instance of `CacheKey`
    */
   static fromKey(key: string): CacheKey {
-    const [prefix, clientId, audience, scope] = key.split('::');
+    const [prefix, clientId, audience, scope, organization] = key.split('::');
 
-    return new CacheKey({ clientId, scope, audience }, prefix);
+    return new CacheKey({ clientId, scope, audience, organization }, prefix);
   }
 
   /**
@@ -51,11 +54,12 @@ export class CacheKey {
    * @returns An instance of `CacheKey`
    */
   static fromCacheEntry(entry: CacheEntry): CacheKey {
-    const { scope, audience, client_id: clientId } = entry;
+    const { scope, audience, organization, client_id: clientId } = entry;
 
     return new CacheKey({
       scope,
       audience,
+      organization,
       clientId
     });
   }
@@ -78,6 +82,7 @@ export type CacheEntry = {
   decodedToken?: DecodedToken;
   audience: string;
   scope: string;
+  organization?: string;
   client_id: string;
   refresh_token?: string;
   oauthTokenScope?: string;

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -82,7 +82,7 @@ export type CacheEntry = {
   decodedToken?: DecodedToken;
   audience: string;
   scope: string;
-  organization?: string;
+  organization: string;
   client_id: string;
   refresh_token?: string;
   oauthTokenScope?: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const DEFAULT_SCOPE = 'openid profile email';
 /**
  * @ignore
  */
-export const MISSING_ORGANIZATION = '<no_org>';
+export const NO_ORG = '<no_org>';
 
 /**
  * @ignore

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const DEFAULT_SCOPE = 'openid profile email';
 /**
  * @ignore
  */
-export const DEFAULT_ORGANIZATION = '<no_org>';
+export const MISSING_ORGANIZATION = '<no_org>';
 
 /**
  * @ignore

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,6 +49,11 @@ export const DEFAULT_SCOPE = 'openid profile email';
 /**
  * @ignore
  */
+export const DEFAULT_ORGANIZATION = '<no_org>';
+
+/**
+ * @ignore
+ */
 export const DEFAULT_SESSION_CHECK_EXPIRY_DAYS = 1;
 
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -85,7 +85,7 @@ export class MfaRequiredError extends GenericError {
  * Error thrown when there is no refresh token to use
  */
 export class MissingRefreshTokenError extends GenericError {
-  constructor(public audience: string, public scope: string) {
+  constructor(public audience: string, public scope: string, public organization: string) {
     super(
       'missing_refresh_token',
       `Missing Refresh Token (audience: '${valueOrEmptyString(audience, [

--- a/src/http.ts
+++ b/src/http.ts
@@ -153,7 +153,7 @@ export async function getJSON<T>(
     }
 
     if (error === 'missing_refresh_token') {
-      throw new MissingRefreshTokenError(audience, scope);
+      throw new MissingRefreshTokenError(audience, scope, organization);
     }
 
     throw new GenericError(error || 'request_error', errorMessage);

--- a/src/http.ts
+++ b/src/http.ts
@@ -50,6 +50,7 @@ const fetchWithoutWorker = async (
 const fetchWithWorker = async (
   fetchUrl: string,
   audience: string,
+  organization: string,
   scope: string,
   fetchOptions: FetchOptions,
   timeout: number,
@@ -60,7 +61,8 @@ const fetchWithWorker = async (
     {
       auth: {
         audience,
-        scope
+        organization,
+        scope,
       },
       timeout,
       fetchUrl,
@@ -74,6 +76,7 @@ const fetchWithWorker = async (
 export const switchFetch = async (
   fetchUrl: string,
   audience: string,
+  organization: string,
   scope: string,
   fetchOptions: FetchOptions,
   worker?: Worker,
@@ -84,6 +87,7 @@ export const switchFetch = async (
     return fetchWithWorker(
       fetchUrl,
       audience,
+      organization,
       scope,
       fetchOptions,
       timeout,
@@ -99,6 +103,7 @@ export async function getJSON<T>(
   url: string,
   timeout: number | undefined,
   audience: string,
+  organization: string,
   scope: string,
   options: FetchOptions,
   worker?: Worker,
@@ -112,6 +117,7 @@ export async function getJSON<T>(
       response = await switchFetch(
         url,
         audience,
+        organization,
         scope,
         options,
         worker,

--- a/src/worker/worker.types.ts
+++ b/src/worker/worker.types.ts
@@ -10,6 +10,7 @@ export type WorkerRefreshTokenMessage = {
   useFormData?: boolean;
   auth: {
     audience: string;
+    organization: string;
     scope: string;
   };
 };


### PR DESCRIPTION

### Changes

This PR allows saving `organization` in the tokenset as `audience` and `scope`. At the same time when saving and retrieving the tokenset we add it in the tokenset key. 

When no organization is configured, we add `<no_org>` as string.

This will allow us to search fort tokens that belong to the same organization when doing MRRT.

### References

https://auth0team.atlassian.net/browse/DXFL-2028

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
