### PR TITLE
fix: handle undefined value when finding MRRT refresh token

### DIFF
--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -91,7 +91,7 @@ export class CacheManager {
       // To refresh using MRRT we need to send a request to the server
       // If cacheMode is 'cache-only', this will make us unable to call the server
       // so it won't be needed to find a valid refresh token
-      if (!matchedKey && useMrrt && cacheMode !== 'cache-only') {
+      if (!wrappedEntry && useMrrt && cacheMode !== 'cache-only') {
         return this.getEntryWithRefreshToken(cacheKey, keys);
       }
     }


### PR DESCRIPTION
<!-- By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo. -->

### Changes

When `useMrrt` is enabled and the library is retrieving a token from the cache, it will now handle the case where the requested audience has a key in the cache, but the value is `undefined`. Previously this would cause an issue where the library would fail to try using the refresh token from other cache entries. See #1507.

### References

Fixes #1507.

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
