### PR TITLE
fix: add closePopup option for Chrome extension compatibility

### DIFF
--- a/__tests__/Auth0Client/loginWithPopup.test.ts
+++ b/__tests__/Auth0Client/loginWithPopup.test.ts
@@ -811,36 +811,6 @@ describe('Auth0Client', () => {
       expect(popup.close).toHaveBeenCalled();
     });
 
-    it('should close popup on state mismatch error regardless of closePopup setting', async () => {
-      const auth0 = setup();
-      const popup = {
-        location: { href: '' },
-        close: jest.fn()
-      };
-
-      let error;
-      try {
-        await loginWithPopup(
-          auth0,
-          {},
-          { popup, closePopup: false },
-          {
-            authorize: {
-              response: {
-                state: 'other-state'
-              }
-            }
-          }
-        );
-      } catch (e) {
-        error = e;
-      }
-
-      expect(error).toBeDefined();
-      expect(error.message).toBe('Invalid state');
-      expect(popup.close).toHaveBeenCalled();
-    });
-
     it('should not close popup when closePopup is false', async () => {
       const auth0 = setup();
       const popup = {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -429,10 +429,6 @@ export class Auth0Client {
     });
 
     if (params.state !== codeResult.state) {
-      // Always close popup on state mismatch error, regardless of closePopup setting
-      if (config.popup) {
-        config.popup.close();
-      }
       throw new GenericError('state_mismatch', 'Invalid state');
     }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -409,11 +409,21 @@ export interface PopupConfigOptions {
    * Controls whether the SDK automatically closes the popup window.
    *
    * - `true` (default): SDK closes the popup automatically after receiving the authorization response
-   * - `false`: SDK does not close the popup. The caller is responsible for closing it.
+   * - `false`: SDK does not close the popup. The caller is responsible for closing it, including on errors.
    *
-   * Setting this to `false` is useful when you need control over when the popup closes,
+   * Setting this to `false` is useful when you need full control over the popup lifecycle,
    * such as in Chrome extensions where closing the popup too early can terminate the
    * extension's service worker before authentication completes.
+   *
+   * When `closePopup: false`, you should close the popup in a try/finally block:
+   * ```
+   * const popup = window.open('', '_blank');
+   * try {
+   *   await auth0.loginWithPopup({}, { popup, closePopup: false });
+   * } finally {
+   *   popup.close();
+   * }
+   * ```
    *
    * @default true
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,8 +126,7 @@ export const runPopup = (config: PopupConfigOptions) => {
       clearInterval(popupTimer);
       window.removeEventListener('message', popupEventListener, false);
 
-      // Only close popup immediately if closePopup is not explicitly set to false
-      // When false, the caller is responsible for closing the popup
+      // Close popup automatically unless closePopup is explicitly set to false
       if (config.closePopup !== false) {
         config.popup.close();
       }


### PR DESCRIPTION
Fixes #1318

## Problem
When using `loginWithPopup()` in Chrome extensions, the popup closes immediately after receiving the authorization response. This terminates the extension's service worker before token exchange completes, leaving the user unauthenticated.

## Solution
Added a `closePopup` option to `PopupConfigOptions`:
- `true` (default): SDK closes the popup automatically after receiving the authorization response
- `false`: SDK does not close the popup. The caller is responsible for closing it, including on errors.

This gives users full control over the popup lifecycle, which is especially useful for Chrome extensions where closing too early terminates the service worker.

## Changes
- **utils.ts**: Modified popup closing logic to respect `closePopup` option
- **global.ts**: Added JSDoc documentation for `closePopup` option with try/finally usage example
- **loginWithPopup.test.ts**: Added comprehensive test coverage for the `closePopup` option

## Usage
```typescript
const popup = window.open('', '_blank');
try {
  await auth0.loginWithPopup({}, {
    popup: popup,
    closePopup: false  // SDK won't close the popup
  });
  // Tokens are cached, authentication successful
} catch (error) {
  // Handle authentication errors
  console.error('Login failed:', error);
} finally {
  // Always close popup, even on errors
  popup.close();
}
```

This also provides flexibility for other use cases like showing post-login messages or executing additional logic before closing the popup.

## Testing

### Unit Tests
Added 4 test cases covering:
- Default behavior (popup closes immediately)
- Explicit `closePopup: true`
- `closePopup: false` (SDK does not close popup on success)
- `closePopup: false` (SDK does not close popup on token exchange failure)

All tests pass ✅

### Manual Testing
Manually tested the fix in Chrome extension scenarios:

**Before fix:**
- ❌ Popup closes immediately after authorization
- ❌ Extension terminates before token exchange
- ❌ User remains unauthenticated (no tokens cached)

**After fix with `closePopup: false`:**
- ✅ SDK does not close the popup
- ✅ User closes popup in finally block after `loginWithPopup` completes
- ✅ Tokens are successfully cached before popup closes
- ✅ User is authenticated
- ✅ On reopening extension, user is logged in (tokens persisted in localStorage)
- ✅ Popup properly closed even when errors occur

**Other scenarios:**
- ✅ Default behavior: Popup closes immediately after authorization (no regression)

## Backward Compatibility
No breaking changes. Default behavior unchanged - popup still closes immediately after authorization.

## Credits
This PR builds upon the initial investigation and work by @ashwsn.

Closes #1318