### PR TITLE
fix: prevent ghost cache entry when subset-matched token expires

### DIFF
--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -427,6 +427,51 @@ cacheFactories.forEach(cacheFactory => {
         global.Date.now = realDateNow;
       });
 
+      it('does not corrupt the original superset entry in InMemoryCache when subset-matched entry is expired', async () => {
+        const now = Date.now();
+        const realDateNow = Date.now.bind(global.Date);
+
+        const extendedScope = 'openid profile read:data';
+        const defaultScope = 'openid profile';
+
+        const data = {
+          ...defaultData,
+          scope: extendedScope,
+          refresh_token: TEST_REFRESH_TOKEN,
+        };
+
+        await manager.set(data);
+
+        // Read the original entry BEFORE expiry to get a reference
+        const originalKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: extendedScope,
+        });
+        const beforeExpiry = await cache.get<WrappedCacheEntry>(originalKey.toKey());
+        expect(beforeExpiry.body.access_token).toBe(TEST_ACCESS_TOKEN);
+
+        // Advance past expiry
+        global.Date.now = jest.fn(() => now + (dayInSeconds + 60) * 1000);
+
+        // Look up by narrower scope — triggers subset match + modifiedCachedEntry
+        const lookupKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: defaultScope,
+        });
+
+        await manager.get(lookupKey);
+
+        // The entry under the original key IS expected to be stripped (body replaced),
+        // but via cache.set with a new object, not via in-place mutation of the old reference.
+        const afterExpiry = await cache.get<WrappedCacheEntry>(originalKey.toKey());
+        expect(afterExpiry.body.refresh_token).toBe(TEST_REFRESH_TOKEN);
+        expect(afterExpiry.body).not.toBe(beforeExpiry.body);
+
+        global.Date.now = realDateNow;
+      });
+
       it('removes expired subset-matched entry under the correct key when no refresh token', async () => {
         const now = Date.now();
         const realDateNow = Date.now.bind(global.Date);

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -240,6 +240,10 @@ cacheFactories.forEach(cacheFactory => {
 
 
     describe('when refresh tokens are used', () => {
+      beforeEach(async () => {
+        await manager.clear();
+      });
+
       describe('when no matching key has been found and the useMrrt is true', () => {
         it('should return undefined when no entry has a refresh_token', async () => {
           const data = {
@@ -365,6 +369,99 @@ cacheFactories.forEach(cacheFactory => {
           audience: data.audience,
           scope: data.scope
         });
+
+        global.Date.now = realDateNow;
+      });
+
+      it('does not create a ghost entry under the lookup key when subset-matched entry is expired', async () => {
+        const now = Date.now();
+        const realDateNow = Date.now.bind(global.Date);
+
+        const extendedScope = 'openid profile read:data';
+        const defaultScope = 'openid profile';
+
+        const data = {
+          ...defaultData,
+          scope: extendedScope,
+          refresh_token: TEST_REFRESH_TOKEN,
+        };
+
+        await manager.set(data);
+
+        // Advance past expiry
+        global.Date.now = jest.fn(() => now + (dayInSeconds + 60) * 1000);
+
+        // Look up by default (narrower) scope — triggers subset matching
+        const lookupKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: defaultScope,
+        });
+
+        const result = await manager.get(lookupKey);
+
+        // Should return stripped entry with refresh token
+        expect(result).toStrictEqual({
+          refresh_token: TEST_REFRESH_TOKEN,
+          audience: data.audience,
+          scope: data.scope,
+        });
+
+        // The stripped entry should be saved under the ORIGINAL (extended scope) key,
+        // not under the lookup (default scope) key.
+        const ghostKey = lookupKey.toKey();
+        const ghostEntry = await cache.get(ghostKey);
+        expect(ghostEntry).toBeFalsy();
+
+        // The original key should still have an entry (now stripped)
+        const originalKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: extendedScope,
+        });
+        const originalEntry = await cache.get<WrappedCacheEntry>(originalKey.toKey());
+        expect(originalEntry).toBeDefined();
+        expect(originalEntry.body.refresh_token).toBe(TEST_REFRESH_TOKEN);
+        expect(originalEntry.body.access_token).toBeUndefined();
+
+        global.Date.now = realDateNow;
+      });
+
+      it('removes expired subset-matched entry under the correct key when no refresh token', async () => {
+        const now = Date.now();
+        const realDateNow = Date.now.bind(global.Date);
+
+        const extendedScope = 'openid profile read:data';
+        const defaultScope = 'openid profile';
+
+        const data = {
+          ...defaultData,
+          scope: extendedScope,
+          // No refresh_token
+        };
+
+        await manager.set(data);
+
+        // Advance past expiry
+        global.Date.now = jest.fn(() => now + (dayInSeconds + 60) * 1000);
+
+        const lookupKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: defaultScope,
+        });
+
+        const result = await manager.get(lookupKey);
+        expect(result).toBeUndefined();
+
+        // The original key should be removed
+        const originalKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: extendedScope,
+        });
+        const entry = await cache.get(originalKey.toKey());
+        expect(entry).toBeFalsy();
 
         global.Date.now = realDateNow;
       });

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -127,18 +127,27 @@ export class CacheManager {
   private async modifiedCachedEntry(wrappedEntry: WrappedCacheEntry, cacheKey: CacheKey): Promise<Partial<CacheEntry>> {
     // We need to keep audience and scope in order to check them later when doing refresh
     // using MRRT. See getScopeToRequest method.
-    wrappedEntry.body = {
+    //
+    // Build a new object instead of mutating wrappedEntry.body in-place,
+    // because InMemoryCache returns direct references — mutating would
+    // corrupt the original entry stored under a different (superset) key.
+    const strippedBody: Partial<CacheEntry> = {
       refresh_token: wrappedEntry.body.refresh_token,
       audience: wrappedEntry.body.audience,
       scope: wrappedEntry.body.scope,
     };
 
-    await this.cache.set(cacheKey.toKey(), wrappedEntry);
+    const strippedEntry: WrappedCacheEntry = {
+      body: strippedBody,
+      expiresAt: wrappedEntry.expiresAt,
+    };
+
+    await this.cache.set(cacheKey.toKey(), strippedEntry);
 
     return {
-      refresh_token: wrappedEntry.body.refresh_token,
-      audience: wrappedEntry.body.audience,
-      scope: wrappedEntry.body.scope,
+      refresh_token: strippedBody.refresh_token,
+      audience: strippedBody.audience,
+      scope: strippedBody.scope,
     };
   }
 

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -77,6 +77,11 @@ export class CacheManager {
       cacheKey.toKey()
     );
 
+    // Track the key where the entry was actually found, so that
+    // expiry-related writes (strip / remove) target the correct entry
+    // instead of creating a ghost entry under the lookup key.
+    let resolvedCacheKey = cacheKey;
+
     if (!wrappedEntry) {
       const keys = await this.getCacheKeys();
 
@@ -86,6 +91,7 @@ export class CacheManager {
 
       if (matchedKey) {
         wrappedEntry = await this.cache.get<WrappedCacheEntry>(matchedKey);
+        resolvedCacheKey = CacheKey.fromKey(matchedKey);
       }
 
       // To refresh using MRRT we need to send a request to the server
@@ -106,11 +112,11 @@ export class CacheManager {
 
     if (wrappedEntry.expiresAt - expiryAdjustmentSeconds < nowSeconds) {
       if (wrappedEntry.body.refresh_token) {
-        return this.modifiedCachedEntry(wrappedEntry, cacheKey);
+        return this.modifiedCachedEntry(wrappedEntry, resolvedCacheKey);
       }
 
-      await this.cache.remove(cacheKey.toKey());
-      await this.keyManifest?.remove(cacheKey.toKey());
+      await this.cache.remove(resolvedCacheKey.toKey());
+      await this.keyManifest?.remove(resolvedCacheKey.toKey());
 
       return;
     }


### PR DESCRIPTION
## Problem

When `getTokenSilently` is called with a narrow scope and only a broader scope token exists in cache, `CacheManager.get()` finds the entry via subset scope matching. If that entry is expired, `modifiedCachedEntry` strips it down to just the refresh token and saves it back under the **requested** scope key instead of the key where the entry was found.

This creates a ghost entry under the narrower scope key that was never written by a real login. On the next call, the exact key lookup hits the ghost entry first, finds no `access_token`, and returns `undefined` even though a valid token exists under the broader scope key.

This is most reliably triggered when `cacheMode: 'cache-only'` is used — the ghost entry is created immediately during the cache lookup and never overwritten (since no token exchange is attempted), causing any subsequent `getTokenSilently` call for the narrow scope to fail silently.

## Solution

- Track `resolvedCacheKey` in `get()` to record the key where the entry was actually found
- Pass `resolvedCacheKey` to `modifiedCachedEntry` and `cache.remove` instead of the requested key
- Build a new object in `modifiedCachedEntry` instead of mutating `wrappedEntry.body` in place, which previously caused silent corruption of the source entry in `InMemoryCache`

## Tests

- [x] `does not create a ghost entry under the lookup key when subset-matched entry is expired`
- [x] `removes expired subset-matched entry under the correct key when no refresh token`
- [x] `does not corrupt the original superset entry in InMemoryCache when subset-matched entry is expired`
