### PR TITLE
Bump @auth0/component-cdn-uploader to v2.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "es-cookie": "~1.3.2"
       },
       "devDependencies": {
-        "@auth0/component-cdn-uploader": "^2.4.0",
+        "@auth0/component-cdn-uploader": "^2.4.2",
         "@rollup/plugin-replace": "^4.0.0",
         "@types/cypress": "^1.1.3",
         "@types/jest": "^28.1.7",
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@auth0/component-cdn-uploader": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@auth0/component-cdn-uploader/-/component-cdn-uploader-2.4.0.tgz",
-      "integrity": "sha512-skvs89lFZ5jKKN394ScGRsIVy/M+SOBVSobvk5BFAJgKbAtzZErA3YsKCXpQs9w195aGmqdqNtci/V/NfcHkdg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@auth0/component-cdn-uploader/-/component-cdn-uploader-2.4.2.tgz",
+      "integrity": "sha512-rkLGo9ekKDmNxZrf1C0fOO3U3uXsHcDOcv63SNG9nUOihgJrBrxHB3ih/mljy/vsZZoZAZX4yatPD+hOtDEzuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "publish:cdn": "ccu --trace"
   },
   "devDependencies": {
-    "@auth0/component-cdn-uploader": "^2.4.0",
+    "@auth0/component-cdn-uploader": "^2.4.2",
     "@rollup/plugin-replace": "^4.0.0",
     "@types/cypress": "^1.1.3",
     "@types/jest": "^28.1.7",


### PR DESCRIPTION
This PR updates @auth0/component-cdn-uploader from ^2.4.0 to ^2.4.2.

v2.4.2 includes the following fixes:
- Lint error in v2.4.0 that broke CDN uploads.
- Fixed GitHub release action (release-create) workflow.

This ensures that auth0-spa-js can upload new versions to the CDN successfully.