### PR TITLE
fix: Update Node.js version to 22 for npm@11 compatibility

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -5,7 +5,7 @@ inputs:
   node:
     description: The Node version to use
     required: false
-    default: 18
+    default: 22
 
 runs:
   using: composite

--- a/.github/actions/framework/action.yml
+++ b/.github/actions/framework/action.yml
@@ -5,7 +5,7 @@ inputs:
   node:
     description: The Node version to use
     required: false
-    default: 18
+    default: 22
   cache:
     description: Cache key to restore for build artifacts.
     required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   rl-scanner:
     uses: ./.github/workflows/rl-secure.yml
     with:
-      node-version: 18
+      node-version: 22
       artifact-name: 'auth0-spa-js.tgz'
     secrets:
       RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/npm-release.yml
     needs: rl-scanner
     with:
-      node-version: 18
+      node-version: 22
       require-build: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
Release workflow failed because npm@11 requires Node.js >=20.17.0, but we were using Node.js 18.

## Solution
Updated Node.js version from 18 to 22 in:
- `.github/workflows/release.yml`
- `.github/actions/framework/action.yml`
- `.github/actions/build/action.yml`

Aligns with test and browserstack workflows already on Node.js 22.