### PR TITLE
fix: prevent script injection in GitHub Actions workflows

### DIFF
--- a/.github/actions/framework/action.yml
+++ b/.github/actions/framework/action.yml
@@ -41,19 +41,14 @@ runs:
 
     - name: Create application
       shell: bash
-      env:
-        INSTALL: ${{ inputs.install }}
-      run: $INSTALL
+      run: ${{ inputs.install }}
 
     - name: Install SDK
       shell: bash
-      env:
-        CONTENT: ${{ inputs.content }}
-        IMPORT: ${{ inputs.import }}
       run: |
         npm link '../'
-        $CONTENT
-        $IMPORT
+        ${{ inputs.content }}
+        ${{ inputs.import }}
       working-directory: my-app
 
     - name: Build application

--- a/.github/actions/framework/action.yml
+++ b/.github/actions/framework/action.yml
@@ -41,14 +41,19 @@ runs:
 
     - name: Create application
       shell: bash
-      run: ${{ inputs.install }}
+      env:
+        INSTALL: ${{ inputs.install }}
+      run: $INSTALL
 
     - name: Install SDK
       shell: bash
+      env:
+        CONTENT: ${{ inputs.content }}
+        IMPORT: ${{ inputs.import }}
       run: |
         npm link '../'
-        ${{ inputs.content }}
-        ${{ inputs.import }}
+        $CONTENT
+        $IMPORT
       working-directory: my-app
 
     - name: Build application

--- a/.github/actions/rl-scanner/action.yml
+++ b/.github/actions/rl-scanner/action.yml
@@ -40,16 +40,18 @@ runs:
         RLSECURE_SITE_KEY: ${{ env.RLSECURE_SITE_KEY }}
         SIGNAL_HANDLER_TOKEN: ${{ env.SIGNAL_HANDLER_TOKEN }}
         PYTHONUNBUFFERED: 1
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        VERSION: ${{ inputs.version }}
       run: |
-        if [ ! -f "${{ inputs.artifact-path }}" ]; then
-          echo "Artifact not found: ${{ inputs.artifact-path }}"
+        if [ ! -f "$ARTIFACT_PATH" ]; then
+          echo "Artifact not found: $ARTIFACT_PATH"
           exit 1
         fi
 
         rl-wrapper \
-          --artifact "${{ inputs.artifact-path }}" \
+          --artifact "$ARTIFACT_PATH" \
           --name "${{ github.event.repository.name }}" \
-          --version "${{ inputs.version }}" \
+          --version "$VERSION" \
           --repository "${{ github.repository }}" \
           --commit "${{ github.sha }}" \
           --build-env "github_actions" \

--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -43,8 +43,10 @@ jobs:
           node: ${{ inputs.node-version }}
 
       - name: Create tgz build artifact
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
         run: |
-          tar -czvf ${{ inputs.artifact-name }} *
+          tar -czvf "$ARTIFACT_NAME" *
 
       - id: get_version
         uses: ./.github/actions/get-version
@@ -53,7 +55,7 @@ jobs:
         id: rl-scan-conclusion
         uses: ./.github/actions/rl-scanner
         with:
-          artifact-path: "$(pwd)/${{ inputs.artifact-name }}"
+          artifact-path: "${{ github.workspace }}/${{ inputs.artifact-name }}"
           version: "${{ steps.get_version.outputs.version }}"
         env:
           RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}


### PR DESCRIPTION
## Summary

- Move `inputs.*` template expressions out of `run:` scripts and into `env:` blocks across two workflow files
- Replace `$(pwd)` with `${{ github.workspace }}` in `rl-secure.yml` to maintain correct path resolution after the env var refactor

## Files changed

- `.github/actions/rl-scanner/action.yml` — `inputs.artifact-path` and `inputs.version`
- `.github/workflows/rl-secure.yml` — `inputs.artifact-name` and artifact path construction

## Security impact

Interpolating `${{ inputs.* }}` directly into `run:` scripts allows shell metacharacters in user-controlled input to break out of the intended command context. Routing through `env:` variables ensures values are treated as data, not inline script.

> **Note:** `.github/actions/framework/action.yml` was excluded because its inputs contain shell operators (`>`, `|`, `&&`) that require inline expansion, and they are not user-controlled.
