### PR TITLE
Fetcher should set DPoP nonce with nonce id

### DIFF
--- a/__tests__/Auth0Client/createFetcher.test.ts
+++ b/__tests__/Auth0Client/createFetcher.test.ts
@@ -1,0 +1,49 @@
+import { Auth0Client } from '../../src/Auth0Client';
+import 'fake-indexeddb/auto';
+
+(<any>global).crypto = { subtle: {} };
+
+describe('Auth0Client', () => {
+  let client: Auth0Client;
+
+  beforeEach(() => {
+    client = new Auth0Client({
+      domain: 'test.auth0.com',
+      clientId: 'abc123',
+      useDpop: true
+    });
+  });
+
+  describe('createFetcher', () => {
+    it('retries with dpop nonce in JWT payload after 401 with dpop-nonce header', async () => {
+      const mockFetch = jest.fn();
+      mockFetch.mockImplementationOnce(async () => {
+          return {
+            status: 401,
+            headers: Object.entries({
+              'dpop-nonce': 'test-nonce',
+              'www-authenticate': `DPoP error="use_dpop_nonce"`
+            })
+          };
+      });
+      mockFetch.mockImplementationOnce(async () => {
+        return {
+          status: 200,
+          headers: { get: () => undefined },
+        };
+      });
+      (client as any).generateDpopProof = jest.fn().mockReturnValue('proof');
+      const fetcher = client.createFetcher({
+        dpopNonceId: 'nonce-id',
+        getAccessToken: jest.fn().mockReturnValue('at'),
+        fetch: mockFetch,
+      });
+
+      await fetcher.fetchWithAuth('https://api.example.com/data');
+
+      const retry = (client as any).generateDpopProof.mock.calls[1][0];
+      expect(retry.nonce).toBe('test-nonce');
+    });
+  });
+
+});

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1385,7 +1385,7 @@ export class Auth0Client {
           }
         }),
       getDpopNonce: () => this.getDpopNonce(config.dpopNonceId),
-      setDpopNonce: nonce => this.setDpopNonce(nonce),
+      setDpopNonce: nonce => this.setDpopNonce(nonce, config.dpopNonceId),
       generateDpopProof: params => this.generateDpopProof(params)
     });
   }


### PR DESCRIPTION
### Changes

I noticed the fetcher wasn't saving the dpop nonce for the correct nonce id

### Testing

Follow the example here https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#using-dpop-in-your-own-requests

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines have been run/followed
