### PR TITLE
fix: move runtime dependencies from devDependencies to dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Run framework tests
         uses: ./.github/actions/framework
         with:
-          node: 20
+          node: ${{ env.NODE_VERSION }}
           cache: ${{ env.CACHE_KEY }}
           install: |
             npx -p @vue/cli vue create my-app -d --packageManager npm  < /dev/null
@@ -164,6 +164,6 @@ jobs:
           install: |
             npx -p @angular/cli ng new my-app --defaults=true < /dev/null
           content: |
-            echo -e "$AUTH0_CONTENT" > src/auth0.ts;
+            echo -e "${{ env.AUTH0_CONTENT }}" > src/auth0.js;
           import: |
             echo -e "${{ env.IMPORT_STATEMENT }}"|cat - src/main.ts > /tmp/out && mv /tmp/out src/main.ts;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "@auth0/auth0-spa-js",
       "version": "2.4.0",
       "license": "MIT",
+      "dependencies": {
+        "browser-tabs-lock": "^1.2.15",
+        "dpop": "^2.1.1",
+        "es-cookie": "~1.3.2"
+      },
       "devDependencies": {
         "@auth0/component-cdn-uploader": "^2.2.2",
         "@rollup/plugin-replace": "^4.0.0",
@@ -15,14 +20,11 @@
         "@types/jest": "^28.1.7",
         "@typescript-eslint/eslint-plugin-tslint": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
-        "browser-tabs-lock": "^1.2.15",
         "browserstack-cypress-cli": "1.32.8",
         "cli-table": "^0.3.6",
         "concurrently": "^7.3.0",
         "cypress": "13.17.0",
-        "dpop": "^2.1.1",
         "es-check": "^7.0.1",
-        "es-cookie": "~1.3.2",
         "eslint": "^8.22.0",
         "eslint-plugin-security": "^1.5.0",
         "fake-indexeddb": "^6.0.1",
@@ -3009,7 +3011,6 @@
     },
     "node_modules/browser-tabs-lock": {
       "version": "1.3.0",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5123,7 +5124,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
       "integrity": "sha512-J0Of2JTiM4h5si0tlbPQ/lkqfZ5wAEVkKYBhkwyyANnPJfWH4VsR5uIkZ+T+OSPIwDYUg1fbd5Mmodd25HjY1w==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -5402,7 +5402,6 @@
     },
     "node_modules/es-cookie": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-define-property": {
@@ -9951,7 +9950,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
       ]
     }
   },
+  "dependencies": {
+    "browser-tabs-lock": "^1.2.15",
+    "dpop": "^2.1.1",
+    "es-cookie": "~1.3.2"
+  },
   "scripts": {
     "dev": "rimraf dist && rollup -c --watch",
     "start": "npm run dev",
@@ -54,14 +59,11 @@
     "@types/jest": "^28.1.7",
     "@typescript-eslint/eslint-plugin-tslint": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
-    "browser-tabs-lock": "^1.2.15",
     "browserstack-cypress-cli": "1.32.8",
     "cli-table": "^0.3.6",
     "concurrently": "^7.3.0",
-    "dpop": "^2.1.1",
     "cypress": "13.17.0",
     "es-check": "^7.0.1",
-    "es-cookie": "~1.3.2",
     "eslint": "^8.22.0",
     "eslint-plugin-security": "^1.5.0",
     "fake-indexeddb": "^6.0.1",


### PR DESCRIPTION
### 🔄 Changes
- This PR fixes the issue mentioned in https://github.com/auth0/auth0-spa-js/issues/1410
- Move `dpop`, `browser-tabs-lock`, and `es-cookie`  back to dependencies
- Maintained the bundling behavior from #971 (no rollup externals)



PR #971 successfully implemented dependency bundling but placed runtime dependencies in devDependencies. This potentially introduced TypeScript compilation failures for users because published type definitions reference modules that aren't installed. Also it's more semantically accurate to keep run time dependencies under dependencies property

### 🧪 Testing
- The changes were verified by ensuring that the application builds and runs correctly after the modifications.

### 💥 Impact
- This change ensures that the necessary runtime dependencies are correctly installed. 

### 📋 Checklist
- [x] Code follows the project's coding standards
- [ ] Tests have been added/updated
- [ ] Documentation has been updated
- [x] All tests are passing