### PR TITLE
Export type for Custom Token Exchange support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,6 @@ export {
 
 export { type FetcherConfig } from './fetcher';
 
-export {
-  MyAccountApiError
-} from './MyAccountApiClient';
+export { MyAccountApiError } from './MyAccountApiClient';
+
+export { CustomTokenExchangeOptions } from './TokenExchange';


### PR DESCRIPTION
Export `CustomTokenExchangeOptions` type from `auth0-spa-js` for use in `auth0-react`. No functional changes.