### PR TITLE
feat: export missing Fetcher-related types for SDK consumption

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,11 @@ export {
   CacheKeyData
 } from './cache';
 
-export { type FetcherConfig } from './fetcher';
+export type {
+  FetcherConfig,
+  Fetcher,
+  CustomFetchMinimalOutput
+} from './fetcher';
 
 export { MyAccountApiError } from './MyAccountApiClient';
 


### PR DESCRIPTION
## Description
Adds missing type exports to enable proper imports in auth0-angular, auth0-vue, and other consuming packages.

## Changes
- Added `FetcherConfig` and `CustomFetchMinimalOutput` to type exports in `index.ts`

## Testing
- Verify types are properly exported and can be imported:
```typescript
import type { FetcherConfig, CustomFetchMinimalOutput } from '@auth0/auth0-spa-js';
```