### PR TITLE
Support isAuthorized method

### DIFF
--- a/__tests__/Auth0Client/isAuthorized.test.ts
+++ b/__tests__/Auth0Client/isAuthorized.test.ts
@@ -1,0 +1,149 @@
+import { expect } from '@jest/globals';
+import { MessageChannel } from 'worker_threads';
+import { verify } from '../../src/jwt';
+import * as scope from '../../src/scope';
+import * as utils from '../../src/utils';
+
+import { loginWithPopupFn, loginWithRedirectFn, setupFn } from './helpers';
+
+import { checkScopesInToken } from '../../src/Auth0Client.utils';
+import { TEST_ACCESS_TOKEN, TEST_CODE_CHALLENGE } from '../constants';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+jest.mock('../../src/Auth0Client.utils', () => {
+    const originalModule = jest.requireActual('../../src/Auth0Client.utils');
+    return {
+        ...originalModule,
+        checkScopesInToken: jest.fn()
+    };
+});
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+    .spyOn(utils, 'bufferToBase64UrlEncoded')
+    .mockReturnValue(TEST_CODE_CHALLENGE);
+
+jest.spyOn(utils, 'runPopup');
+
+const setup = setupFn(mockVerify);
+
+describe('Auth0Client', () => {
+    const oldWindowLocation = window.location;
+
+    beforeEach(() => {
+        // https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
+        delete window.location;
+        window.location = Object.defineProperties(
+            {},
+            {
+                ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+                assign: {
+                    configurable: true,
+                    value: jest.fn()
+                }
+            }
+        ) as Location;
+        // --
+
+        mockWindow.open = jest.fn();
+        mockWindow.addEventListener = jest.fn();
+
+        mockWindow.crypto = {
+            subtle: {
+                digest: () => 'foo'
+            },
+            getRandomValues() {
+                return '123';
+            }
+        };
+
+        mockWindow.MessageChannel = MessageChannel;
+        mockWindow.Worker = {};
+
+        jest.spyOn(scope, 'getUniqueScopes');
+
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        mockFetch.mockReset();
+        jest.clearAllMocks();
+        window.location = oldWindowLocation;
+    });
+
+    describe('requireAuth', () => {
+        it('redirects to login if not authenticated', async () => {
+            const auth0 = setup();
+
+            jest.spyOn(auth0, 'isAuthenticated').mockResolvedValue(false);
+            jest.spyOn(auth0, 'loginWithRedirect').mockResolvedValue(undefined);
+
+            const result = await auth0.isAuthorized({
+                audience: 'test-audience',
+                scope: 'test-scope',
+                redirectTo: '/test'
+            });
+
+            expect(auth0.isAuthenticated).toHaveBeenCalled();
+            expect(auth0.loginWithRedirect).toHaveBeenCalledWith({
+                authorizationParams: { audience: 'test-audience', scope: 'test-scope' },
+                appState: { targetUrl: '/test' }
+            });
+            expect(result).toBe(false);
+        });
+
+        it('returns true if authenticated and token is valid', async () => {
+            const auth0 = setup();
+
+            jest.spyOn(auth0, 'isAuthenticated').mockResolvedValue(true);
+            jest.spyOn(auth0, 'getTokenSilently').mockResolvedValue(TEST_ACCESS_TOKEN);
+            jest.spyOn(auth0, 'loginWithRedirect').mockImplementation(() => Promise.resolve());
+            const checkScopesInTokenMock = jest.spyOn(require('../../src/Auth0Client.utils'), 'checkScopesInToken');
+            checkScopesInTokenMock.mockReturnValue(true);
+
+            const result = await auth0.isAuthorized({ scope: 'test-scope' });
+
+            expect(auth0.isAuthenticated).toHaveBeenCalled();
+            expect(auth0.loginWithRedirect).not.toHaveBeenCalled();
+            expect(auth0.getTokenSilently).toHaveBeenCalledWith({
+                authorizationParams: { scope: 'test-scope' }
+            });
+            expect(checkScopesInTokenMock).toHaveBeenCalledWith(TEST_ACCESS_TOKEN, 'test-scope');
+            expect(result).toBe(true);
+        });
+
+        it('returns false if token does not include required scopes', async () => {
+            const auth0 = setup();
+
+            jest.spyOn(auth0, 'isAuthenticated').mockResolvedValue(true);
+            jest.spyOn(auth0, 'getTokenSilently').mockResolvedValue(TEST_ACCESS_TOKEN);
+            (checkScopesInToken as jest.Mock).mockReturnValue(false);
+
+            const result = await auth0.isAuthorized({ scope: 'missing-scope' });
+
+            expect(auth0.getTokenSilently).toHaveBeenCalledWith({
+                authorizationParams: { scope: 'missing-scope' }
+            });
+            expect(checkScopesInToken).toHaveBeenCalledWith(TEST_ACCESS_TOKEN, 'missing-scope');
+            expect(result).toBe(false);
+        });
+
+        it('returns false if an error occurs during token retrieval', async () => {
+            const auth0 = setup();
+
+            jest.spyOn(auth0, 'isAuthenticated').mockResolvedValue(true);
+            jest.spyOn(auth0, 'getTokenSilently').mockRejectedValue(new Error('Token error'));
+
+            const result = await auth0.isAuthorized({ scope: 'test-scope' });
+
+            expect(auth0.getTokenSilently).toHaveBeenCalledWith({
+                authorizationParams: { scope: 'test-scope' }
+            });
+            expect(result).toBe(false);
+        });
+    })
+});

