### PR TITLE
build(deps): update @auth0/auth0-auth-js to version 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-auth-js": "^1.4.0",
+    "@auth0/auth0-auth-js": "^1.5.0",
     "browser-tabs-lock": "^1.2.15",
     "dpop": "^2.1.1",
     "es-cookie": "~1.3.2"


### PR DESCRIPTION
## Summary

Bump the `@auth0/auth0-auth-js` dependency from `^1.4.0` to `^1.5.0` to pull in the latest features and fixes from the core auth library.

Conatins fixes related barcode_uri param for MFA API to https://github.com/auth0/auth0-auth-js/pull/147



## Testing

- Verified `npm install` resolves `@auth0/auth0-auth-js@1.5.0` successfully
- Run the existing test suite to confirm no regressions
