### PR TITLE
feat: CTE delegation and impersonation support

### DIFF
--- a/__tests__/Auth0Client/exchangeToken.test.ts
+++ b/__tests__/Auth0Client/exchangeToken.test.ts
@@ -2,6 +2,7 @@ import { verify } from '../../src/jwt';
 import { MessageChannel } from 'worker_threads';
 import * as utils from '../../src/utils';
 import * as scope from '../../src/scope';
+import * as api from '../../src/api';
 
 // @ts-ignore
 
@@ -747,6 +748,165 @@ describe('Auth0Client', () => {
       await auth0.loginWithCustomTokenExchange(cteOptions);
 
       expect(capturedRequestOptions.organization).toEqual('org_12345');
+    });
+  });
+
+  describe('customTokenExchange()', () => {
+    const mockTokenResponse = {
+      id_token: TEST_ID_TOKEN,
+      access_token: TEST_ACCESS_TOKEN,
+      token_type: 'Bearer',
+      expires_in: 86400
+    };
+
+    const localSetup = (clientOptions?: Partial<Auth0ClientOptions>) => {
+      const auth0 = setup(clientOptions);
+      setupMessageEventLister(mockWindow, { state: TEST_STATE });
+      jest.spyOn(api, 'oauthToken').mockResolvedValue(mockTokenResponse as any);
+      return auth0;
+    };
+
+    it('calls oauthToken directly with skipTokenStorage: true', async () => {
+      const auth0 = localSetup();
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      expect(api.oauthToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+          subject_token: 'external_token',
+          subject_token_type: 'urn:acme:legacy-token'
+        }),
+        undefined,
+        true // skipTokenStorage
+      );
+    });
+
+    it('does not affect the current session', async () => {
+      const auth0 = localSetup();
+
+      expect(await auth0.isAuthenticated()).toBe(false);
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      expect(await auth0.isAuthenticated()).toBe(false);
+    });
+
+    it('returns the token response', async () => {
+      const auth0 = localSetup();
+
+      const result = await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      expect(result.access_token).toEqual(TEST_ACCESS_TOKEN);
+      expect(result.id_token).toEqual(TEST_ID_TOKEN);
+      expect(result.expires_in).toEqual(86400);
+    });
+
+    it('passes actor_token and actor_token_type when provided', async () => {
+      const auth0 = localSetup();
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token',
+        actor_token: 'agent_token',
+        actor_token_type: 'https://idp.example.com/token-type/agent'
+      });
+
+      expect(api.oauthToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actor_token: 'agent_token',
+          actor_token_type: 'https://idp.example.com/token-type/agent'
+        }),
+        undefined,
+        true
+      );
+    });
+
+    it('does not include actor_token when not provided', async () => {
+      const auth0 = localSetup();
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      const calledWith = (api.oauthToken as jest.Mock).mock.calls[0][0];
+      expect(calledWith.actor_token).toBeUndefined();
+      expect(calledWith.actor_token_type).toBeUndefined();
+    });
+
+    it('falls back to client default audience', async () => {
+      const auth0 = localSetup({
+        authorizationParams: { audience: 'https://default-api.com' }
+      });
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      expect(api.oauthToken).toHaveBeenCalledWith(
+        expect.objectContaining({ audience: 'https://default-api.com' }),
+        undefined,
+        true
+      );
+    });
+
+    it('uses provided audience over client default', async () => {
+      const auth0 = localSetup({
+        authorizationParams: { audience: 'https://default-api.com' }
+      });
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token',
+        audience: 'https://downstream-api.com'
+      });
+
+      expect(api.oauthToken).toHaveBeenCalledWith(
+        expect.objectContaining({ audience: 'https://downstream-api.com' }),
+        undefined,
+        true
+      );
+    });
+
+    it('passes organization when provided', async () => {
+      const auth0 = localSetup();
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token',
+        organization: 'org_12345'
+      });
+
+      expect(api.oauthToken).toHaveBeenCalledWith(
+        expect.objectContaining({ organization: 'org_12345' }),
+        undefined,
+        true
+      );
+    });
+
+    it('propagates errors from oauthToken', async () => {
+      const auth0 = setup();
+      jest
+        .spyOn(api, 'oauthToken')
+        .mockRejectedValue(new Error('invalid_grant'));
+
+      await expect(
+        auth0.customTokenExchange({
+          subject_token: 'bad_token',
+          subject_token_type: 'urn:acme:legacy-token'
+        })
+      ).rejects.toThrow('invalid_grant');
     });
   });
 

