### PR TITLE
feat: enable trusted publishing for npm packages

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -3,8 +3,6 @@ name: Publish release to npm
 inputs:
   node-version:
     required: true
-  npm-token:
-    required: true
   version:
     required: true
   require-build:
@@ -26,6 +24,10 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@11
+
     - name: Install dependencies
       shell: bash
       run: npm ci --include=dev
@@ -46,7 +48,6 @@ runs:
         else
           TAG="latest"
         fi
-        npm publish --provenance --tag $TAG
+        npm publish --tag $TAG
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         VERSION: ${{ inputs.version }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -15,14 +15,15 @@ on:
     secrets:
       github-token:
         required: true
-      npm-token:
-        required: true
 
 jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       # Checkout the code
@@ -66,7 +67,6 @@ jobs:
           node-version: ${{ inputs.node-version }}
           require-build: ${{ inputs.require-build }}
           version: ${{ steps.get_version.outputs.version }}
-          npm-token: ${{ secrets.npm-token }}
           release-directory: ${{ inputs.release-directory }}
 
       # Create a release for the tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,4 @@ jobs:
       node-version: 18
       require-build: true
     secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implements trusted publishing using OIDC authentication to eliminate long-lived npm tokens.

## Changes

- Add `id-token: write` permissions to workflows
- Update npm CLI to version 11 (includes trusted publishing support ≥11.5.1)
- Remove `--provenance` flag (auto-generated with trusted publishing) [Refer](https://docs.npmjs.com/generating-provenance-statements#prerequisites)
- Remove npm-token dependency

## Post-merge: Configure on npmjs.com

Package Settings → Trusted Publisher → GitHub Actions:
- **Organization**: `auth0`
- **Repository**: `auth0-spa-js`
- **Workflow**: `release.yml`
- **Environment**: `release`

## Benefits

- Enhanced security with short-lived tokens
- Automatic provenance attestations
- No token management needed

Follows [OpenSSF trusted publishers standard](https://repos.openssf.org/trusted-publishers)