### PR TITLE
Remove dpop/mrrt requirements from connected accounts

### DIFF
--- a/__tests__/Auth0Client/connectAccountWithRedirect.test.ts
+++ b/__tests__/Auth0Client/connectAccountWithRedirect.test.ts
@@ -130,19 +130,5 @@ describe('Auth0Client', () => {
         'API error'
       );
     });
-
-    it('should throw if useDpop is not enabled', async () => {
-      (client as any).options.useDpop = false;
-      (client as any).options.useMrrt = true;
-      await expect(client.connectAccountWithRedirect({ connection: 'github' }))
-        .rejects.toThrow('`useDpop` option must be enabled before using connectAccountWithRedirect.');
-    });
-
-    it('should throw if useMrrt is not enabled', async () => {
-      (client as any).options.useDpop = true;
-      (client as any).options.useMrrt = false;
-      await expect(client.connectAccountWithRedirect({ connection: 'github' }))
-        .rejects.toThrow('`useMrrt` option must be enabled before using connectAccountWithRedirect.');
-    });
   });
 });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1527,13 +1527,6 @@ export class Auth0Client {
   public async connectAccountWithRedirect<TAppState = any>(
     options: RedirectConnectAccountOptions<TAppState>
   ) {
-    if (!this.options.useDpop) {
-      throw new Error('`useDpop` option must be enabled before using connectAccountWithRedirect.');
-    }
-
-    if (!this.options.useMrrt) {
-      throw new Error('`useMrrt` option must be enabled before using connectAccountWithRedirect.');
-    }
 
     const {
       openUrl,


### PR DESCRIPTION
### Changes

Remove hardcoded requirements for DPoP and MRRT for Connected Accounts

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [X] This change has been tested on the latest version of the platform/language

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All code quality tools/guidelines have been run/followed
