### PR TITLE
fix: throw GenericError from worker path in revokeRefreshToken

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -161,13 +161,17 @@ await auth0.revokeRefreshToken();
 
 #### Error Handling
 
-`revokeRefreshToken()` throws if the `/oauth/revoke` endpoint returns an error (for example, if the token has already been revoked or is invalid). Wrap the call in a try/catch:
+`revokeRefreshToken()` throws a `GenericError` if the `/oauth/revoke` endpoint returns an error (for example, if the token has already been revoked or is invalid). Wrap the call in a try/catch:
 
 ```js
+import { GenericError } from '@auth0/auth0-spa-js';
+
 try {
   await auth0.revokeRefreshToken();
 } catch (e) {
-  console.error('Failed to revoke refresh token:', e.message);
+  if (e instanceof GenericError) {
+    console.error(e.error, e.error_description);
+  }
 }
 ```
 

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -5,6 +5,7 @@ import {
 
 import version from '../src/version';
 import { oauthToken, revokeToken } from '../src/api';
+import { GenericError } from '../src/errors';
 import * as http from '../src/http';
 import * as dpopUtils from '../src/dpop/utils';
 
@@ -693,6 +694,27 @@ describe('revokeToken', () => {
       },
       worker
     );
+  });
+
+  it('throws GenericError when worker rejects', async () => {
+    const workerUtils = require('../src/worker/worker.utils');
+    jest.spyOn(workerUtils, 'sendMessage').mockRejectedValue(new Error('HTTP error 400'));
+
+    const worker = {} as Worker;
+
+    const error = await revokeToken(
+      {
+        baseUrl: `https://${TEST_DOMAIN}`,
+        client_id: TEST_CLIENT_ID,
+        refreshTokens: [],
+        auth0Client: DEFAULT_AUTH0_CLIENT
+      },
+      worker
+    ).catch(e => e);
+
+    expect(error).toBeInstanceOf(GenericError);
+    expect(error.error).toBe('revoke_error');
+    expect(error.message).toBe('HTTP error 400');
   });
 
   it('sends form-encoded body to worker when useFormData is true', async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -130,17 +130,21 @@ export async function revokeToken(
       ? createQueryParams(baseParams)
       : JSON.stringify(baseParams);
 
-    return sendMessage(
-      {
-        type: 'revoke',
-        timeout: resolvedTimeout,
-        fetchUrl,
-        fetchOptions: { method: 'POST', body, headers },
-        useFormData,
-        auth: { audience: audience ?? DEFAULT_AUDIENCE }
-      },
-      worker
-    );
+    try {
+      return await sendMessage(
+        {
+          type: 'revoke',
+          timeout: resolvedTimeout,
+          fetchUrl,
+          fetchOptions: { method: 'POST', body, headers },
+          useFormData,
+          auth: { audience: audience ?? DEFAULT_AUDIENCE }
+        },
+        worker
+      );
+    } catch (e) {
+      throw new GenericError('revoke_error', (e as Error).message);
+    }
   }
 
   for (const refreshToken of refreshTokens) {


### PR DESCRIPTION
## Summary

- The non-worker path in `revokeRefreshToken` already threw `GenericError`; the worker path rejected with a plain `Error`, causing inconsistent error types for callers
- Wrap the `sendMessage` rejection in `api.ts` so both paths surface `GenericError`
- Add a test asserting `instanceof GenericError` on the worker error path
- Update `EXAMPLES.md` error handling section to document `GenericError` with `error` and `error_description` fields

## Notes

`GenericError extends Error` so existing `catch` blocks keep working. The JSDoc already documented `@throws {GenericError}`; this aligns the worker path with that contract.

Spotted during review of #1588.
