### PR TITLE
fix: update permissions for claude-review job to allow write access to contents

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   claude-review:
     permissions:
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
       id-token: write


### PR DESCRIPTION
## 📝 Pull Request Description

### 🔄 Changes
- The permissions for the claude-review job were updated.
- Write access to contents was granted to the claude-review job.
- This change allows the job to write to the repository's contents.

### 💥 Impact
- This change allows Claude to make changes to the codebase during the review process.
- The system will now allow Claude to make suggested changes directly.
- There is no performance impact expected from this change.

### 📋 Checklist
- [ ] Code follows the project's coding standards
- [ ] Tests have been added/updated
- [ ] Documentation has been updated
- [ ] All tests are passing