### PR TITLE
fix(security): add .npmrc with ignore-scripts=true

### DIFF
--- a/.github/actions/framework/action.yml
+++ b/.github/actions/framework/action.yml
@@ -18,6 +18,10 @@ inputs:
   import:
     description: The SDK's import code to inject.
     required: true
+  ignore-scripts:
+    description: Ignore npm scripts during app creation.
+    required: false
+    default: true
 
 runs:
   using: composite
@@ -42,6 +46,8 @@ runs:
     - name: Create application
       shell: bash
       run: ${{ inputs.install }}
+      env:
+        npm_config_ignore_scripts: ${{ inputs.ignore-scripts }}
 
     - name: Install SDK
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           node: ${{ env.NODE_VERSION }}
           cache: ${{ env.CACHE_KEY }}
+          ignore-scripts: false
           install: |
             npx gatsby new my-app < /dev/null
           content: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ package-lock.json
 .DS_Store
 release-tmp*
 bundle-stats
-.npmrc
 
 # BrowserStack
 log/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
This prevents malicious postinstall scripts from running during `npm install`, both in CI and locally.

### Changes

- Added `.npmrc` with `ignore-scripts=true`
- Removed `.npmrc` from `.gitignore` (auth tokens belong in `~/.npmrc`, not project-level)
- Added `ignore-scripts` input to the framework action (default: `true`), with Gatsby overriding to `false` since it depends on `sharp`, a native addon that requires its postinstall script to download the platform-specific binary