### PR TITLE
 [DO NOT MERGE] [MRRT] Rename get method from cache-manager

### DIFF
--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -97,7 +97,7 @@ cacheFactories.forEach(cacheFactory => {
     });
 
     it('returns undefined when there is nothing in the cache', async () => {
-      const result = await manager.get(defaultKey);
+      const result = await manager.getToken(defaultKey);
 
       expect(result).toBeFalsy();
     });
@@ -124,7 +124,7 @@ cacheFactories.forEach(cacheFactory => {
         scope: 'read:messages'
       });
 
-      expect(await manager.get(key)).toStrictEqual(data);
+      expect(await manager.getToken(key)).toStrictEqual(data);
     });
 
     it('should return an entry from the cache if no scopes provided', async () => {
@@ -140,7 +140,7 @@ cacheFactories.forEach(cacheFactory => {
         audience: TEST_AUDIENCE
       });
 
-      expect(await manager.get(key)).toStrictEqual(data);
+      expect(await manager.getToken(key)).toStrictEqual(data);
     });
 
     it('should return an entry directly from the cache if the key matches exactly', async () => {
@@ -157,7 +157,7 @@ cacheFactories.forEach(cacheFactory => {
         scope: 'read:messages write:messages'
       });
 
-      expect(await manager.get(key)).toStrictEqual(data);
+      expect(await manager.getToken(key)).toStrictEqual(data);
     });
 
     it('should not fetch from the cache if allKeys returns empty array of keys', async () => {
@@ -173,7 +173,7 @@ cacheFactories.forEach(cacheFactory => {
       cache.set(defaultKey.toKey(), defaultData);
 
       expect(
-        await manager.get(
+        await manager.getToken(
           new CacheKey({ clientId: 'test', audience: 'test', scope: 'test' })
         )
       ).not.toBeDefined();
@@ -191,7 +191,7 @@ cacheFactories.forEach(cacheFactory => {
         // Remove the manifest entry that is created by the manifest
         await cache.remove(manifestKey);
 
-        const result = await manager.get(defaultKey);
+        const result = await manager.getToken(defaultKey);
 
         expect(result).toStrictEqual(defaultData);
         expect(await cache.get(manifestKey)).toBeTruthy();
@@ -212,7 +212,7 @@ cacheFactories.forEach(cacheFactory => {
         scope: 'read:messages read:actions'
       });
 
-      expect(await manager.get(key)).toBeFalsy();
+      expect(await manager.getToken(key)).toBeFalsy();
     });
 
     it('returns undefined from the cache when expires_in < expiryAdjustmentSeconds', async () => {
@@ -224,7 +224,7 @@ cacheFactories.forEach(cacheFactory => {
       await manager.set(data);
 
       expect(
-        await manager.get(
+        await manager.getToken(
           new CacheKey({
             clientId: TEST_CLIENT_ID,
             audience: TEST_AUDIENCE,
@@ -241,9 +241,9 @@ cacheFactories.forEach(cacheFactory => {
       const cacheSpy = jest.spyOn(cache, 'remove');
 
       await manager.set(defaultData);
-      expect(await manager.get(defaultKey)).toStrictEqual(defaultData);
+      expect(await manager.getToken(defaultKey)).toStrictEqual(defaultData);
       cache.remove(defaultKey.toKey());
-      expect(await manager.get(defaultKey)).toBeFalsy();
+      expect(await manager.getToken(defaultKey)).toBeFalsy();
       expect(cacheSpy).toHaveBeenCalledWith(defaultKey.toKey());
     });
 
@@ -270,13 +270,13 @@ cacheFactories.forEach(cacheFactory => {
         const cacheKey = CacheKey.fromCacheEntry(data);
 
         // Test that the cache state is normal up until just before the expiry time..
-        expect(await manager.get(cacheKey)).toStrictEqual(data);
+        expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
         // Advance the time to just past the expiry..
         const dateNowStub = jest.fn(() => now + (dayInSeconds + 60) * 1000);
         global.Date.now = dateNowStub;
 
-        expect(await manager.get(cacheKey)).toStrictEqual({
+        expect(await manager.getToken(cacheKey)).toStrictEqual({
           refresh_token: TEST_REFRESH_TOKEN
         });
 
@@ -295,9 +295,9 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
-      const result = await manager.get(
+      const result = await manager.getToken(
         cacheKey,
         {
           expiryAdjustmentSeconds: 60,
@@ -324,14 +324,14 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Move back in time to ensure the token is valid
       provider.mockResolvedValue(
         now - (expiryAdjustmentSeconds - data.expires_in) * 1000
       );
 
-      const result = await manager.get(
+      const result = await manager.getToken(
         cacheKey,
         { expiryAdjustmentSeconds },
       );
@@ -362,14 +362,14 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Advance the time to just past the expiry..
       const dateNowStub = jest.fn(() => (now + dayInSeconds + 100) * 1000);
 
       global.Date.now = dateNowStub;
 
-      const result = await manager.get(cacheKey);
+      const result = await manager.getToken(cacheKey);
 
       global.Date.now = realDateNow;
 
@@ -408,12 +408,12 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Advance the time to just past the expiry..
       provider.mockResolvedValue((now + dayInSeconds + 100) * 1000);
 
-      const result = await manager.get(cacheKey);
+      const result = await manager.getToken(cacheKey);
 
       // And test that the cache has been emptied
       expect(result).toBeFalsy();
@@ -450,12 +450,12 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Advance the time to just past the expiry..
       provider.mockReturnValue((now + dayInSeconds + 100) * 1000);
 
-      const result = await manager.get(cacheKey);
+      const result = await manager.getToken(cacheKey);
 
       // And test that the cache has been emptied
       expect(result).toBeFalsy();
@@ -483,13 +483,13 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Advance the time to just past the expiry..
       const dateNowStub = jest.fn(() => (now + dayInSeconds + 100) * 1000);
       global.Date.now = dateNowStub;
 
-      const result = await manager.get(cacheKey);
+      const result = await manager.getToken(cacheKey);
 
       global.Date.now = realDateNow;
 
@@ -521,12 +521,12 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Advance the time to just past the expiry..
       provider.mockResolvedValue((now + dayInSeconds + 100) * 1000);
 
-      const result = await manager.get(cacheKey);
+      const result = await manager.getToken(cacheKey);
 
       // And test that the cache has been emptied
       expect(result).toBeFalsy();
@@ -556,12 +556,12 @@ cacheFactories.forEach(cacheFactory => {
       const cacheKey = CacheKey.fromCacheEntry(data);
 
       // Test that the cache state is normal before we expire the data
-      expect(await manager.get(cacheKey)).toStrictEqual(data);
+      expect(await manager.getToken(cacheKey)).toStrictEqual(data);
 
       // Advance the time to just past the expiry..
       provider.mockReturnValue((now + dayInSeconds + 100) * 1000);
 
-      const result = await manager.get(cacheKey);
+      const result = await manager.getToken(cacheKey);
 
       // And test that the cache has been emptied
       expect(result).toBeFalsy();
@@ -583,22 +583,22 @@ cacheFactories.forEach(cacheFactory => {
       await manager.set(entry2);
       await manager.set(entry3);
 
-      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
         entry1
       );
 
-      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
         entry2
       );
 
-      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
         entry3
       );
 
       await manager.clear();
-      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
-      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
-      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toBeFalsy();
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry3))).toBeFalsy();
     });
 
     it('clears only the keys relating to a specific client ID from the cache', async () => {
@@ -610,24 +610,24 @@ cacheFactories.forEach(cacheFactory => {
       await manager.set(entry2);
       await manager.set(entry3);
 
-      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry1))).toStrictEqual(
         entry1
       );
 
-      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry2))).toStrictEqual(
         entry2
       );
 
-      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
         entry3
       );
 
       await manager.clear(TEST_CLIENT_ID);
-      expect(await manager.get(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
-      expect(await manager.get(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry1))).toBeFalsy();
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry2))).toBeFalsy();
 
       // Should not be removed as it has a different client ID from the manager instance
-      expect(await manager.get(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
+      expect(await manager.getToken(CacheKey.fromCacheEntry(entry3))).toStrictEqual(
         entry3
       );
     });
@@ -813,7 +813,7 @@ cacheFactories.forEach(cacheFactory => {
     describe('get', () => {
       describe('when there is nothing in the cache', () => {
         it('returns undefined', async () => {
-          const result = await manager.get(defaultKey);
+          const result = await manager.getToken(defaultKey);
 
           expect(result).toBeFalsy();
         });
@@ -838,7 +838,7 @@ cacheFactories.forEach(cacheFactory => {
             scope: TEST_SCOPES
           });
 
-          const res = await manager.get(key);
+          const res = await manager.getToken(key);
 
           expect(res).toStrictEqual(data);
           expect(manager.getActiveToken).toHaveBeenCalledTimes(1);
@@ -868,7 +868,7 @@ cacheFactories.forEach(cacheFactory => {
             scope: TEST_SCOPES
           });
 
-          const res = await manager.get(key);
+          const res = await manager.getToken(key);
 
           const expectedResult = { refresh_token: TEST_REFRESH_TOKEN };
 
@@ -901,7 +901,7 @@ cacheFactories.forEach(cacheFactory => {
             scope: 'read:user'
           });
 
-          const res = await manager.get(key);
+          const res = await manager.getToken(key);
 
           expect(res).toStrictEqual(data);
           expect(manager.getActiveToken).toHaveBeenCalledTimes(1);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -766,7 +766,7 @@ export class Auth0Client {
 
     await this.loginWithPopup(localOptions, config);
 
-    const cache = await this.cacheManager.get(
+    const cache = await this.cacheManager.getToken(
       new CacheKey({
         scope: localOptions.authorizationParams.scope,
         audience: localOptions.authorizationParams.audience || 'default',
@@ -943,7 +943,7 @@ export class Auth0Client {
       authorizationParams: AuthorizationParams & { scope: string };
     }
   ): Promise<GetTokenSilentlyResult> {
-    const cache = await this.cacheManager.get(
+    const cache = await this.cacheManager.getToken(
       new CacheKey({
         scope: options.authorizationParams.scope,
         audience: options.authorizationParams.audience || 'default',
@@ -1062,7 +1062,7 @@ export class Auth0Client {
     audience: string;
     clientId: string;
   }): Promise<undefined | GetTokenSilentlyVerboseResponse> {
-    const entry = await this.cacheManager.get(
+    const entry = await this.cacheManager.getToken(
       new CacheKey({
         scope,
         audience,

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -45,7 +45,7 @@ export class CacheManager {
     );
 
     if (!entry && cacheKey.scope && cacheKey.audience) {
-      const entryByScope = await this.get(cacheKey);
+      const entryByScope = await this.getToken(cacheKey);
 
       if (!entryByScope) {
         return;
@@ -68,7 +68,7 @@ export class CacheManager {
     return { id_token: entry.id_token, decodedToken: entry.decodedToken };
   }
 
-  async get(
+  async getToken(
     cacheKey: CacheKey,
     options: {
       expiryAdjustmentSeconds: number,


### PR DESCRIPTION
### Changes

In this PR, the `get` method from `cache-manager` has been renamed to `getToken`, which is more descriptive of what this method returns.

⚠️ DO NOT MERGE UNTIL https://github.com/auth0/auth0-spa-js/pull/1371 IS MERGED AND THE BASE BRANCH IS CHANGED TO MAIN

### References

https://auth0team.atlassian.net/browse/DXFL-2037

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines have been run/followed
