### PR TITLE
Make Fetcher to be Scope- and Audience-Aware

### DIFF
--- a/__tests__/fetcher.test.ts
+++ b/__tests__/fetcher.test.ts
@@ -485,7 +485,10 @@ describe('Fetcher', () => {
       });
 
       it('request is prepared', () =>
-        expect(fetcher['prepareRequest']).toHaveBeenCalledWith(request));
+        expect(fetcher['prepareRequest']).toHaveBeenCalledWith(
+          request,
+          undefined
+        ));
 
       it('calls fetch() properly', () =>
         expect(fetcher['config']['fetch']).toHaveBeenCalledWith(request));
@@ -537,6 +540,43 @@ describe('Fetcher', () => {
 
       it('returns the second response', () =>
         expect(output).toBe(secondResponse));
+    });
+
+    describe('when scope and audience is passed', () => {
+      const existingToken = 'existing-token-123';
+      const getAccessTokenMock = jest.fn().mockResolvedValue(TEST_ACCESS_TOKEN);
+      const fetcher = newTestFetcher({
+        getAccessToken: getAccessTokenMock
+      });
+      const request = new Request('https://example.com', {
+        headers: { authorization: `Bearer ${existingToken}` }
+      });
+
+      beforeEach(() => {
+        fetcher['setAuthorizationHeader'] = jest.fn();
+        fetcher['setDpopProofHeader'] = jest.fn();
+      });
+
+      beforeEach(() =>
+        fetcher.fetchWithAuth(request, undefined, {
+          scope: ['<scope>'],
+          audience: '<audience>'
+        })
+      );
+
+      it('does call getAccessToken', async () => {
+        await fetcher.fetchWithAuth(request, undefined, {
+          scope: ['<scope>'],
+          audience: '<audience>'
+        });
+
+        expect(getAccessTokenMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            scope: ['<scope>'],
+            audience: '<audience>'
+          })
+        );
+      });
     });
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1298,7 +1298,7 @@ export class Auth0Client {
    * This is a drop-in replacement for the Fetch API's `fetch()` method, but will
    * handle certain authentication logic for you, like building the proper auth
    * headers or managing DPoP nonces and retries automatically.
-   * 
+   *
    * Check the `EXAMPLES.md` file for a deeper look into this method.
    */
   public createFetcher<TOutput extends CustomFetchMinimalOutput = Response>(
@@ -1312,7 +1312,13 @@ export class Auth0Client {
 
     return new Fetcher(config, {
       isDpopEnabled: () => !!this.options.useDpop,
-      getAccessToken: () => this.getTokenSilently(),
+      getAccessToken: authParams =>
+        this.getTokenSilently({
+          authorizationParams: {
+            scope: authParams?.scope?.join(' '),
+            audience: authParams?.audience
+          }
+        }),
       getDpopNonce: () => this.getDpopNonce(config.dpopNonceId),
       setDpopNonce: nonce => this.setDpopNonce(nonce),
       generateDpopProof: params => this.generateDpopProof(params)


### PR DESCRIPTION
### Changes

We should ensure we can pass `scope` and `audience` to `fetchWithAuth`, and ensure it gets passed-through to `getAccessToken` so that it can be used to figure out what token should be requested.

### References

N/A

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
