### PR TITLE
feat: Add organization support to Custom Token Exchange examples

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -320,6 +320,14 @@ async function performTokenExchange() {
       scope: 'openid profile read:records'
     });
 
+    // Option 3: Exchange token within an organization context
+    const orgTokenResponse = await auth0.exchangeToken({
+      subject_token: 'EXTERNAL_PROVIDER_TOKEN',
+      subject_token_type: 'urn:example:external-token',
+      organization: '<MY_ORG_ID_OR_NAME>', // Organization ID or name
+      scope: 'openid profile email'
+    });
+
     console.log('Received tokens:', tokenResponse);
   } catch (error) {
     console.error('Exchange failed:', error);


### PR DESCRIPTION
## Summary
This PR adds documentation for the new `organization` parameter support in the Custom Token Exchange (CTE) flow.

## Changes
- Added Option 3 in CTE examples showing organization parameter usage
- Documents that organization ID will be present in access token payload
- Aligns with EA API changes for Organizations with Custom Token Exchange

## Related
- API Status: EA
- Feature flag: `custom_token_exchange_public_ea`
- API endpoint: `POST /oauth/token` with `grant_type: urn:ietf:params:oauth:grant-type:token-exchange`