### PR TITLE
fix: pass CODECOV_TOKEN to codecov uploader to avoid rate limit issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@4fe8c5f003fae66aa5ebb77cfd3e7bfbbda0b6b0 # pin@3.1.5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   gatsby:
     needs: test
 


### PR DESCRIPTION
**Description**:
This PR updates the Unit Tests GitHub Actions workflow (`.github/workflows/test.yml`) for `auth0-spa-js` to explicitly provide the `CODECOV_TOKEN` to the Codecov action.

**Background**:

- Previously, the Codecov uploader often failed due to hitting rate limits.
- Logs showed `No token specified or token is empty`, meaning the workflow wasn’t using the secret.
- Because the uploader exits with status code 0, the workflow appeared green even when coverage wasn’t uploaded.

**Changes**:

- Added token: ${{ secrets.CODECOV_TOKEN }} to the Upload coverage step.
- This ensures the uploader authenticates properly with Codecov and avoids rate limiting issues.

**Impact**:

- Coverage reports should now reliably upload in GitHub Actions for PRs and pushes to main.
- Failures due to rate limiting should no longer occur.