### PR TITLE
test: fix naming and tighten assertions from #1597

### DIFF
--- a/__tests__/Auth0Client/logout.test.ts
+++ b/__tests__/Auth0Client/logout.test.ts
@@ -372,7 +372,7 @@ describe('Auth0Client', () => {
       // src/worker/__mocks__/token.worker.ts makes that the in-process
       // messageRouter, so we can spy on TokenWorker.prototype.postMessage.
 
-      it("Test D — logout sends a 'clear' message to the worker", async () => {
+      it("logout sends a 'clear' message to the worker", async () => {
         const postMessageSpy = jest.spyOn(
           TokenWorker.prototype as any,
           'postMessage'
@@ -391,10 +391,10 @@ describe('Auth0Client', () => {
         const clearCalls = postMessageSpy.mock.calls.filter(
           ([msg]) => msg && (msg as any).type === 'clear'
         );
-        expect(clearCalls.length).toBeGreaterThanOrEqual(1);
+        expect(clearCalls.length).toBe(1);
       });
 
-      it('Test E — getTokenSilently after logout throws MissingRefreshTokenError', async () => {
+      it('getTokenSilently after logout throws MissingRefreshTokenError', async () => {
         const auth0 = setup({
           useRefreshTokens: true,
           cacheLocation: 'memory'
@@ -429,7 +429,7 @@ describe('Auth0Client', () => {
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
-      it('Test E (cacheMode=off) — explicit refresh after logout also throws', async () => {
+      it('explicit refresh with cacheMode=off after logout throws MissingRefreshTokenError', async () => {
         const auth0 = setup({
           useRefreshTokens: true,
           cacheLocation: 'memory'
@@ -446,7 +446,7 @@ describe('Auth0Client', () => {
         expect(mockFetch).not.toHaveBeenCalled();
       });
 
-      it('Test F — falls back to iframe after logout when useRefreshTokensFallback is true', async () => {
+      it('falls back to iframe after logout when useRefreshTokensFallback is true', async () => {
         const auth0 = setup({
           useRefreshTokens: true,
           useRefreshTokensFallback: true,
@@ -491,7 +491,7 @@ describe('Auth0Client', () => {
         runIframeSpy.mockRestore();
       });
 
-      it('Test G — logout without a worker (localstorage) does not post any message', async () => {
+      it('logout without a worker (localstorage) does not post any message', async () => {
         const postMessageSpy = jest.spyOn(
           TokenWorker.prototype as any,
           'postMessage'
@@ -514,7 +514,7 @@ describe('Auth0Client', () => {
         expect(postMessageSpy).not.toHaveBeenCalled();
       });
 
-      it('Test G2 — logout without useRefreshTokens does not post any message', async () => {
+      it('logout without useRefreshTokens does not post any message', async () => {
         const postMessageSpy = jest.spyOn(
           TokenWorker.prototype as any,
           'postMessage'
@@ -674,7 +674,7 @@ describe('Auth0Client', () => {
         const clearCalls = postMessageSpy.mock.calls.filter(
           ([msg]) => msg && (msg as any).type === 'clear'
         );
-        expect(clearCalls.length).toBeGreaterThanOrEqual(1);
+        expect(clearCalls.length).toBe(1);
 
         postMessageSpy.mockRestore();
       });

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -918,7 +918,7 @@ describe('token worker', () => {
   });
 
   describe('clear message', () => {
-    it('Test A — clear empties the refresh-token store', async () => {
+    it('clear empties the refresh-token store', async () => {
       // Seed a refresh token via a normal authorization_code round-trip
       mockFetch.mockReturnValueOnce(
         Promise.resolve({
@@ -966,7 +966,7 @@ describe('token worker', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('Test B — clear wipes the MRRT latest_refresh_token slot', async () => {
+    it('clear wipes the MRRT latest_refresh_token slot', async () => {
       const { messageRouter } = require('../src/worker/token.worker');
 
       const mrrtFor = (audience: string, scope: string) => (opts: any) =>
@@ -1044,7 +1044,7 @@ describe('token worker', () => {
       expect(original.json.error).toBe('missing_refresh_token');
     });
 
-    it('Test C — clear with no ports is a safe no-op', () => {
+    it('clear with no ports is a safe no-op', () => {
       const { messageRouter } = require('../src/worker/token.worker');
 
       expect(() =>


### PR DESCRIPTION
## Summary

Follow-up cleanup on the tests added in #1597:

- Rename tests from the `Test A/B/C/D/E/F/G` prefix pattern to plain descriptive names, matching the convention used throughout the rest of the test suite
- Tighten two `toBeGreaterThanOrEqual(1)` assertions to `toBe(1)` — a single `logout()` call should dispatch exactly one `clear` message to the worker

No logic changes.