### PR TITLE
feat: add public API to register plugins

### DIFF
--- a/__tests__/Auth0Client/installPlugin.test.ts
+++ b/__tests__/Auth0Client/installPlugin.test.ts
@@ -1,0 +1,119 @@
+import { expect } from '@jest/globals';
+
+// @ts-ignore
+import { Auth0Client } from '../../src';
+
+const mockWindow = <any>global;
+
+describe('Auth0Client', () => {
+  beforeEach(() => {
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('installPlugin', () => {
+    it('returns register a plugin', async () => {
+      const auth0 = new Auth0Client({
+        domain: 'test',
+        clientId: 'test'
+      });
+      const auth0WithPlugin = auth0.installPlugin({
+        name: 'test',
+        install: () => ({
+          bar: () => 'bar'
+        })
+      });
+
+      expect(auth0WithPlugin.bar()).toBe('bar');
+    });
+
+    it('should not allow overriding existing properties', async () => {
+      const auth0 = new Auth0Client({
+        domain: 'test',
+        clientId: 'test'
+      });
+
+      expect(() =>
+        auth0.installPlugin({
+          name: 'test',
+          install: () =>
+            ({
+              scope: 'foo'
+            } as any)
+        })
+      ).toThrow();
+    });
+
+    it('should not allow overriding existing methods', async () => {
+      const auth0 = new Auth0Client({
+        domain: 'test',
+        clientId: 'test'
+      });
+
+      expect(() =>
+        auth0.installPlugin({
+          name: 'test',
+          install: () => ({
+            loginWithRedirect: () => 'foo'
+          })
+        })
+      ).toThrow();
+    });
+
+    it('should not allow overriding the same method twice', async () => {
+      const auth0 = new Auth0Client({
+        domain: 'test',
+        clientId: 'test'
+      });
+
+      auth0.installPlugin({
+        name: 'test',
+        install: () => ({
+          foo: () => 'foo'
+        })
+      });
+
+      expect(() =>
+        auth0.installPlugin({
+          name: 'test2',
+          install: () => ({
+            foo: () => 'bar'
+          })
+        })
+      ).toThrow();
+    });
+
+    it('should not allow overriding the same property twice', async () => {
+      const auth0 = new Auth0Client({
+        domain: 'test',
+        clientId: 'test'
+      });
+
+      auth0.installPlugin({
+        name: 'test',
+        install: () => ({
+          foo: 'foo'
+        })
+      });
+
+      expect(() =>
+        auth0.installPlugin({
+          name: 'test2',
+          install: () => ({
+            foo: 'bar'
+          })
+        })
+      ).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
### Changes

This PR adds the initial infrastructure to be able to register plugins into the Auth0Client instance.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines have been run/followed
