### PR TITLE
Retry when DPoP nonce is expired

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -206,7 +206,7 @@ export class Fetcher<TOutput extends CustomFetchMinimalOutput> {
 
     const wwwAuthHeader = this.getHeader(response.headers, 'www-authenticate');
 
-    return wwwAuthHeader.includes('use_dpop_nonce');
+    return wwwAuthHeader.includes('invalid_dpop_nonce') || wwwAuthHeader.includes('use_dpop_nonce');
   }
 
   protected async handleResponse(


### PR DESCRIPTION
### Changes

Retry DPoP request when nonce is expired

### Testing

<img width="1886" height="1784" alt="image" src="https://github.com/user-attachments/assets/04f6b537-e5cd-48e7-ad19-52a10bc02421" />

⬆️ The connect request is retried after DPoP nonce expires and connect flow starts successfully

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines have been run/followed
