### PR TITLE
Change error message when there are missing scopes after a refresh with MRRT

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -38,6 +38,7 @@ import {
   ConnectError,
   GenericError,
   MissingRefreshTokenError,
+  MissingScopesError,
   TimeoutError
 } from './errors';
 
@@ -98,7 +99,8 @@ import {
   patchOpenUrlWithOnRedirect,
   getScopeToRequest,
   allScopesAreIncluded,
-  isRefreshWithMrrt
+  isRefreshWithMrrt,
+  getMissingScopes
 } from './Auth0Client.utils';
 import { CustomTokenExchangeOptions } from './TokenExchange';
 import { Dpop } from './dpop/dpop';
@@ -1176,9 +1178,14 @@ export class Auth0Client {
               return await this._getTokenFromIFrame(options);
             }
 
-            throw new MissingRefreshTokenError(
+            const missingScopes = getMissingScopes(
+              scopesToRequest,
+              tokenResult.scope,
+            );
+
+            throw new MissingScopesError(
               options.authorizationParams.audience || 'default',
-              options.authorizationParams.scope,
+              missingScopes,
             );
           }
         }
@@ -1534,7 +1541,7 @@ export class Auth0Client {
       connection,
       authorization_params,
       redirectUri = this.options.authorizationParams.redirect_uri ||
-        window.location.origin
+      window.location.origin
     } = options;
 
     if (!connection) {

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -110,6 +110,20 @@ export const allScopesAreIncluded = (scopeToInclude?: string, scopes?: string): 
 
 /**
  * @ignore
+ * 
+ * Returns the scopes that are missing after a refresh
+ */
+export const getMissingScopes = (requestedScope?: string, respondedScope?: string): string => {
+  const requestedScopes = requestedScope?.split(" ") || [];
+  const respondedScopes = respondedScope?.split(" ") || [];
+
+  const missingScopes = requestedScopes.filter((scope) => respondedScopes.indexOf(scope) == -1);
+
+  return missingScopes.join(",");
+}
+
+/**
+ * @ignore
  *
  * For backward compatibility we are going to check if we are going to downscope while doing a refresh request
  * while MRRT is allowed. If the audience is the same for the refresh_token we are going to use and it has

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -115,6 +115,21 @@ export class MissingRefreshTokenError extends GenericError {
 }
 
 /**
+ * Error thrown when there are missing scopes after refreshing a token
+ */
+export class MissingScopesError extends GenericError {
+  constructor(public audience: string, public scope: string) {
+    super(
+      'missing_scopes',
+      `Missing requested scopes after refresh (audience: '${valueOrEmptyString(audience, [
+        'default'
+      ])}', missing scope: '${valueOrEmptyString(scope)}')`
+    );
+    Object.setPrototypeOf(this, MissingScopesError.prototype);
+  }
+}
+
+/**
  * Error thrown when the wrong DPoP nonce is used and a potential subsequent retry wasn't able to fix it.
  */
 export class UseDpopNonceError extends GenericError {


### PR DESCRIPTION

### Changes

The error message has changed when we refresh a token with MRRT and we receive less scopes than the ones requested.

```
error 5 y: Missing requested scopes after refresh (audience: 'orders', missing scope: 'delete:orders')
```

### References


### Testing

- Create the Auth0Client with an audience and scopes. Add useMrrt and useRefreshTokens to true. You must not add useRefreshTokensFallback.
- Use getTokenSilently to request a token for the same audience with a scope that is not inside the refresh policies. 
- You will see the error on console.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
