### PR TITLE
fix: add validation to prevent oversized auth0Client HTTP headers 

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -13,7 +13,8 @@ import {
   openPopup,
   getDomain,
   getTokenIssuer,
-  parseNumber
+  parseNumber,
+  validateAuth0ClientSize
 } from './utils';
 
 import { oauthToken } from './api';
@@ -318,8 +319,10 @@ export class Auth0Client {
   }
 
   private _url(path: string) {
+    const auth0ClientObj = this.options.auth0Client || DEFAULT_AUTH0_CLIENT;
+    validateAuth0ClientSize(auth0ClientObj);
     const auth0Client = encodeURIComponent(
-      btoa(JSON.stringify(this.options.auth0Client || DEFAULT_AUTH0_CLIENT))
+      btoa(JSON.stringify(auth0ClientObj))
     );
     return `${this.domainUrl}${path}&auth0Client=${auth0Client}`;
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,7 +2,11 @@ import { TokenEndpointOptions, TokenEndpointResponse } from './global';
 import { DEFAULT_AUTH0_CLIENT, DEFAULT_AUDIENCE } from './constants';
 import * as dpopUtils from './dpop/utils';
 import { getJSON } from './http';
-import { createQueryParams, stripAuth0Client } from './utils';
+import {
+  createQueryParams,
+  stripAuth0Client,
+  validateAuth0ClientSize
+} from './utils';
 
 export async function oauthToken(
   {
@@ -36,6 +40,12 @@ export async function oauthToken(
 
   const isDpopSupported = dpopUtils.isGrantTypeSupported(options.grant_type);
 
+  // Strip and validate the auth0Client before encoding
+  const strippedAuth0Client = stripAuth0Client(
+    auth0Client || DEFAULT_AUTH0_CLIENT
+  );
+  validateAuth0ClientSize(strippedAuth0Client);
+
   return await getJSON<TokenEndpointResponse>(
     `${baseUrl}/oauth/token`,
     timeout,
@@ -48,9 +58,7 @@ export async function oauthToken(
         'Content-Type': useFormData
           ? 'application/x-www-form-urlencoded'
           : 'application/json',
-        'Auth0-Client': btoa(
-          JSON.stringify(stripAuth0Client(auth0Client || DEFAULT_AUTH0_CLIENT))
-        )
+        'Auth0-Client': btoa(JSON.stringify(strippedAuth0Client))
       }
     },
     worker,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -149,6 +149,20 @@ export class UseDpopNonceError extends GenericError {
 }
 
 /**
+ * Error thrown when the auth0Client configuration object exceeds the maximum allowed size
+ * for the Auth0-Client HTTP header.
+ */
+export class Auth0ClientSizeError extends GenericError {
+  constructor(public actualSize: number, public maxSize: number) {
+    super(
+      'auth0_client_too_large',
+      `The auth0Client configuration is too large (${actualSize} bytes). The resulting Auth0-Client HTTP header would exceed the maximum size of ${maxSize} bytes. Please reduce the size of the 'env' object in your auth0Client configuration.`
+    );
+    Object.setPrototypeOf(this, Auth0ClientSizeError.prototype);
+  }
+}
+
+/**
  * Returns an empty string when value is falsy, or when it's value is included in the exclude argument.
  * @param value The value to check
  * @param exclude An array of values that should result in an empty string.

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export {
   PopupOpenError,
   MfaRequiredError,
   MissingRefreshTokenError,
-  UseDpopNonceError
+  UseDpopNonceError,
+  Auth0ClientSizeError
 } from './errors';
 
 export {


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                                        
                                                                                                                                                                                                                                        
  Adds validation to prevent oversized `auth0Client` configuration objects from causing HTTP header truncation issues.                                                                                                                  
                                                                                                                                                                                                                                       
  ## Problem                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  When customers set a large `env` object in the `auth0Client` configuration, the resulting `Auth0-Client` HTTP header can exceed standard 8KB limits, causing:                                                                         
                                                                                                                                                                                                                                        
  - HTTP requests rejected with 400 Bad Request by web servers/proxies                                                                                                                                                                  
  - Header truncation by intermediaries                                                                                                                                                                                                 
  - Incomplete/malformed JSON in server logs                                                                                                                                                                                            
  - Analytics systems failing to parse truncated data                                                                                                                                                                                   
                                                                                                                                                                                                                                        
  The SDK previously had no size validation on the `auth0Client` object before base64-encoding it into HTTP headers.                                                                                                                    
                                                                                                                                                                                                                                        
  ## Solution                                                                                                                                                                                                                           
                                                                                                                                                                                                                                        
  - Added `Auth0ClientSizeError` class for clear error messaging                                                                                                                                                                        
  - Added `validateAuth0ClientSize()` utility function                                                                                                                                                                                  
  - Set maximum size limit to 6KB (ensures <8KB after base64 encoding)                                                                                                                                                                  
  - Applied validation in two locations:                                                                                                                                                                                                
    - `oauthToken()` - validates before sending as HTTP header in token requests                                                                                                                                                        
    - `Auth0Client._url()` - validates before sending as URL query parameter in authorize requests                                                                                                                                      
  - Exported new error type for consumer error handling                                                                                                                                                                                 
                                                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  - **src/errors.ts**: Added `Auth0ClientSizeError` with size information                                                                                                                                                               
  - **src/utils.ts**: Added validation function and `MAX_AUTH0_CLIENT_SIZE` constant                                                                                                                                                    
  - **src/api.ts**: Validate auth0Client size before encoding in token requests                                                                                                                                                         
  - **src/Auth0Client.ts**: Validate auth0Client size before encoding in authorization URLs                                                                                                                                             
  - **src/index.ts**: Export new error type                                                                                                                                                                                             
  - **__tests__/utils.test.ts**: 6 unit tests for validation function                                                                                                                                                                   
  - **__tests__/api.test.ts**: 4 integration tests for API validation                                                                                                                                                                   
                                                                                                                                                                                                                                        
  ## Testing                                                                                                                                                                                                                            
                                                                                                                                                                                                                                        
  All new tests passing:                                                                                                                                                                                                                
                                                                                                                                                                                                                                        
  - ✓ Validates small auth0Client objects pass                                                                                                                                                                                          
  - ✓ Validates oversized objects throw `Auth0ClientSizeError`                                                                                                                                                                          
  - ✓ Verifies HTTP requests are not made when validation fails                                                                                                                                                                         
  - ✓ Tests boundary conditions and error properties                                                                                                                                                                                    
  - ✓ Tests nested env objects                                                                                                                                                                                                          
                                                                                                                                                                                                                                        
  ## Breaking Changes                                                                                                                                                                                                                   
                                                                                                                                                                                                                                        
  None. This is a backward-compatible addition that only affects customers with extremely large auth0Client configurations (>6KB when JSON stringified).                                                                                
                                                                                                                                                                                                                                        
  ## Example Usage                                                                                                                                                                                                                      
                                                                                                                                                                                                                                        
  ```typescript                                                                                                                                                                                                                         
  const client = new Auth0Client({                                                                                                                                                                                                      
    domain: 'your-domain.auth0.com',                                                                                                                                                                                                    
    clientId: 'your-client-id',                                                                                                                                                                                                         
    auth0Client: {                                                                                                                                                                                                                      
      name: 'my-sdk',                                                                                                                                                                                                                   
      version: '1.0.0',                                                                                                                                                                                                                 
      env: { /* large object */ }                                                                                                                                                                                                       
    }                                                                                                                                                                                                                                   
  });                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                        
  try {                                                                                                                                                                                                                                 
    // Validation occurs when making API calls                                                                                                                                                                                          
    await client.loginWithRedirect();                                                                                                                                                                                                   
    // or                                                                                                                                                                                                                               
    await client.getTokenSilently();                                                                                                                                                                                                    
  } catch (error) {                                                                                                                                                                                                                     
    if (error instanceof Auth0ClientSizeError) {                                                                                                                                                                                        
      console.error(`Config too large: ${error.actualSize}/${error.maxSize} bytes`);                                                                                                                                                    
      console.error('Please reduce the size of the env object');                                                                                                                                                                        
    }                                                                                                                                                                                                                                   
  }
  ```  