--- a/__tests__/Auth0Client/exchangeToken.test.ts
+++ b/__tests__/Auth0Client/exchangeToken.test.ts
@@ -908,6 +908,35 @@ describe('Auth0Client', () => {
         })
       ).rejects.toThrow('invalid_grant');
     });
+
+    it('verifies the id_token when present in the response', async () => {
+      const auth0 = localSetup();
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      expect(mockVerify).toHaveBeenCalledWith(
+        expect.objectContaining({ id_token: TEST_ID_TOKEN })
+      );
+    });
+
+    it('skips id_token verification when not present in the response', async () => {
+      const auth0 = setup();
+      jest.spyOn(api, 'oauthToken').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        token_type: 'Bearer',
+        expires_in: 86400
+      } as any);
+
+      await auth0.customTokenExchange({
+        subject_token: 'external_token',
+        subject_token_type: 'urn:acme:legacy-token'
+      });
+
+      expect(mockVerify).not.toHaveBeenCalled();
+    });
   });
 
   describe('exchangeToken() deprecation', () => {

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -1269,6 +1269,129 @@ describe('token worker', () => {
     });
   });
 
+  describe('skipTokenStorage', () => {
+    it('strips refresh_token from the response when skipTokenStorage is true', async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve({
+          ok: true,
+          json: () => ({ access_token: 'at', refresh_token: 'rt' }),
+          headers: new Headers()
+        })
+      );
+
+      const response = await messageHandlerAsync({
+        type: 'refresh',
+        skipTokenStorage: true,
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({ grant_type: 'token-exchange' })
+        },
+        auth: { audience: 'default', scope: 'openid' }
+      });
+
+      expect(response.json.refresh_token).toBeUndefined();
+      expect(response.json.access_token).toBe('at');
+    });
+
+    it('does not store the refresh_token when skipTokenStorage is true', async () => {
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          json: () => ({ access_token: 'at', refresh_token: 'rt' }),
+          headers: new Headers()
+        })
+      );
+
+      await messageHandlerAsync({
+        type: 'refresh',
+        skipTokenStorage: true,
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({ grant_type: 'token-exchange' })
+        },
+        auth: { audience: 'default', scope: 'openid' }
+      });
+
+      // Subsequent refresh_token grant should fail — nothing was stored
+      const response = await messageHandlerAsync({
+        type: 'refresh',
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({ grant_type: 'refresh_token' })
+        },
+        auth: { audience: 'default', scope: 'openid' }
+      });
+
+      expect(response.json.error).toBe('missing_refresh_token');
+      // Only one fetch call was made (the exchange); the refresh short-circuits
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not overwrite a previously stored refresh_token when skipTokenStorage is true', async () => {
+      // Seed a refresh token via a normal authorization_code grant
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          json: () => ({ refresh_token: 'stored_rt' }),
+          headers: new Headers()
+        })
+      );
+
+      await messageHandlerAsync({
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({ grant_type: 'authorization_code' })
+        },
+        auth: { audience: 'default', scope: 'openid' }
+      });
+
+      // Token exchange with skipTokenStorage — must not touch the stored RT
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          json: () => ({ access_token: 'at', refresh_token: 'exchange_rt' }),
+          headers: new Headers()
+        })
+      );
+
+      await messageHandlerAsync({
+        type: 'refresh',
+        skipTokenStorage: true,
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({ grant_type: 'token-exchange' })
+        },
+        auth: { audience: 'default', scope: 'openid' }
+      });
+
+      // The subsequent refresh_token grant must still use 'stored_rt'
+      mockFetch.mockReturnValueOnce(
+        Promise.resolve({
+          ok: true,
+          json: () => ({ access_token: 'new_at' }),
+          headers: new Headers()
+        })
+      );
+
+      await messageHandlerAsync({
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({ grant_type: 'refresh_token' })
+        },
+        auth: { audience: 'default', scope: 'openid' }
+      });
+
+      const refreshBody = JSON.parse(mockFetch.mock.calls[2][1].body);
+      expect(refreshBody.refresh_token).toBe('stored_rt');
+    });
+  });
+
   describe("useMrrt", () => {
     beforeEach(() => {
       originalFetch = window.fetch;

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1813,7 +1813,7 @@ export class Auth0Client {
   async customTokenExchange(
     options: CustomTokenExchangeOptions
   ): Promise<TokenEndpointResponse> {
-    return oauthToken(
+    const result = await oauthToken(
       {
         baseUrl: this.domainUrl,
         client_id: this.options.clientId,
@@ -1826,6 +1826,12 @@ export class Auth0Client {
       this.worker,
       true // skipTokenStorage — when using a worker, refresh_token is discarded inside it
     );
+
+    if (result.id_token) {
+      await this._verifyIdToken(result.id_token, undefined, options.organization);
+    }
+
+    return result;
   }
 
   /**

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1750,14 +1750,16 @@ export class Auth0Client {
    * }
    * ```
    */
-  async loginWithCustomTokenExchange(
+  private _buildTokenExchangeParams(
     options: CustomTokenExchangeOptions
-  ): Promise<TokenEndpointResponse> {
-    return this._requestToken({
+  ): TokenExchangeRequestOptions {
+    return {
       ...options,
       grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
       subject_token: options.subject_token,
       subject_token_type: options.subject_token_type,
+      ...(options.actor_token && { actor_token: options.actor_token }),
+      ...(options.actor_token_type && { actor_token_type: options.actor_token_type }),
       scope: scopesToRequest(
         this.scope,
         options.scope,
@@ -1765,7 +1767,63 @@ export class Auth0Client {
       ),
       audience: options.audience || this.options.authorizationParams.audience,
       organization: options.organization || this.options.authorizationParams.organization
-    });
+    };
+  }
+
+  async loginWithCustomTokenExchange(
+    options: CustomTokenExchangeOptions
+  ): Promise<TokenEndpointResponse> {
+    return this._requestToken(this._buildTokenExchangeParams(options));
+  }
+
+  /**
+   * ```js
+   * await auth0.customTokenExchange(options);
+   * ```
+   *
+   * Exchanges an external subject token for Auth0 tokens without affecting the current session.
+   *
+   * Unlike `loginWithCustomTokenExchange`, this method has no side effects — it does not cache
+   * tokens, does not update the authenticated session, and does not affect `isAuthenticated()`
+   * or `getUser()`. Use this for delegation or impersonation scenarios where you need a token
+   * for a downstream API but do not want to change who the current user is.
+   *
+   * When a Web Worker is configured, the refresh_token is discarded inside the worker and
+   * never reaches the main thread.
+   *
+   * @param {CustomTokenExchangeOptions} options - The options required to perform the token exchange.
+   * @returns {Promise<TokenEndpointResponse>} A promise that resolves to the token endpoint response.
+   *
+   * **Example:**
+   * ```js
+   * const tokenResponse = await auth0.customTokenExchange({
+   *   subject_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',
+   *   subject_token_type: 'urn:acme:legacy-system-token',
+   *   actor_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp...',
+   *   actor_token_type: 'https://idp.example.com/token-type/agent',
+   *   audience: 'https://api.example.com',
+   * });
+   *
+   * // Use tokenResponse.access_token to call downstream API
+   * // Current user session is unchanged
+   * ```
+   */
+  async customTokenExchange(
+    options: CustomTokenExchangeOptions
+  ): Promise<TokenEndpointResponse> {
+    return oauthToken(
+      {
+        baseUrl: this.domainUrl,
+        client_id: this.options.clientId,
+        auth0Client: this.options.auth0Client,
+        useFormData: this.options.useFormData,
+        timeout: this.httpTimeoutMs,
+        dpop: this.dpop,
+        ...this._buildTokenExchangeParams(options)
+      },
+      this.worker,
+      true // skipTokenStorage — when using a worker, refresh_token is discarded inside it
+    );
   }
 
   /**

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1815,13 +1815,13 @@ export class Auth0Client {
   ): Promise<TokenEndpointResponse> {
     const result = await oauthToken(
       {
+        ...this._buildTokenExchangeParams(options),
         baseUrl: this.domainUrl,
         client_id: this.options.clientId,
         auth0Client: this.options.auth0Client,
         useFormData: this.options.useFormData,
         timeout: this.httpTimeoutMs,
         dpop: this.dpop,
-        ...this._buildTokenExchangeParams(options)
       },
       this.worker,
       true // skipTokenStorage — when using a worker, refresh_token is discarded inside it

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1789,7 +1789,9 @@ export class Auth0Client {
    * for a downstream API but do not want to change who the current user is.
    *
    * When a Web Worker is configured, the refresh_token is discarded inside the worker and
-   * never reaches the main thread.
+   * never reaches the main thread. When no Web Worker is configured, the raw authorization
+   * server response is returned — if a refresh_token is present, discard it; this method
+   * intentionally does not store it.
    *
    * @param {CustomTokenExchangeOptions} options - The options required to perform the token exchange.
    * @returns {Promise<TokenEndpointResponse>} A promise that resolves to the token endpoint response.

--- a/src/TokenExchange.ts
+++ b/src/TokenExchange.ts
@@ -65,6 +65,30 @@ export type CustomTokenExchangeOptions = {
   organization?: string;
 
   /**
+   * A token representing the acting party for delegation or impersonation scenarios.
+   *
+   * @remarks
+   * Used when one principal needs to act on behalf of another.
+   * For example, an AI agent acting on behalf of a user.
+   *
+   * @example
+   * "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  actor_token?: string;
+
+  /**
+   * The type identifier for the actor token.
+   *
+   * @remarks
+   * Must be a URI under your organization's control, following the same
+   * rules as subject_token_type.
+   *
+   * @example
+   * "https://idp.example.com/token-type/agent"
+   */
+  actor_token_type?: string;
+
+  /**
    * Additional custom parameters for Auth0 Action processing
    *
    * @remarks

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,7 +40,8 @@ export async function oauthToken(
     dpop,
     ...options
   }: TokenEndpointOptions,
-  worker?: Worker
+  worker?: Worker,
+  skipTokenStorage?: boolean
 ) {
   const isTokenExchange =
     options.grant_type === 'urn:ietf:params:oauth:grant-type:token-exchange';
@@ -80,7 +81,9 @@ export async function oauthToken(
     worker,
     useFormData,
     useMrrt,
-    isDpopSupported ? dpop : undefined
+    isDpopSupported ? dpop : undefined,
+    undefined,
+    skipTokenStorage
   );
 }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -895,6 +895,7 @@ export class User {
   address?: string;
   updated_at?: string;
   sub?: string;
+  act?: ActClaim;
   [key: string]: any;
 }
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -812,6 +812,20 @@ export interface JWTVerifyOptions {
   now?: number;
 }
 
+/**
+ * Represents the actor claim (`act`) in an ID token returned via a token exchange response.
+ *
+ * The `act` claim identifies the acting party — the entity that has been delegated authority
+ * to act on behalf of the subject. It is set via Auth0 Actions using the `setActor` command.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8693#section-4.1 | RFC 8693 Section 4.1}
+ */
+export interface ActClaim {
+  /** The identifier of the acting party. */
+  sub?: string;
+  [key: string]: any;
+}
+
 export interface IdToken {
   __raw: string;
   name?: string;
@@ -851,6 +865,12 @@ export interface IdToken {
   sid?: string;
   org_id?: string;
   org_name?: string;
+  /**
+   * The actor claim, present in ID tokens returned via token exchange responses.
+   * Identifies the acting party that has been delegated authority to act on behalf
+   * of the subject. Set via Auth0 Actions using the `setActor` command.
+   */
+  act?: ActClaim;
   [key: string]: any;
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -72,7 +72,8 @@ const fetchWithWorker = async (
   timeout: number,
   worker: Worker,
   useFormData?: boolean,
-  useMrrt?: boolean
+  useMrrt?: boolean,
+  skipTokenStorage?: boolean
 ) => {
   return sendMessage(
     {
@@ -85,7 +86,8 @@ const fetchWithWorker = async (
       fetchUrl,
       fetchOptions,
       useFormData,
-      useMrrt
+      useMrrt,
+      skipTokenStorage
     },
     worker
   );
@@ -100,6 +102,7 @@ export const switchFetch = async (
   useFormData?: boolean,
   timeout = DEFAULT_FETCH_TIMEOUT_MS,
   useMrrt?: boolean,
+  skipTokenStorage?: boolean
 ): Promise<any> => {
   if (worker) {
     return fetchWithWorker(
@@ -110,7 +113,8 @@ export const switchFetch = async (
       timeout,
       worker,
       useFormData,
-      useMrrt
+      useMrrt,
+      skipTokenStorage
     );
   } else {
     return fetchWithoutWorker(fetchUrl, fetchOptions, timeout);
@@ -127,7 +131,8 @@ export async function getJSON<T>(
   useFormData?: boolean,
   useMrrt?: boolean,
   dpop?: Pick<Dpop, 'generateProof' | 'getNonce' | 'setNonce'>,
-  isDpopRetry?: boolean
+  isDpopRetry?: boolean,
+  skipTokenStorage?: boolean
 ): Promise<T> {
   if (dpop) {
     const dpopProof = await dpop.generateProof({
@@ -153,6 +158,7 @@ export async function getJSON<T>(
         useFormData,
         timeout,
         useMrrt,
+        skipTokenStorage
       );
       fetchError = null;
       break;
@@ -225,7 +231,8 @@ export async function getJSON<T>(
         useFormData,
         useMrrt,
         dpop,
-        true // !
+        true, // !
+        skipTokenStorage
       );
     }
 

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -82,7 +82,7 @@ const checkDownscoping = (scope: string, audience: string): boolean => {
 }
 
 const messageHandler = async ({
-  data: { timeout, auth, fetchUrl, fetchOptions, useFormData, useMrrt },
+  data: { timeout, auth, fetchUrl, fetchOptions, useFormData, useMrrt, skipTokenStorage },
   ports: [port]
 }: MessageEvent<WorkerRefreshTokenMessage>) => {
   let headers: FetchResponse['headers'] = {};
@@ -168,23 +168,28 @@ const messageHandler = async ({
     headers = fromEntries(response.headers);
     json = await response.json();
 
-    if (json.refresh_token) {
-      // If useMrrt is configured to true we want to save the latest refresh_token
-      // to be used when refreshing tokens with MRRT
-      if (useMrrt) {
-        refreshTokens["latest_refresh_token"] = json.refresh_token;
+    if (!skipTokenStorage) {
+      if (json.refresh_token) {
+        // If useMrrt is configured to true we want to save the latest refresh_token
+        // to be used when refreshing tokens with MRRT
+        if (useMrrt) {
+          refreshTokens["latest_refresh_token"] = json.refresh_token;
 
-        // To avoid having some refresh_token that has already been used
-        // we will update those inside the list with the new one obtained
-        // by the server
-        updateRefreshTokens(refreshToken, json.refresh_token);
+          // To avoid having some refresh_token that has already been used
+          // we will update those inside the list with the new one obtained
+          // by the server
+          updateRefreshTokens(refreshToken, json.refresh_token);
+        }
+
+        setRefreshToken(json.refresh_token, audience, scope);
+      } else {
+        deleteRefreshToken(audience, scope);
       }
-
-      setRefreshToken(json.refresh_token, audience, scope);
-      delete json.refresh_token;
-    } else {
-      deleteRefreshToken(audience, scope);
     }
+
+    // Always strip — the worker manages refresh tokens internally,
+    // they must never reach the main thread.
+    delete json.refresh_token;
 
     port.postMessage({
       ok: response.ok,

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -168,28 +168,29 @@ const messageHandler = async ({
     headers = fromEntries(response.headers);
     json = await response.json();
 
-    if (!skipTokenStorage) {
-      if (json.refresh_token) {
-        // If useMrrt is configured to true we want to save the latest refresh_token
-        // to be used when refreshing tokens with MRRT
-        if (useMrrt) {
-          refreshTokens["latest_refresh_token"] = json.refresh_token;
-
-          // To avoid having some refresh_token that has already been used
-          // we will update those inside the list with the new one obtained
-          // by the server
-          updateRefreshTokens(refreshToken, json.refresh_token);
-        }
-
-        setRefreshToken(json.refresh_token, audience, scope);
-      } else {
-        deleteRefreshToken(audience, scope);
-      }
+    if (skipTokenStorage) {
+      delete json.refresh_token;
+      port.postMessage({ ok: response.ok, json, headers });
+      return;
     }
 
-    // Always strip — the worker manages refresh tokens internally,
-    // they must never reach the main thread.
-    delete json.refresh_token;
+    if (json.refresh_token) {
+      // If useMrrt is configured to true we want to save the latest refresh_token
+      // to be used when refreshing tokens with MRRT
+      if (useMrrt) {
+        refreshTokens["latest_refresh_token"] = json.refresh_token;
+
+        // To avoid having some refresh_token that has already been used
+        // we will update those inside the list with the new one obtained
+        // by the server
+        updateRefreshTokens(refreshToken, json.refresh_token);
+      }
+
+      setRefreshToken(json.refresh_token, audience, scope);
+      delete json.refresh_token;
+    } else {
+      deleteRefreshToken(audience, scope);
+    }
 
     port.postMessage({
       ok: response.ok,

--- a/src/worker/worker.types.ts
+++ b/src/worker/worker.types.ts
@@ -19,6 +19,7 @@ type WorkerTokenMessage = {
 export type WorkerRefreshTokenMessage = WorkerTokenMessage & {
   type: 'refresh';
   useMrrt?: boolean;
+  skipTokenStorage?: boolean;
 };
 
 export type WorkerRevokeTokenMessage = Omit<WorkerTokenMessage, 'auth'> & {


### PR DESCRIPTION
## Summary

Adds delegation and impersonation support for Custom Token Exchange (CTE) per RFC 8693, allowing an actor (e.g. an AI agent or support rep) to act on behalf of a user.

- Add `customTokenExchange()` for stateless token exchange (no session side effects)
- Add `actor_token` and `actor_token_type` to `CustomTokenExchangeOptions`
- Add `ActClaim` type and `act` claim to `IdToken` and `User`
- Add `skipTokenStorage` flag so `refresh_token` is discarded inside the worker and never reaches the main thread (non-worker path returns the raw response as documented)
- `customTokenExchange()` validates `id_token` when present, consistent with `loginWithCustomTokenExchange`

## Test plan

- [x] All existing tests pass (938 passing)
- [x] `customTokenExchange()`: no session side effects, correct params, actor token, audience/org fallback
- [x] `customTokenExchange()`: `id_token` verified when present, skipped when absent
- [x] Worker `skipTokenStorage`: response stripping, no storage side-effect, no overwrite of existing tokens
- [x] `loginWithCustomTokenExchange()` with actor token, `isAuthenticated()` returns true
- [x] `getIdTokenClaims().act` and `getUser().act` populated correctly
- [x] No error when `refresh_token` is absent (suppressed by Auth0 when `actor_token` is present)
- [x] Auth0 error codes surfaced via standard SDK error types

## Intentional omissions

- **Paired parameter validation:** Auth0 returns a clear error (`invalid_request`). No benefit duplicating this client-side.
- **URI validation:** Auth0 validates server-side and returns a clear error. Duplicating adds complexity with no real benefit.