### PR TITLE
Add support for Multi-Resource Refresh Tokens

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1806,7 +1806,7 @@ describe('Auth0Client', () => {
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
     });
 
-    it('sends audience and scope the token endpoint when using multi-resource refresh tokens when not using useFormData', async () => {
+    it('sends audience and scope to the token endpoint when using multi-resource refresh tokens when not using useFormData', async () => {
       const auth0 = setup({
         useMultiResourceRefreshTokens: true,
         useFormData: false
@@ -1860,7 +1860,7 @@ describe('Auth0Client', () => {
       expect(access_token).toEqual(TEST_ACCESS_TOKEN);
     });
 
-    it('sends audience and scope the token endpoint when using multi-resource refresh tokens', async () => {
+    it('sends audience and scope to the token endpoint when using multi-resource refresh tokens', async () => {
       const auth0 = setup({
         useMultiResourceRefreshTokens: true
       });

--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -70,7 +70,7 @@ describe('Auth0Client', () => {
   });
 
   describe('logout()', () => {
-    it('removes authenticated cookie from storage', async () => {
+    it.only('removes authenticated cookie from storage', async () => {
       const auth0 = setup();
       await auth0.logout();
 

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -10,7 +10,8 @@ import {
   CacheKey,
   CACHE_KEY_PREFIX,
   DecodedToken,
-  ICache
+  ICache,
+  CACHE_REFRESH_TOKEN_SUFFIX
 } from '../../src/cache/shared';
 
 import {
@@ -785,6 +786,51 @@ cacheFactories.forEach(cacheFactory => {
             '@@user@@'
           ).toKey()
         );
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(result).toBeUndefined();
+
+        cacheSpy.mockClear();
+      });
+    });
+
+    describe('getMultiResourceRefreshToken', () => {
+      const cacheKey = new CacheKey(
+        { clientId: TEST_CLIENT_ID },
+        CACHE_KEY_PREFIX,
+        CACHE_REFRESH_TOKEN_SUFFIX
+      );
+
+      beforeEach(async () => {
+        await manager.clear();
+      });
+
+      it('should read the refresh token from cache if it exists', async () => {
+        await manager.setMultiResourceRefreshToken(
+          defaultData.client_id,
+          'foo'
+        );
+
+        const cacheSpy = jest.spyOn(cache, 'get');
+
+        const result = await manager.getMultiResourceRefreshToken(
+          defaultData.client_id
+        );
+
+        expect(cache.get).toHaveBeenCalledWith(cacheKey.toKey());
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(result).toEqual('foo');
+
+        cacheSpy.mockClear();
+      });
+
+      it('should return undefined if no refresh token exists', async () => {
+        const cacheSpy = jest.spyOn(cache, 'get');
+
+        const result = await manager.getMultiResourceRefreshToken(
+          defaultData.client_id
+        );
+
+        expect(cache.get).toHaveBeenCalledWith(cacheKey.toKey());
         expect(cache.get).toHaveBeenCalledTimes(1);
         expect(result).toBeUndefined();
 

--- a/__tests__/cache/shared.ts
+++ b/__tests__/cache/shared.ts
@@ -10,11 +10,6 @@ export class InMemoryAsyncCacheNoKeys implements ICache {
 
   get<T = Cacheable>(key: string) {
     const cacheEntry = this.cache[key] as T;
-
-    if (!cacheEntry) {
-      return Promise.resolve(null);
-    }
-
     return Promise.resolve(cacheEntry);
   }
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -79,6 +79,14 @@ Cypress.Commands.add('getUser', () => cy.get('[data-cy=profile]'));
 
 Cypress.Commands.add('getError', () => cy.get(`[data-cy=error]`));
 
+Cypress.Commands.add('getAudience', index =>
+  cy.get(index ? `[data-cy=audience-${index}]` : '[data-cy=audience]')
+);
+
+Cypress.Commands.add('getScope', index =>
+  cy.get(index ? `[data-cy=scope-${index}]` : '[data-cy=scope]')
+);
+
 Cypress.Commands.add('getAccessTokens', index =>
   cy.get(index ? `[data-cy=access-token-${index}]` : '[data-cy=access-token]')
 );

--- a/scripts/oidc-provider.js
+++ b/scripts/oidc-provider.js
@@ -86,6 +86,11 @@ const config = {
         };
       }
     };
+  },
+  issueRefreshToken(ctx, client, code) {
+    // Add extra scopes that may be requested during MRRT requests
+    code.scope += ' profile email read:rules read:example';
+    return true;
   }
 };
 

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -9,7 +9,8 @@ import {
   WrappedCacheEntry,
   DecodedToken,
   CACHE_KEY_ID_TOKEN_SUFFIX,
-  IdTokenEntry
+  IdTokenEntry,
+  CACHE_REFRESH_TOKEN_SUFFIX
 } from './shared';
 
 const DEFAULT_EXPIRY_ADJUSTMENT_SECONDS = 0;
@@ -65,6 +66,24 @@ export class CacheManager {
     }
 
     return { id_token: entry.id_token, decodedToken: entry.decodedToken };
+  }
+
+  async setMultiResourceRefreshToken(
+    clientId: string,
+    refreshToken: string
+  ): Promise<void> {
+    await this.cache.set<string>(
+      this.getMultiResourceRefreshTokenCacheKey(clientId),
+      refreshToken
+    );
+  }
+
+  async getMultiResourceRefreshToken(
+    clientId: string
+  ): Promise<string | undefined> {
+    return this.cache.get<string>(
+      this.getMultiResourceRefreshTokenCacheKey(clientId)
+    );
   }
 
   async get(
@@ -171,6 +190,19 @@ export class CacheManager {
       { clientId },
       CACHE_KEY_PREFIX,
       CACHE_KEY_ID_TOKEN_SUFFIX
+    ).toKey();
+  }
+
+  /**
+   * Returns the cache key to be used to store the refresh token when MRRT is enabled
+   * @param clientId The client id used to link to the refresh token
+   * @returns The constructed cache key, as a string, to store the refresh token
+   */
+  private getMultiResourceRefreshTokenCacheKey(clientId: string) {
+    return new CacheKey(
+      { clientId },
+      CACHE_KEY_PREFIX,
+      CACHE_REFRESH_TOKEN_SUFFIX
     ).toKey();
   }
 

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -2,6 +2,7 @@ import { IdToken, User } from '../global';
 
 export const CACHE_KEY_PREFIX = '@@auth0spajs@@';
 export const CACHE_KEY_ID_TOKEN_SUFFIX = '@@user@@';
+export const CACHE_REFRESH_TOKEN_SUFFIX = '@@refresh_token@@';
 
 export type CacheKeyData = {
   audience?: string;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -85,7 +85,7 @@ export class MfaRequiredError extends GenericError {
  * Error thrown when there is no refresh token to use
  */
 export class MissingRefreshTokenError extends GenericError {
-  constructor(public audience: string, public scope: string) {
+  constructor(public audience?: string, public scope?: string) {
     super(
       'missing_refresh_token',
       `Missing Refresh Token (audience: '${valueOrEmptyString(audience, [
@@ -102,6 +102,6 @@ export class MissingRefreshTokenError extends GenericError {
  * @param exclude An array of values that should result in an empty string.
  * @returns The value, or an empty string when falsy or included in the exclude argument.
  */
-function valueOrEmptyString(value: string, exclude: string[] = []) {
+function valueOrEmptyString(value?: string, exclude: string[] = []) {
   return value && !exclude.includes(value) ? value : '';
 }

--- a/src/global.ts
+++ b/src/global.ts
@@ -156,11 +156,20 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
 
   /**
    * If true, refresh tokens are used to fetch new access tokens from the Auth0 server. If false, the legacy technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` is used.
-   * The default setting is `false`.
+   * The default setting is `false`, unless `useMultiResourceRefreshTokens` is `true`, in which case the default setting is `true`.
    *
    * **Note**: Use of refresh tokens must be enabled by an administrator on your Auth0 client application.
    */
   useRefreshTokens?: boolean;
+
+  /**
+   * If true, enables [Multi-Resource Refresh Tokens (MRRT)](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token). Setting this to true implicitly sets `useRefreshTokens` to `true` as well.
+   * The default setting is `false`.
+   *
+   * When enabled, `audience` and `scope` from `authorizationParams` will be sent in refresh token requests, allowing retrieval of access tokens for multiple APIs using a single refresh token.
+   * Additionally, cached refresh tokens will be tied only to the client ID, as opposed to a combination of client ID, audience, and scope.
+   */
+  useMultiResourceRefreshTokens?: boolean;
 
   /**
    * If true, fallback to the technique of using a hidden iframe and the `authorization_code` grant with `prompt=none` when unable to use refresh tokens. If false, the iframe fallback is not used and
@@ -264,10 +273,10 @@ export interface Auth0ClientOptions extends BaseLoginOptions {
 
   /**
    * If provided, the SDK will load the token worker from this URL instead of the integrated `blob`. An example of when this is useful is if you have strict
-   * Content-Security-Policy (CSP) and wish to avoid needing to set `worker-src: blob:`. We recommend either serving the worker, which you can find in the module 
-   * at `<module_path>/dist/auth0-spa-js.worker.production.js`, from the same host as your application or using the Auth0 CDN 
+   * Content-Security-Policy (CSP) and wish to avoid needing to set `worker-src: blob:`. We recommend either serving the worker, which you can find in the module
+   * at `<module_path>/dist/auth0-spa-js.worker.production.js`, from the same host as your application or using the Auth0 CDN
    * `https://cdn.auth0.com/js/auth0-spa-js/<version>/auth0-spa-js.worker.production.js`.
-   * 
+   *
    * **Note**: The worker is only used when `useRefreshTokens: true`, `cacheLocation: 'memory'`, and the `cache` is not custom.
    */
   workerUrl?: string;
@@ -527,6 +536,7 @@ export interface TokenEndpointOptions {
   timeout?: number;
   auth0Client: any;
   useFormData?: boolean;
+  useMultiResourceRefreshTokens?: boolean;
   [key: string]: any;
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -49,8 +49,8 @@ const fetchWithoutWorker = async (
 
 const fetchWithWorker = async (
   fetchUrl: string,
-  audience: string,
-  scope: string,
+  audience: string | undefined,
+  scope: string | undefined,
   fetchOptions: FetchOptions,
   timeout: number,
   worker: Worker,
@@ -73,8 +73,8 @@ const fetchWithWorker = async (
 
 export const switchFetch = async (
   fetchUrl: string,
-  audience: string,
-  scope: string,
+  audience: string | undefined,
+  scope: string | undefined,
   fetchOptions: FetchOptions,
   worker?: Worker,
   useFormData?: boolean,
@@ -98,8 +98,8 @@ export const switchFetch = async (
 export async function getJSON<T>(
   url: string,
   timeout: number | undefined,
-  audience: string,
-  scope: string,
+  audience: string | undefined,
+  scope: string | undefined,
   options: FetchOptions,
   worker?: Worker,
   useFormData?: boolean

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -4,19 +4,24 @@ import { WorkerRefreshTokenMessage } from './worker.types';
 
 let refreshTokens: Record<string, string> = {};
 
-const cacheKey = (audience: string, scope: string) => `${audience}|${scope}`;
+const cacheKey = (audience: string | undefined, scope: string | undefined) =>
+  audience === undefined ? 'global' : `${audience}|${scope}`;
 
-const getRefreshToken = (audience: string, scope: string) =>
-  refreshTokens[cacheKey(audience, scope)];
+const getRefreshToken = (
+  audience: string | undefined,
+  scope: string | undefined
+) => refreshTokens[cacheKey(audience, scope)];
 
 const setRefreshToken = (
   refreshToken: string,
-  audience: string,
-  scope: string
+  audience: string | undefined,
+  scope: string | undefined
 ) => (refreshTokens[cacheKey(audience, scope)] = refreshToken);
 
-const deleteRefreshToken = (audience: string, scope: string) =>
-  delete refreshTokens[cacheKey(audience, scope)];
+const deleteRefreshToken = (
+  audience: string | undefined,
+  scope: string | undefined
+) => delete refreshTokens[cacheKey(audience, scope)];
 
 const wait = (time: number) =>
   new Promise(resolve => setTimeout(resolve, time));

--- a/src/worker/worker.types.ts
+++ b/src/worker/worker.types.ts
@@ -9,7 +9,7 @@ export type WorkerRefreshTokenMessage = {
   fetchOptions: FetchOptions;
   useFormData?: boolean;
   auth: {
-    audience: string;
-    scope: string;
+    audience: string | undefined;
+    scope: string | undefined;
   };
 };

--- a/static/index.html
+++ b/static/index.html
@@ -94,7 +94,9 @@
         <div v-for="current in scopesWithSuffix">
           <div class="card mb-3 bg-light">
             <div class="card-header">
-              <strong>{{current.audience || 'default'}}</strong>
+              <strong :data-cy="'audience' + current.suffix"
+                >{{current.audience || 'default'}}</strong
+              >
               <span
                 v-for="s of current.scope.split(' ')"
                 class="badge badge-success ml-1"
@@ -345,6 +347,7 @@
                 class="custom-control-input"
                 id="refresh_token_switch"
                 v-model="useRefreshTokens"
+                :disabled="useMultiResourceRefreshTokens"
               />
               <label
                 for="refresh_token_switch"
@@ -566,6 +569,12 @@
           initializeClient: function () {
             var _self = this;
 
+            if (_self.useMultiResourceRefreshTokens) {
+              // Enabling useMultiResourceRefreshTokens implicitly enables useRefreshToken in the
+              // client, so update our state to match this behavior.
+              _self.useRefreshTokens = true;
+            }
+
             var clientOptions = {
               domain: _self.domain,
               clientId: _self.clientId,
@@ -660,8 +669,8 @@
             this.useLocalStorage = false;
             this.useCustomStorage = false;
             this.useRefreshTokens = false;
-            (this.useMultiResourceRefreshTokens = false),
-              (this.useCache = true);
+            this.useMultiResourceRefreshTokens = false;
+            this.useCache = true;
             this.audience = defaultAudience;
             this.useConstructor = false;
             this.useCookiesForTransactions = false;

--- a/static/index.html
+++ b/static/index.html
@@ -139,7 +139,7 @@
                   <ul v-for="token in current.access_tokens">
                     <li :data-cy="'access-token' + current.suffix">
                       {{token | concat}} (<a
-                        :href="'https://jwt.io?token=' + token"
+                        :href="'https://jwt.io#token=' + token"
                         target="_blank"
                         >view</a
                       >)
@@ -358,6 +358,21 @@
               <input
                 type="checkbox"
                 class="custom-control-input"
+                id="multi_resource_refresh_token_switch"
+                v-model="useMultiResourceRefreshTokens"
+              />
+              <label
+                for="multi_resource_refresh_token_switch"
+                class="custom-control-label"
+                data-cy="switch-multi-resource-refresh-tokens"
+                >Use multi-resource refresh tokens</label
+              >
+            </div>
+
+            <div class="custom-control custom-switch mb-5">
+              <input
+                type="checkbox"
+                class="custom-control-input"
                 id="constructor-switch"
                 v-model="useConstructor"
               />
@@ -454,6 +469,8 @@
             useLocalStorage: data.useLocalStorage || false,
             useCustomStorage: data.useCustomStorage || false,
             useRefreshTokens: data.useRefreshTokens || false,
+            useMultiResourceRefreshTokens:
+              data.useMultiResourceRefreshTokens || false,
             useCache: data.useCache === false ? false : true,
             useConstructor: data.useConstructor === false ? false : true,
             useCookiesForTransactions: data.useCookiesForTransactions || false,
@@ -482,6 +499,11 @@
                     : 'https://' + data.domain + '/api/v2/',
                 scope: 'read:rules',
                 access_tokens: []
+              },
+              {
+                audience: 'https://test-api.example.com',
+                scope: 'read:example',
+                access_tokens: []
               }
             ],
             error: null
@@ -500,6 +522,10 @@
             this.saveForm();
           },
           useRefreshTokens: function () {
+            this.initializeClient();
+            this.saveForm();
+          },
+          useMultiResourceRefreshTokens: function () {
             this.initializeClient();
             this.saveForm();
           },
@@ -526,7 +552,7 @@
           useWorkerUrl: function () {
             this.initializeClient();
             this.saveForm();
-          },
+          }
         },
         computed: {
           scopesWithSuffix: function () {
@@ -545,10 +571,14 @@
               clientId: _self.clientId,
               cacheLocation: _self.useLocalStorage ? 'localstorage' : 'memory',
               useRefreshTokens: _self.useRefreshTokens,
+              useMultiResourceRefreshTokens:
+                _self.useMultiResourceRefreshTokens,
               useCookiesForTransactions: _self.useCookiesForTransactions,
               useFormData: _self.useFormData,
               useRefreshTokensFallback: _self.useRefreshTokensFallback,
-              workerUrl: _self.useWorkerUrl ? '/auth0-spa-js.worker.development.js' : undefined,
+              workerUrl: _self.useWorkerUrl
+                ? '/auth0-spa-js.worker.development.js'
+                : undefined,
               authorizationParams: {
                 redirect_uri: window.location.origin
               }
@@ -610,13 +640,15 @@
                 useLocalStorage: this.useLocalStorage,
                 useCustomStorage: this.useCustomStorage,
                 useRefreshTokens: this.useRefreshTokens,
+                useMultiResourceRefreshTokens:
+                  this.useMultiResourceRefreshTokens,
                 useConstructor: this.useConstructor,
                 useCookiesForTransactions: this.useCookiesForTransactions,
                 useCache: this.useCache,
                 useFormData: this.useFormData,
                 useOrgAtLogin: this.useOrgAtLogin,
                 useRefreshTokensFallback: this.useRefreshTokensFallback,
-                useWorkerUrl: this.useWorkerUrl,
+                useWorkerUrl: this.useWorkerUrl
               })
             );
 
@@ -628,7 +660,8 @@
             this.useLocalStorage = false;
             this.useCustomStorage = false;
             this.useRefreshTokens = false;
-            this.useCache = true;
+            (this.useMultiResourceRefreshTokens = false),
+              (this.useCache = true);
             this.audience = defaultAudience;
             this.useConstructor = false;
             this.useCookiesForTransactions = false;


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

This PR will add support for [Multi-Resource Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token).

- Adds the `useMultiResourceRefreshTokens` option to `Auth0ClientOptions`
  - Enabling this will implicitly enable `useRefreshTokens`
- When MRRT is enabled:
  - The refresh token is stored in the cache under its own key, tied only to the client ID, instead of being tied to a combination of client ID, audience, and scope.
    - When using the web worker, the refresh token is stored under the `"global"` cache key inside the worker. Since each `Auth0Client` has its own separate worker instance, the refresh tokens are still scoped to each client instance.
  - This shared refresh token is used for all `getTokenSilently` requests on the client. These requests will now include the `audience` and `scope` from `authorizationParams` in the `/oauth/token` request, allowing users to request tokens for different APIs.
- This is **not** a breaking change. The behaviour when `useMultiResourceRefreshTokens` is `false` (the default) is unchanged.

### NOTE: Multi-Resource Refresh Tokens are currently in early access and are not available on all Auth0 tenants

### References
<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

- Multi-Resource Refresh Token Documentation: https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token
- Fixes #1379

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

1. Enable MRRT on your Auth0 Tenant (you will need to reach out to Auth0 for this)
2. Configure the refresh token policies on your client to allow MRRT (see [here](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token#configure-applications-for-mrrt))
3. Create an `Auth0Client` with the `useMultiResourceRefreshTokens` config option set to `true`
4. Try retrieving multiple access tokens using `getTokenSilently` and passing different `audience` and `scope` values in the `authorizationParams`.

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