--- a/__tests__/Auth0ClientUtils/checkScopesInToken.test.ts
+++ b/__tests__/Auth0ClientUtils/checkScopesInToken.test.ts
@@ -1,0 +1,37 @@
+import { checkScopesInToken } from '../../src/Auth0Client.utils';
+import { TEST_ACCESS_TOKEN, TEST_SCOPES } from '../constants';
+
+const createMockToken = (scopes: string): string => {
+    const payload = { scope: scopes };
+    const base64Payload = Buffer.from(JSON.stringify(payload)).toString('base64');
+    return `header.${base64Payload}.signature`;
+};
+
+describe('checkScopesInToken', () => {
+    it('returns true if all required scopes are present in the token', () => {
+        const token = createMockToken(`${TEST_SCOPES} another-scope`);
+        const requiredScope = `${TEST_SCOPES} another-scope`;
+
+        const result = checkScopesInToken(token, requiredScope);
+
+        expect(result).toBe(true);
+    });
+
+    it('returns false if any required scope is missing from the token', () => {
+        const token = createMockToken(TEST_SCOPES);
+        const requiredScope = `${TEST_SCOPES} missing-scope`;
+
+        const result = checkScopesInToken(token, requiredScope);
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false if the token is invalid', () => {
+        const token = TEST_ACCESS_TOKEN
+        const requiredScope = TEST_SCOPES;
+
+        const result = checkScopesInToken(token, requiredScope);
+
+        expect(result).toBe(false);
+    });
+});

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -6,6 +6,7 @@ import {
   LogoutOptions
 } from './global';
 import { getUniqueScopes } from './scope';
+import { urlDecodeB64 } from './utils';
 
 /**
  * @ignore
@@ -73,6 +74,23 @@ export const getAuthorizeParams = (
     code_challenge,
     code_challenge_method: 'S256'
   };
+};
+
+/**
+ * @ignore
+ */
+export const checkScopesInToken = (token: string, requiredScope: string): boolean => {
+  if (!requiredScope) return true;
+  try {
+    const payload = JSON.parse(urlDecodeB64(token.split('.')[1]));
+    const tokenScopes = (payload.scope || '').split(' ').filter(Boolean);
+    const requiredScopes = requiredScope.split(' ').filter(Boolean);
+
+    return requiredScopes.every(scope => tokenScopes.includes(scope));
+  } catch (error) {
+    console.warn("Error validating scopes in token:", error);
+    return false;
+  }
 };
 
 /**


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes
This PR introduces a new `isAuthorized` method to the Auth0Client that provides a way to check user authentication status and validate token scopes in a single call. This method is particularly useful for protecting routes or resources that require specific permissions.

Example of usage: 
```
// Protect a route that requires specific scopes
async function protectAdminRoute() {
  const isAuthorized = await auth0.isAuthorized({
    audience: 'https://api.example.com',
    scope: 'admin:users admin:settings',
    redirectTo: '/admin/dashboard' // Redirect here after login
  });
  
  if (!isAuthorized) {
    // User will be redirected to login if not authenticated
    // or this method returns false if they lack required scopes
    return;
  }
  
  // Continue with admin functionality
  loadAdminDashboard();
}
```

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->
**Prerequisites:**
- Auth0 tenant with configured application
- Test users with different permission levels
- API configured with scopes in Auth0 Dashboard
- Demo app with auth0-spa-js installed 

**Test scenarios:**
**1. Unauthenticated User - Automatic Redirect**
<details><summary>Code Example</summary>
<p>

```javascript
// Test with unauthenticated user
await auth0.logout();
const result = await auth0.isAuthorized({
  audience: 'https://api.example.com',
  scope: 'read:profile'
});
```

</p>
</details>

<details><summary>Expected Behaviour</summary>
<p>

- User should be redirected to Auth0 login page
- Method returns `false`
- After login, user should be redirected back with `targetUrl` preserved

</p>
</details>

**2. Authenticated User with Sufficient Scopes**
<details><summary>Code Example</summary>
<p>

```javascript
// Login first with required scopes
await auth0.loginWithRedirect({
  authorizationParams: {
    audience: 'https://api.example.com',
    scope: 'openid profile email read:profile write:profile'
  }
});

// Test authorization check
const result = await auth0.isAuthorized({
  audience: 'https://api.example.com',
  scope: 'read:profile write:profile'
});
```

</p>
</details>

<details><summary>Expected Behaviour</summary>
<p>

- Method returns `true`
- No redirect occurs
- User remains on current page

</p>
</details>

**3. Authenticated User with Insufficient Scopes**
<details><summary>Code Example</summary>
<p>

```javascript
// Login with limited scopes
await auth0.loginWithRedirect({
  authorizationParams: {
    audience: 'https://api.example.com',
    scope: 'openid profile email read:profile'
  }
});

// Test with higher scope requirements
const result = await auth0.isAuthorized({
  audience: 'https://api.example.com',
  scope: 'read:profile write:profile admin:users'
});
```

</p>
</details>

<details><summary>Expected Behaviour</summary>
<p>

- Method returns `false`
- No redirect occurs (user is authenticated)
- User can continue using the application

</p>
</details>

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
