### PR TITLE
fix: prevent ghost cache entry during multi-audience refresh token (MRRT) lookup

### DIFF
--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -336,6 +336,52 @@ cacheFactories.forEach(cacheFactory => {
         });
       })
 
+      it('does not write a ghost entry at the requested key when finding a refresh token via MRRT', async () => {
+        const data = {
+          ...defaultData,
+          refresh_token: TEST_REFRESH_TOKEN,
+          decodedToken: {
+            claims: {
+              __raw: TEST_ID_TOKEN,
+              name: 'Test',
+              exp: nowSeconds() + dayInSeconds * 2
+            },
+            user: { name: 'Test' }
+          }
+        };
+
+        await manager.set(data);
+
+        const mrrtKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: 'my_second_audience',
+          scope: 'scope_1 scope_2',
+        });
+
+        const result = await manager.get(mrrtKey, undefined, true);
+
+        // Return value should carry the donor's refresh token, audience and scope
+        expect(result).toStrictEqual({
+          refresh_token: TEST_REFRESH_TOKEN,
+          audience: data.audience,
+          scope: data.scope,
+        });
+
+        // No entry should have been written at the requested key
+        const ghostEntry = await cache.get(mrrtKey.toKey());
+        expect(ghostEntry).toBeFalsy();
+
+        // The donor entry should be untouched
+        const donorKey = new CacheKey({
+          clientId: TEST_CLIENT_ID,
+          audience: TEST_AUDIENCE,
+          scope: data.scope,
+        });
+        const donorEntry = await cache.get<WrappedCacheEntry>(donorKey.toKey());
+        expect(donorEntry?.body?.access_token).toBe(TEST_ACCESS_TOKEN);
+        expect(donorEntry?.body?.refresh_token).toBe(TEST_REFRESH_TOKEN);
+      });
+
       it('strips everything except the refresh token and audience when expiry has been reached', async () => {
         const now = Date.now();
         const realDateNow = Date.now.bind(global.Date);

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -293,7 +293,11 @@ export class CacheManager {
         const cachedEntry = await this.cache.get<WrappedCacheEntry>(key);
 
         if (cachedEntry?.body?.refresh_token) {
-          return this.modifiedCachedEntry(cachedEntry, keyToMatch);
+          return {
+            refresh_token: cachedEntry.body.refresh_token,
+            audience: cachedEntry.body.audience,
+            scope: cachedEntry.body.scope,
+          };
         }
       }
     }


### PR DESCRIPTION
## Problem

When `getTokenSilently` is called for an audience with no cached token, the SDK looks for a refresh token from a different audience to use (MRRT). It was finding that refresh token but also writing a partial cache entry for the requested audience — with the wrong audience and scope values from the donor entry.

## Fix

Just return the refresh token data without writing anything to the cache. The correct entry is stored after a successful refresh anyway.

## Tests

Added: `does not write a ghost entry at the requested key when finding a refresh token via MRRT`