### PR TITLE
feat: add Passkeys support via PasskeyApiClient

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -925,17 +925,14 @@ This is useful when you need to:
 
 ## Passkeys
 
-Passkeys provide password-less authentication using platform biometrics (Face ID, Touch ID, Windows Hello) or security keys via the WebAuthn standard. The SDK supports three flows:
+Passkeys provide password-less authentication using platform biometrics (Face ID, Touch ID, Windows Hello) or security keys via the WebAuthn standard. The SDK supports two flows:
 
 1. **Signup**: Register a new user with a passkey
 2. **Login**: Authenticate an existing user with a passkey
-3. **Enrollment**: Add a passkey to an already-authenticated user's account
 
 - [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys)
 - [Signup with Passkey](#signup-with-passkey)
 - [Login with Passkey](#login-with-passkey)
-- [Passkey Enrollment (Authenticated Users)](#passkey-enrollment-authenticated-users)
-- [Credential Serialization Helper](#credential-serialization-helper)
 - [Complete Passkey Flow Example](#complete-passkey-flow-example)
 - [Error Handling](#passkey-error-handling)
 
@@ -1052,101 +1049,15 @@ const tokens = await auth0.passkey.login({
 });
 ```
 
-### Passkey Enrollment (Authenticated Users)
-
-Allow an already-authenticated user to add a passkey to their account. This uses the My Account API and requires a valid access token.
-
-```js
-// User must already be logged in
-const isAuthenticated = await auth0.isAuthenticated();
-
-if (isAuthenticated) {
-  // 1. Request an enrollment challenge
-  const enrollment = await auth0.passkey.enrollmentChallenge();
-
-  // 2. Create the credential
-  const credential = await navigator.credentials.create({
-    publicKey: enrollment.authnParamsPublicKey
-  });
-
-  // 3. Verify the enrollment
-  await auth0.passkey.enrollmentVerify({
-    authSession: enrollment.authSession,
-    credential: serializeCredential(credential)
-  });
-
-  console.log('Passkey enrolled successfully');
-}
-```
-
-#### Enrollment Options
-
-```js
-// Specify a connection or identity for multi-identity users
-const enrollment = await auth0.passkey.enrollmentChallenge({
-  connection: 'Username-Password-Authentication',
-  identity: 'auth0|user123'
-});
-```
-
-### Credential Serialization Helper
-
-For **enrollment**, the WebAuthn ceremony is not handled automatically by the SDK (since authenticated users may need custom UI between steps). You'll need to serialize the credential manually. Here's a helper:
-
-```js
-function serializeCredential(credential) {
-  const response = {};
-
-  if (credential.response.attestationObject) {
-    response.attestationObject = bufferToBase64Url(
-      credential.response.attestationObject
-    );
-  }
-
-  response.clientDataJSON = bufferToBase64Url(
-    credential.response.clientDataJSON
-  );
-
-  return {
-    id: credential.id,
-    rawId: bufferToBase64Url(credential.rawId),
-    type: credential.type,
-    authenticatorAttachment: credential.authenticatorAttachment,
-    response,
-    clientExtensionResults: credential.getClientExtensionResults()
-  };
-}
-
-function bufferToBase64Url(buffer) {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-}
-```
-
-> [!NOTE]
-> The `serializeCredential` helper is only needed for enrollment. For `signup()` and `login()`, the SDK handles WebAuthn and serialization internally.
-
 ### Complete Passkey Flow Example
-
-A full example implementing signup, login, and enrollment with proper error handling:
 
 ```js
 import { createAuth0Client } from '@auth0/auth0-spa-js';
-import {
-  PasskeyEnrollmentError,
-  PasskeyEnrollmentVerifyError
-} from '@auth0/auth0-spa-js';
 
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
+  useRefreshTokens: true,
   authorizationParams: {
     redirect_uri: '<MY_CALLBACK_URL>'
   }
@@ -1163,56 +1074,12 @@ async function loginWithPasskey() {
   await auth0.passkey.login();
   return await auth0.getUser();
 }
-
-// --- Enrollment (multi-step, WebAuthn handled by caller) ---
-async function enrollPasskey() {
-  const enrollment = await auth0.passkey.enrollmentChallenge();
-
-  const credential = await navigator.credentials.create({
-    publicKey: enrollment.authnParamsPublicKey
-  });
-
-  if (!credential) {
-    throw new Error('User cancelled the credential creation');
-  }
-
-  await auth0.passkey.enrollmentVerify({
-    authSession: enrollment.authSession,
-    credential: serializeCredential(credential)
-  });
-}
 ```
 
 ### Passkey Error Handling
 
-```js
-import {
-  PasskeyEnrollmentError,
-  PasskeyEnrollmentVerifyError
-} from '@auth0/auth0-spa-js';
-
-try {
-  await auth0.passkey.enrollmentChallenge();
-} catch (error) {
-  if (error instanceof PasskeyEnrollmentError) {
-    console.error('Enrollment failed:', error.message);
-    console.error('Error code:', error.code);
-    console.error('API details:', error.cause);
-  }
-}
-
-try {
-  await auth0.passkey.enrollmentVerify({ authSession, credential });
-} catch (error) {
-  if (error instanceof PasskeyEnrollmentVerifyError) {
-    console.error('Verification failed:', error.message);
-    console.error('API details:', error.cause);
-  }
-}
-```
-
 > [!TIP]
-> For `signup()` and `login()`, the SDK throws an `Error` with a descriptive message if the user cancels the biometric prompt (i.e., the WebAuthn API returns `null`). Wrap calls in try/catch to handle cancellation, network failures, or misconfigured connections.
+> Both `signup()` and `login()` throw an `Error` with a descriptive message if the user cancels the biometric prompt (i.e., the WebAuthn API returns `null`). Wrap calls in try/catch to handle cancellation, network failures, or misconfigured connections.
 
 ## Multi-Factor Authentication (MFA)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1005,6 +1005,17 @@ const tokens = await auth0.passkey.signup({
 });
 ```
 
+#### Organization-Scoped Signup
+
+To register a user within an organization context:
+
+```js
+const tokens = await auth0.passkey.signup({
+  email: 'user@example.com',
+  organization: 'org_abc123'
+});
+```
+
 > [!NOTE]
 > `passkey.signup()` and `passkey.login()` cache tokens and establish a session automatically, just like `loginWithRedirect()`. After calling them, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` all work as expected.
 >
@@ -1028,6 +1039,16 @@ If your tenant has multiple database connections with passkeys enabled, specify 
 ```js
 const tokens = await auth0.passkey.login({
   realm: 'Username-Password-Authentication'
+});
+```
+
+#### Organization-Scoped Login
+
+To authenticate within an organization context:
+
+```js
+const tokens = await auth0.passkey.login({
+  organization: 'org_abc123'
 });
 ```
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -931,6 +931,7 @@ Passkeys provide password-less authentication using platform biometrics (Face ID
 2. **Login**: Authenticate an existing user with a passkey
 3. **Enrollment**: Add a passkey to an already-authenticated user's account
 
+- [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys)
 - [Signup with Passkey](#signup-with-passkey)
 - [Login with Passkey](#login-with-passkey)
 - [Passkey Enrollment (Authenticated Users)](#passkey-enrollment-authenticated-users)
@@ -941,6 +942,32 @@ Passkeys provide password-less authentication using platform biometrics (Face ID
 ### Setup
 
 Before using passkeys, enable the Database Connection with passkey support in your [Auth0 Dashboard](https://manage.auth0.com) under **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
+
+### Important: Use Refresh Tokens with Passkeys
+
+> [!IMPORTANT]
+> When using passkeys, you **must** configure the SDK with `useRefreshTokens: true`.
+
+Passkey authentication uses a direct token exchange (`/oauth/token` with the WebAuthn grant type). It does **not** create an Auth0 session cookie because there is no redirect to `/authorize`. This means that when the access token expires, the SDK cannot silently obtain a new one using an iframe (which relies on the Auth0 session cookie via `prompt=none`).
+
+Without refresh tokens, `getTokenSilently()` will either:
+- Fail with a `login_required` error (if no Auth0 session exists), or
+- Return tokens for a **different user** if a separate Auth0 session cookie exists from a prior redirect-based login, causing an unintended session swap.
+
+To avoid this, always enable refresh tokens:
+
+```js
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  useRefreshTokens: true, // Required for passkey-based sessions
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+```
+
+You must also enable **Refresh Token Rotation** in your Auth0 Dashboard under **Applications** > your app > **Settings** > **Refresh Token Rotation**.
 
 ### Signup with Passkey
 
@@ -980,6 +1007,8 @@ const tokens = await auth0.passkey.signup({
 
 > [!NOTE]
 > `passkey.signup()` and `passkey.login()` cache tokens and establish a session automatically, just like `loginWithRedirect()`. After calling them, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` all work as expected.
+>
+> Remember to configure `useRefreshTokens: true`. See [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys).
 
 ### Login with Passkey
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -927,9 +927,9 @@ This is useful when you need to:
 
 Passkeys provide password-less authentication using platform biometrics (Face ID, Touch ID, Windows Hello) or security keys via the WebAuthn standard. The SDK supports three flows:
 
-1. **Signup** — Register a new user with a passkey
-2. **Login** — Authenticate an existing user with a passkey
-3. **Enrollment** — Add a passkey to an already-authenticated user's account
+1. **Signup**: Register a new user with a passkey
+2. **Login**: Authenticate an existing user with a passkey
+3. **Enrollment**: Add a passkey to an already-authenticated user's account
 
 - [Signup with Passkey](#signup-with-passkey)
 - [Login with Passkey](#login-with-passkey)
@@ -944,7 +944,7 @@ Before using passkeys, enable the Database Connection with passkey support in yo
 
 ### Signup with Passkey
 
-Register a new user by requesting a signup challenge, creating a credential with the browser's WebAuthn API, then exchanging it for tokens.
+Register a new user with a passkey. The SDK handles the entire flow internally: requesting a challenge from Auth0, triggering the browser's WebAuthn credential creation ceremony, serializing the result, and exchanging it for tokens.
 
 ```js
 import { createAuth0Client } from '@auth0/auth0-spa-js';
@@ -957,21 +957,10 @@ const auth0 = await createAuth0Client({
   }
 });
 
-// 1. Request a signup challenge
-const challenge = await auth0.passkey.signupChallenge({
+// One call handles everything — the user sees the biometric prompt
+const tokens = await auth0.passkey.signup({
   email: 'user@example.com',
   name: 'Jane Doe' // optional display name
-});
-
-// 2. Create the credential using the browser WebAuthn API
-const credential = await navigator.credentials.create({
-  publicKey: challenge.authnParamsPublicKey
-});
-
-// 3. Exchange the credential for tokens (session is established automatically)
-const tokens = await auth0.passkey.signinWithPasskey({
-  authSession: challenge.authSession,
-  credential: serializeCredential(credential)
 });
 
 // User is now logged in — getUser() works immediately
@@ -979,26 +968,25 @@ const user = await auth0.getUser();
 console.log('Signed up:', user);
 ```
 
-> [!NOTE] > `signinWithPasskey()` caches tokens and establishes a session automatically, just like `loginWithRedirect()`. After calling it, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` all work as expected.
+You can also pass `scope` and `audience` to control the access token:
+
+```js
+const tokens = await auth0.passkey.signup({
+  email: 'user@example.com',
+  scope: 'openid profile email read:products',
+  audience: 'https://api.example.com'
+});
+```
+
+> [!NOTE]
+> `passkey.signup()` and `passkey.login()` cache tokens and establish a session automatically, just like `loginWithRedirect()`. After calling them, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` all work as expected.
 
 ### Login with Passkey
 
-Authenticate an existing user with their registered passkey.
+Authenticate an existing user with their registered passkey. Like signup, a single call handles the entire flow.
 
 ```js
-// 1. Request a login challenge
-const challenge = await auth0.passkey.loginChallenge();
-
-// 2. Get the credential using the browser WebAuthn API
-const credential = await navigator.credentials.get({
-  publicKey: challenge.authnParamsPublicKey
-});
-
-// 3. Exchange the credential for tokens
-const tokens = await auth0.passkey.signinWithPasskey({
-  authSession: challenge.authSession,
-  credential: serializeCredential(credential)
-});
+const tokens = await auth0.passkey.login();
 
 const user = await auth0.getUser();
 console.log('Logged in:', user);
@@ -1009,7 +997,7 @@ console.log('Logged in:', user);
 If your tenant has multiple database connections with passkeys enabled, specify the `realm`:
 
 ```js
-const challenge = await auth0.passkey.loginChallenge({
+const tokens = await auth0.passkey.login({
   realm: 'Username-Password-Authentication'
 });
 ```
@@ -1053,7 +1041,7 @@ const enrollment = await auth0.passkey.enrollmentChallenge({
 
 ### Credential Serialization Helper
 
-The WebAuthn API returns `ArrayBuffer` values that must be serialized to base64url strings before sending to Auth0. Here's a helper function:
+For **enrollment**, the WebAuthn ceremony is not handled automatically by the SDK (since authenticated users may need custom UI between steps). You'll need to serialize the credential manually. Here's a helper:
 
 ```js
 function serializeCredential(credential) {
@@ -1063,17 +1051,6 @@ function serializeCredential(credential) {
     response.attestationObject = bufferToBase64Url(
       credential.response.attestationObject
     );
-  }
-  if (credential.response.authenticatorData) {
-    response.authenticatorData = bufferToBase64Url(
-      credential.response.authenticatorData
-    );
-  }
-  if (credential.response.signature) {
-    response.signature = bufferToBase64Url(credential.response.signature);
-  }
-  if (credential.response.userHandle) {
-    response.userHandle = bufferToBase64Url(credential.response.userHandle);
   }
 
   response.clientDataJSON = bufferToBase64Url(
@@ -1103,6 +1080,9 @@ function bufferToBase64Url(buffer) {
 }
 ```
 
+> [!NOTE]
+> The `serializeCredential` helper is only needed for enrollment. For `signup()` and `login()`, the SDK handles WebAuthn and serialization internally.
+
 ### Complete Passkey Flow Example
 
 A full example implementing signup, login, and enrollment with proper error handling:
@@ -1122,50 +1102,19 @@ const auth0 = await createAuth0Client({
   }
 });
 
-// --- Signup ---
+// --- Signup (single call) ---
 async function signupWithPasskey(email, displayName) {
-  const challenge = await auth0.passkey.signupChallenge({
-    email,
-    name: displayName
-  });
-
-  const credential = await navigator.credentials.create({
-    publicKey: challenge.authnParamsPublicKey
-  });
-
-  if (!credential) {
-    throw new Error('User cancelled the credential creation');
-  }
-
-  await auth0.passkey.signinWithPasskey({
-    authSession: challenge.authSession,
-    credential: serializeCredential(credential)
-  });
-
+  await auth0.passkey.signup({ email, name: displayName });
   return await auth0.getUser();
 }
 
-// --- Login ---
+// --- Login (single call) ---
 async function loginWithPasskey() {
-  const challenge = await auth0.passkey.loginChallenge();
-
-  const credential = await navigator.credentials.get({
-    publicKey: challenge.authnParamsPublicKey
-  });
-
-  if (!credential) {
-    throw new Error('User cancelled the credential request');
-  }
-
-  await auth0.passkey.signinWithPasskey({
-    authSession: challenge.authSession,
-    credential: serializeCredential(credential)
-  });
-
+  await auth0.passkey.login();
   return await auth0.getUser();
 }
 
-// --- Enrollment ---
+// --- Enrollment (multi-step, WebAuthn handled by caller) ---
 async function enrollPasskey() {
   const enrollment = await auth0.passkey.enrollmentChallenge();
 
@@ -1213,10 +1162,7 @@ try {
 ```
 
 > [!TIP]
-> For signup and login challenge errors, the SDK propagates the underlying network or API errors directly. Wrap challenge calls in try/catch to handle cases like network failures or misconfigured connections.
-
-> [!IMPORTANT]
-> The WebAuthn API (`navigator.credentials.create()` / `navigator.credentials.get()`) may return `null` if the user cancels the biometric prompt. Always check for `null` before calling `signinWithPasskey()`.
+> For `signup()` and `login()`, the SDK throws an `Error` with a descriptive message if the user cancels the biometric prompt (i.e., the WebAuthn API returns `null`). Wrap calls in try/catch to handle cancellation, network failures, or misconfigured connections.
 
 ## Multi-Factor Authentication (MFA)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,6 +10,7 @@
 - [Device-bound tokens with DPoP](#device-bound-tokens-with-dpop)
 - [Connect Accounts for using Token Vault](#connect-accounts-for-using-token-vault)
 - [Accessing SDK Configuration](#accessing-sdk-configuration)
+- [Passkeys](#passkeys)
 - [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
 - [Step-Up Authentication](#step-up-authentication)
 
@@ -898,7 +899,6 @@ You can now [call the API](#calling-an-api) with your access token and the API c
 > [!IMPORTANT]
 > You must enable `Offline Access` from the Connection Permissions settings to be able to use the connection with Connected Accounts.
 
-
 ## Accessing SDK Configuration
 
 After initializing the Auth0Client, you can retrieve the configuration details:
@@ -923,12 +923,307 @@ This is useful when you need to:
 - Pass configuration to other services or analytics
 - Verify the SDK is configured correctly
 
+## Passkeys
+
+Passkeys provide password-less authentication using platform biometrics (Face ID, Touch ID, Windows Hello) or security keys via the WebAuthn standard. The SDK supports three flows:
+
+1. **Signup** — Register a new user with a passkey
+2. **Login** — Authenticate an existing user with a passkey
+3. **Enrollment** — Add a passkey to an already-authenticated user's account
+
+- [Signup with Passkey](#signup-with-passkey)
+- [Login with Passkey](#login-with-passkey)
+- [Passkey Enrollment (Authenticated Users)](#passkey-enrollment-authenticated-users)
+- [Credential Serialization Helper](#credential-serialization-helper)
+- [Complete Passkey Flow Example](#complete-passkey-flow-example)
+- [Error Handling](#passkey-error-handling)
+
+### Setup
+
+Before using passkeys, enable the Database Connection with passkey support in your [Auth0 Dashboard](https://manage.auth0.com) under **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
+
+### Signup with Passkey
+
+Register a new user by requesting a signup challenge, creating a credential with the browser's WebAuthn API, then exchanging it for tokens.
+
+```js
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+
+// 1. Request a signup challenge
+const challenge = await auth0.passkey.signupChallenge({
+  email: 'user@example.com',
+  name: 'Jane Doe' // optional display name
+});
+
+// 2. Create the credential using the browser WebAuthn API
+const credential = await navigator.credentials.create({
+  publicKey: challenge.authnParamsPublicKey
+});
+
+// 3. Exchange the credential for tokens (session is established automatically)
+const tokens = await auth0.passkey.signinWithPasskey({
+  authSession: challenge.authSession,
+  credential: serializeCredential(credential)
+});
+
+// User is now logged in — getUser() works immediately
+const user = await auth0.getUser();
+console.log('Signed up:', user);
+```
+
+> [!NOTE] > `signinWithPasskey()` caches tokens and establishes a session automatically, just like `loginWithRedirect()`. After calling it, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` all work as expected.
+
+### Login with Passkey
+
+Authenticate an existing user with their registered passkey.
+
+```js
+// 1. Request a login challenge
+const challenge = await auth0.passkey.loginChallenge();
+
+// 2. Get the credential using the browser WebAuthn API
+const credential = await navigator.credentials.get({
+  publicKey: challenge.authnParamsPublicKey
+});
+
+// 3. Exchange the credential for tokens
+const tokens = await auth0.passkey.signinWithPasskey({
+  authSession: challenge.authSession,
+  credential: serializeCredential(credential)
+});
+
+const user = await auth0.getUser();
+console.log('Logged in:', user);
+```
+
+#### Specifying a Realm
+
+If your tenant has multiple database connections with passkeys enabled, specify the `realm`:
+
+```js
+const challenge = await auth0.passkey.loginChallenge({
+  realm: 'Username-Password-Authentication'
+});
+```
+
+### Passkey Enrollment (Authenticated Users)
+
+Allow an already-authenticated user to add a passkey to their account. This uses the My Account API and requires a valid access token.
+
+```js
+// User must already be logged in
+const isAuthenticated = await auth0.isAuthenticated();
+
+if (isAuthenticated) {
+  // 1. Request an enrollment challenge
+  const enrollment = await auth0.passkey.enrollmentChallenge();
+
+  // 2. Create the credential
+  const credential = await navigator.credentials.create({
+    publicKey: enrollment.authnParamsPublicKey
+  });
+
+  // 3. Verify the enrollment
+  await auth0.passkey.enrollmentVerify({
+    authSession: enrollment.authSession,
+    credential: serializeCredential(credential)
+  });
+
+  console.log('Passkey enrolled successfully');
+}
+```
+
+#### Enrollment Options
+
+```js
+// Specify a connection or identity for multi-identity users
+const enrollment = await auth0.passkey.enrollmentChallenge({
+  connection: 'Username-Password-Authentication',
+  identity: 'auth0|user123'
+});
+```
+
+### Credential Serialization Helper
+
+The WebAuthn API returns `ArrayBuffer` values that must be serialized to base64url strings before sending to Auth0. Here's a helper function:
+
+```js
+function serializeCredential(credential) {
+  const response = {};
+
+  if (credential.response.attestationObject) {
+    response.attestationObject = bufferToBase64Url(
+      credential.response.attestationObject
+    );
+  }
+  if (credential.response.authenticatorData) {
+    response.authenticatorData = bufferToBase64Url(
+      credential.response.authenticatorData
+    );
+  }
+  if (credential.response.signature) {
+    response.signature = bufferToBase64Url(credential.response.signature);
+  }
+  if (credential.response.userHandle) {
+    response.userHandle = bufferToBase64Url(credential.response.userHandle);
+  }
+
+  response.clientDataJSON = bufferToBase64Url(
+    credential.response.clientDataJSON
+  );
+
+  return {
+    id: credential.id,
+    rawId: bufferToBase64Url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment,
+    response,
+    clientExtensionResults: credential.getClientExtensionResults()
+  };
+}
+
+function bufferToBase64Url(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+```
+
+### Complete Passkey Flow Example
+
+A full example implementing signup, login, and enrollment with proper error handling:
+
+```js
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+import {
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError
+} from '@auth0/auth0-spa-js';
+
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+
+// --- Signup ---
+async function signupWithPasskey(email, displayName) {
+  const challenge = await auth0.passkey.signupChallenge({
+    email,
+    name: displayName
+  });
+
+  const credential = await navigator.credentials.create({
+    publicKey: challenge.authnParamsPublicKey
+  });
+
+  if (!credential) {
+    throw new Error('User cancelled the credential creation');
+  }
+
+  await auth0.passkey.signinWithPasskey({
+    authSession: challenge.authSession,
+    credential: serializeCredential(credential)
+  });
+
+  return await auth0.getUser();
+}
+
+// --- Login ---
+async function loginWithPasskey() {
+  const challenge = await auth0.passkey.loginChallenge();
+
+  const credential = await navigator.credentials.get({
+    publicKey: challenge.authnParamsPublicKey
+  });
+
+  if (!credential) {
+    throw new Error('User cancelled the credential request');
+  }
+
+  await auth0.passkey.signinWithPasskey({
+    authSession: challenge.authSession,
+    credential: serializeCredential(credential)
+  });
+
+  return await auth0.getUser();
+}
+
+// --- Enrollment ---
+async function enrollPasskey() {
+  const enrollment = await auth0.passkey.enrollmentChallenge();
+
+  const credential = await navigator.credentials.create({
+    publicKey: enrollment.authnParamsPublicKey
+  });
+
+  if (!credential) {
+    throw new Error('User cancelled the credential creation');
+  }
+
+  await auth0.passkey.enrollmentVerify({
+    authSession: enrollment.authSession,
+    credential: serializeCredential(credential)
+  });
+}
+```
+
+### Passkey Error Handling
+
+```js
+import {
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError
+} from '@auth0/auth0-spa-js';
+
+try {
+  await auth0.passkey.enrollmentChallenge();
+} catch (error) {
+  if (error instanceof PasskeyEnrollmentError) {
+    console.error('Enrollment failed:', error.message);
+    console.error('Error code:', error.code);
+    console.error('API details:', error.cause);
+  }
+}
+
+try {
+  await auth0.passkey.enrollmentVerify({ authSession, credential });
+} catch (error) {
+  if (error instanceof PasskeyEnrollmentVerifyError) {
+    console.error('Verification failed:', error.message);
+    console.error('API details:', error.cause);
+  }
+}
+```
+
+> [!TIP]
+> For signup and login challenge errors, the SDK propagates the underlying network or API errors directly. Wrap challenge calls in try/catch to handle cases like network failures or misconfigured connections.
+
+> [!IMPORTANT]
+> The WebAuthn API (`navigator.credentials.create()` / `navigator.credentials.get()`) may return `null` if the user cancels the biometric prompt. Always check for `null` before calling `signinWithPasskey()`.
+
 ## Multi-Factor Authentication (MFA)
 
 The MFA API allows you to manage multi-factor authentication for users. The SDK automatically handles MFA context, eliminating the need for manual parsing of error payloads.
+
 > [!NOTE]
 > Multi Factor Authentication support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
-
 
 - [Understanding the MFA Response](#understanding-the-mfa-response)
 - [Handling MFA required errors](#handling-mfa-required-errors)
@@ -1011,7 +1306,6 @@ try {
   await auth0.getTokenSilently();
 } catch (error) {
   if (error instanceof MfaRequiredError) {
-
     // Check if enrollment is required
     const enrollmentFactors = await auth0.mfa.getEnrollmentFactors(error.mfa_token);
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ window.addEventListener('load', async () => {
 
 ### More Examples
 
-For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, organizations, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.
+For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.
 
 ## API Reference
 

--- a/__tests__/Auth0Client/requestTokenForPasskey.test.ts
+++ b/__tests__/Auth0Client/requestTokenForPasskey.test.ts
@@ -12,8 +12,6 @@ import {
   TEST_REFRESH_TOKEN
 } from '../constants';
 
-import { Auth0ClientOptions } from '../../src';
-
 jest.mock('es-cookie');
 jest.mock('../../src/jwt');
 jest.mock('../../src/worker/token.worker');

--- a/__tests__/Auth0Client/requestTokenForPasskey.test.ts
+++ b/__tests__/Auth0Client/requestTokenForPasskey.test.ts
@@ -1,0 +1,317 @@
+import { verify } from '../../src/jwt';
+import { MessageChannel } from 'worker_threads';
+import * as utils from '../../src/utils';
+import * as scope from '../../src/scope';
+
+import { fetchResponse, setupFn } from './helpers';
+
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_CODE_CHALLENGE,
+  TEST_ID_TOKEN,
+  TEST_REFRESH_TOKEN
+} from '../constants';
+
+import { Auth0ClientOptions } from '../../src';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue(TEST_CODE_CHALLENGE);
+
+jest.spyOn(utils, 'runPopup');
+
+const setup = setupFn(mockVerify);
+
+const TEST_CREDENTIAL = {
+  id: 'credential-id-123',
+  rawId: 'cmF3SWQtYmFzZTY0dXJs',
+  type: 'public-key',
+  authenticatorAttachment: 'platform',
+  response: {
+    clientDataJSON: 'Y2xpZW50RGF0YUpTT04',
+    authenticatorData: 'YXV0aGVudGljYXRvckRhdGE',
+    signature: 'c2lnbmF0dXJl',
+    userHandle: 'dXNlckhhbmRsZQ'
+  },
+  clientExtensionResults: {}
+};
+
+const TEST_AUTH_SESSION = 'auth-session-abc123';
+
+describe('Auth0Client', () => {
+  beforeEach(() => {
+    mockWindow.open = jest.fn();
+    mockWindow.addEventListener = jest.fn();
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+    jest.spyOn(scope, 'getUniqueScopes');
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+  });
+
+  describe('_requestTokenForPasskey', () => {
+    it('passes correct parameters to _requestToken', async () => {
+      const auth0 = setup({
+        authorizationParams: {
+          audience: 'https://default-api.com',
+          scope: 'openid profile'
+        }
+      });
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any,
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(capturedOptions.grant_type).toBe(
+        'urn:okta:params:oauth:grant-type:webauthn'
+      );
+      expect(capturedOptions.auth_session).toBe(TEST_AUTH_SESSION);
+      expect(capturedOptions.authn_response).toEqual(TEST_CREDENTIAL);
+      expect(capturedOptions.audience).toBe('https://api.example.com');
+      expect(capturedOptions.scope).toContain('openid');
+      expect(capturedOptions.scope).toContain('profile');
+      expect(capturedOptions.scope).toContain('email');
+    });
+
+    it('uses default audience when none provided', async () => {
+      const auth0 = setup({
+        authorizationParams: {
+          audience: 'https://default-api.com',
+          scope: 'openid profile'
+        }
+      });
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(capturedOptions.audience).toBe('https://default-api.com');
+    });
+
+    it('includes realm when provided', async () => {
+      const auth0 = setup();
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any,
+        realm: 'Username-Password-Authentication'
+      });
+
+      expect(capturedOptions.realm).toBe('Username-Password-Authentication');
+    });
+
+    it('does not include realm when not provided', async () => {
+      const auth0 = setup();
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(capturedOptions.realm).toBeUndefined();
+    });
+
+    it('caches tokens and establishes session via _requestToken', async () => {
+      const auth0 = setup();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      const result = await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(result.access_token).toBe(TEST_ACCESS_TOKEN);
+      expect(result.id_token).toBe(TEST_ID_TOKEN);
+
+      // Verify user is now authenticated (session established)
+      const isAuthenticated = await auth0.isAuthenticated();
+      expect(isAuthenticated).toBe(true);
+
+      // Verify user claims are accessible
+      const user = await auth0.getUser();
+      expect(user.sub).toBe('me');
+    });
+
+    it('verifies the ID token', async () => {
+      const auth0 = setup();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(mockVerify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id_token: TEST_ID_TOKEN
+        })
+      );
+    });
+
+    it('propagates token endpoint errors', async () => {
+      const auth0 = setup();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'invalid_grant',
+          error_description: 'Auth session has expired'
+        })
+      );
+
+      await expect(
+        auth0._requestTokenForPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: TEST_CREDENTIAL as any
+        })
+      ).rejects.toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Auth session has expired'
+      });
+    });
+
+    it('sends JSON body to /oauth/token endpoint (not form-encoded)', async () => {
+      const auth0 = setup({ useFormData: true });
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any,
+        realm: 'my-connection'
+      });
+
+      const [url, fetchOptions] = mockFetch.mock.calls[0];
+      expect(url).toContain('/oauth/token');
+      expect(fetchOptions.method).toBe('POST');
+      expect(fetchOptions.headers['Content-Type']).toBe('application/json');
+
+      const body = JSON.parse(fetchOptions.body);
+      expect(body.grant_type).toBe(
+        'urn:okta:params:oauth:grant-type:webauthn'
+      );
+      expect(body.auth_session).toBe(TEST_AUTH_SESSION);
+      expect(body.authn_response).toEqual(TEST_CREDENTIAL);
+      expect(body.realm).toBe('my-connection');
+    });
+  });
+});

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -155,10 +155,50 @@ describe('PasskeyApiClient', () => {
           })
         }),
         realm: undefined,
+        organization: undefined,
         scope: undefined,
         audience: undefined
       });
       expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should pass organization to both challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({
+        email: 'user@example.com',
+        organization: 'org_abc123'
+      });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        organization: 'org_abc123'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: 'org_abc123'
+        })
+      );
     });
 
     it('should pass scope and audience to token exchange', async () => {
@@ -370,10 +410,44 @@ describe('PasskeyApiClient', () => {
           })
         }),
         realm: undefined,
+        organization: undefined,
         scope: undefined,
         audience: undefined
       });
       expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should pass organization to both challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.login({ organization: 'org_abc123' });
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith({
+        organization: 'org_abc123'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: 'org_abc123'
+        })
+      );
     });
 
     it('should pass realm option to challenge and token exchange', async () => {

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -3,7 +3,6 @@ jest.mock('@auth0/auth0-auth-js', () => ({
 }));
 
 import { PasskeyApiClient } from '../../src/passkey/PasskeyApiClient';
-import type { PasskeyCredentialResponse } from '../../src/passkey/types';
 import {
   PasskeyEnrollmentError,
   PasskeyEnrollmentVerifyError
@@ -11,26 +10,6 @@ import {
 
 const TEST_API_BASE = 'https://auth0_domain/api/';
 const TEST_AUTH_SESSION = 'auth-session-abc123';
-
-function createMockCredential(
-  overrides?: Partial<PasskeyCredentialResponse>
-): PasskeyCredentialResponse {
-  return {
-    id: 'credential-id-123',
-    rawId: 'cmF3SWQtYmFzZTY0dXJs',
-    type: 'public-key',
-    authenticatorAttachment: 'platform',
-    response: {
-      clientDataJSON: 'Y2xpZW50RGF0YUpTT04',
-      attestationObject: 'YXR0ZXN0YXRpb25PYmplY3Q',
-      authenticatorData: 'YXV0aGVudGljYXRvckRhdGE',
-      signature: 'c2lnbmF0dXJl',
-      userHandle: 'dXNlckhhbmRsZQ'
-    },
-    clientExtensionResults: {},
-    ...overrides
-  };
-}
 
 function createMockFetcher() {
   return {
@@ -52,19 +31,56 @@ function createMockResponse(
   } as unknown as Response;
 }
 
+function createMockPublicKeyCredential(type: 'create' | 'get') {
+  const clientDataJSON = new Uint8Array([1, 2, 3]).buffer;
+
+  if (type === 'create') {
+    return {
+      id: 'credential-id-123',
+      rawId: new Uint8Array([10, 20, 30]).buffer,
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: {
+        clientDataJSON,
+        attestationObject: new Uint8Array([40, 50, 60]).buffer
+      },
+      getClientExtensionResults: () => ({})
+    };
+  }
+
+  return {
+    id: 'credential-id-456',
+    rawId: new Uint8Array([10, 20, 30]).buffer,
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: {
+      clientDataJSON,
+      authenticatorData: new Uint8Array([70, 80, 90]).buffer,
+      signature: new Uint8Array([100, 110, 120]).buffer,
+      userHandle: new Uint8Array([130, 140, 150]).buffer
+    },
+    getClientExtensionResults: () => ({})
+  };
+}
+
 describe('PasskeyApiClient', () => {
   let passkeyClient: PasskeyApiClient;
   let mockPasskeyClient: any;
   let mockAuth0Client: any;
   let mockFetcher: ReturnType<typeof createMockFetcher>;
 
+  const originalCredentials = Object.getOwnPropertyDescriptor(
+    global.navigator,
+    'credentials'
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockPasskeyClient = {
-      signupChallenge: jest.fn(),
-      loginChallenge: jest.fn(),
-      signinWithPasskey: jest.fn()
+      register: jest.fn(),
+      challenge: jest.fn(),
+      getTokenByPasskey: jest.fn()
     };
 
     mockAuth0Client = {
@@ -81,66 +97,232 @@ describe('PasskeyApiClient', () => {
     );
   });
 
-  describe('signupChallenge', () => {
-    it('should delegate to PasskeyClient with email', async () => {
-      const mockResponse = {
+  afterEach(() => {
+    if (originalCredentials) {
+      Object.defineProperty(global.navigator, 'credentials', originalCredentials);
+    }
+  });
+
+  describe('signup', () => {
+    it('should handle full flow: challenge → WebAuthn → serialize → token exchange', async () => {
+      const challengeResponse = {
         authSession: TEST_AUTH_SESSION,
         authnParamsPublicKey: {
           challenge: 'Y2hhbGxlbmdl',
-          rp: { id: 'example.auth0.com', name: 'Example App' },
+          rp: { id: 'example.auth0.com', name: 'Example' },
           user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
           pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
-          authenticatorSelection: { residentKey: 'preferred', userVerification: 'preferred' },
           timeout: 60000
         }
       };
-      mockPasskeyClient.signupChallenge.mockResolvedValue(mockResponse);
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
 
-      const result = await passkeyClient.signupChallenge({ email: 'user@example.com' });
+      const mockCredential = createMockPublicKeyCredential('create');
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(mockCredential) },
+        configurable: true
+      });
 
-      expect(mockPasskeyClient.signupChallenge).toHaveBeenCalledWith({ email: 'user@example.com' });
-      expect(result).toEqual(mockResponse);
-      expect(result.authSession).toBe(TEST_AUTH_SESSION);
-      expect(result.authnParamsPublicKey.rp.id).toBe('example.auth0.com');
+      const mockTokenResponse = {
+        id_token: 'eyJ...',
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.signup({ email: 'user@example.com' });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({ email: 'user@example.com' });
+      expect(navigator.credentials.create).toHaveBeenCalledWith({
+        publicKey: expect.objectContaining({
+          challenge: expect.any(ArrayBuffer),
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: expect.objectContaining({
+            id: expect.any(ArrayBuffer)
+          })
+        })
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential: expect.objectContaining({
+          id: 'credential-id-123',
+          rawId: expect.any(String),
+          type: 'public-key',
+          response: expect.objectContaining({
+            clientDataJSON: expect.any(String),
+            attestationObject: expect.any(String)
+          })
+        }),
+        realm: undefined,
+        scope: undefined,
+        audience: undefined
+      });
+      expect(result).toEqual(mockTokenResponse);
     });
 
-    it('should delegate to PasskeyClient with all options', async () => {
-      const options = {
-        email: 'user@example.com',
-        username: 'testuser',
-        name: 'Test User',
-        realm: 'Username-Password-Authentication'
-      };
-      const mockResponse = {
+    it('should pass scope and audience to token exchange', async () => {
+      const challengeResponse = {
         authSession: TEST_AUTH_SESSION,
         authnParamsPublicKey: {
           challenge: 'Y2hhbGxlbmdl',
-          rp: { id: 'example.auth0.com', name: 'Example App' },
-          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'Test User' },
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
           pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
         }
       };
-      mockPasskeyClient.signupChallenge.mockResolvedValue(mockResponse);
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
 
-      const result = await passkeyClient.signupChallenge(options);
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
 
-      expect(mockPasskeyClient.signupChallenge).toHaveBeenCalledWith(options);
-      expect(result.authnParamsPublicKey.user.displayName).toBe('Test User');
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          realm: 'Username-Password-Authentication',
+          scope: 'openid profile email',
+          audience: 'https://api.example.com'
+        })
+      );
     });
 
-    it('should propagate errors from PasskeyClient', async () => {
-      const error = new Error('Network error');
-      mockPasskeyClient.signupChallenge.mockRejectedValue(error);
+    it('should throw if user cancels WebAuthn prompt', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(null) },
+        configurable: true
+      });
 
       await expect(
-        passkeyClient.signupChallenge({ email: 'user@example.com' })
+        passkeyClient.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('Passkey creation was cancelled or no credential was returned.');
+    });
+
+    it('should propagate errors from PasskeyClient.register', async () => {
+      mockPasskeyClient.register.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        passkeyClient.signup({ email: 'user@example.com' })
       ).rejects.toThrow('Network error');
+    });
+
+    it('should propagate errors from token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(
+        new Error('Token exchange failed')
+      );
+
+      await expect(
+        passkeyClient.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('Token exchange failed');
+    });
+
+    it('should not call PasskeyClient.getTokenByPasskey directly', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({ email: 'user@example.com' });
+
+      expect(mockPasskeyClient.getTokenByPasskey).not.toHaveBeenCalled();
+    });
+
+    it('should serialize credential with base64url encoding', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({ email: 'user@example.com' });
+
+      const credential = mockAuth0Client._requestTokenForPasskey.mock.calls[0][0].credential;
+      expect(credential.rawId).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.clientDataJSON).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.attestationObject).toMatch(/^[A-Za-z0-9_-]+$/);
     });
   });
 
-  describe('loginChallenge', () => {
-    it('should delegate to PasskeyClient without options', async () => {
-      const mockResponse = {
+  describe('login', () => {
+    it('should handle full flow: challenge → WebAuthn → serialize → token exchange', async () => {
+      const challengeResponse = {
         authSession: TEST_AUTH_SESSION,
         authnParamsPublicKey: {
           challenge: 'Y2hhbGxlbmdl',
@@ -149,59 +331,44 @@ describe('PasskeyApiClient', () => {
           userVerification: 'preferred'
         }
       };
-      mockPasskeyClient.loginChallenge.mockResolvedValue(mockResponse);
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
 
-      const result = await passkeyClient.loginChallenge();
+      const mockCredential = createMockPublicKeyCredential('get');
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(mockCredential) },
+        configurable: true
+      });
 
-      expect(mockPasskeyClient.loginChallenge).toHaveBeenCalledWith(undefined);
-      expect(result).toEqual(mockResponse);
-      expect(result.authnParamsPublicKey.rpId).toBe('example.auth0.com');
-    });
-
-    it('should delegate to PasskeyClient with realm option', async () => {
-      const options = { realm: 'Username-Password-Authentication' };
-      const mockResponse = {
-        authSession: TEST_AUTH_SESSION,
-        authnParamsPublicKey: {
-          challenge: 'Y2hhbGxlbmdl',
-          rpId: 'example.auth0.com'
-        }
-      };
-      mockPasskeyClient.loginChallenge.mockResolvedValue(mockResponse);
-
-      const result = await passkeyClient.loginChallenge(options);
-
-      expect(mockPasskeyClient.loginChallenge).toHaveBeenCalledWith(options);
-      expect(result.authSession).toBe(TEST_AUTH_SESSION);
-    });
-
-    it('should propagate errors from PasskeyClient', async () => {
-      const error = new Error('Service unavailable');
-      mockPasskeyClient.loginChallenge.mockRejectedValue(error);
-
-      await expect(passkeyClient.loginChallenge()).rejects.toThrow('Service unavailable');
-    });
-  });
-
-  describe('signinWithPasskey', () => {
-    it('should route through Auth0Client._requestTokenForPasskey', async () => {
-      const credential = createMockCredential();
       const mockTokenResponse = {
         id_token: 'eyJ...',
-        access_token: 'at_123',
+        access_token: 'at_456',
         token_type: 'Bearer',
         expires_in: 86400
       };
       mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
 
-      const result = await passkeyClient.signinWithPasskey({
-        authSession: TEST_AUTH_SESSION,
-        credential
-      });
+      const result = await passkeyClient.login();
 
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith(undefined);
+      expect(navigator.credentials.get).toHaveBeenCalledWith({
+        publicKey: expect.objectContaining({
+          challenge: expect.any(ArrayBuffer),
+          rpId: 'example.auth0.com'
+        })
+      });
       expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
         authSession: TEST_AUTH_SESSION,
-        credential,
+        credential: expect.objectContaining({
+          id: 'credential-id-456',
+          rawId: expect.any(String),
+          type: 'public-key',
+          response: expect.objectContaining({
+            clientDataJSON: expect.any(String),
+            authenticatorData: expect.any(String),
+            signature: expect.any(String),
+            userHandle: expect.any(String)
+          })
+        }),
         realm: undefined,
         scope: undefined,
         audience: undefined
@@ -209,63 +376,158 @@ describe('PasskeyApiClient', () => {
       expect(result).toEqual(mockTokenResponse);
     });
 
-    it('should pass optional realm, scope, and audience', async () => {
-      const credential = createMockCredential();
-      const mockTokenResponse = {
-        id_token: 'eyJ...',
-        access_token: 'at_123',
-        token_type: 'Bearer',
-        expires_in: 86400,
-        scope: 'openid profile email'
+    it('should pass realm option to challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
       };
-      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
 
-      const result = await passkeyClient.signinWithPasskey({
-        authSession: TEST_AUTH_SESSION,
-        credential,
-        realm: 'Username-Password-Authentication',
-        scope: 'openid profile email',
-        audience: 'https://api.example.com'
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
       });
 
-      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
-        authSession: TEST_AUTH_SESSION,
-        credential,
-        realm: 'Username-Password-Authentication',
-        scope: 'openid profile email',
-        audience: 'https://api.example.com'
-      });
-      expect(result.scope).toBe('openid profile email');
-    });
-
-    it('should not call PasskeyClient.signinWithPasskey directly', async () => {
-      const credential = createMockCredential();
       mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
-        id_token: 'eyJ...',
         access_token: 'at_123',
         token_type: 'Bearer',
         expires_in: 86400
       });
 
-      await passkeyClient.signinWithPasskey({
-        authSession: TEST_AUTH_SESSION,
-        credential
+      await passkeyClient.login({
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile',
+        audience: 'https://api.example.com'
       });
 
-      expect(mockPasskeyClient.signinWithPasskey).not.toHaveBeenCalled();
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith({
+        realm: 'Username-Password-Authentication'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          realm: 'Username-Password-Authentication',
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      );
     });
 
-    it('should propagate errors from Auth0Client._requestTokenForPasskey', async () => {
-      const credential = createMockCredential();
-      const error = new Error('Token exchange failed');
-      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(error);
+    it('should throw if user cancels WebAuthn prompt', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
 
-      await expect(
-        passkeyClient.signinWithPasskey({
-          authSession: TEST_AUTH_SESSION,
-          credential
-        })
-      ).rejects.toThrow('Token exchange failed');
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(null) },
+        configurable: true
+      });
+
+      await expect(passkeyClient.login()).rejects.toThrow(
+        'Passkey authentication was cancelled or no credential was returned.'
+      );
+    });
+
+    it('should propagate errors from PasskeyClient.challenge', async () => {
+      mockPasskeyClient.challenge.mockRejectedValue(new Error('Service unavailable'));
+
+      await expect(passkeyClient.login()).rejects.toThrow('Service unavailable');
+    });
+
+    it('should propagate errors from token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(
+        new Error('Token exchange failed')
+      );
+
+      await expect(passkeyClient.login()).rejects.toThrow('Token exchange failed');
+    });
+
+    it('should convert allowCredentials IDs from base64url to ArrayBuffer', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com',
+          allowCredentials: [
+            { id: 'Y3JlZC0x', type: 'public-key', transports: ['internal'] },
+            { id: 'Y3JlZC0y', type: 'public-key', transports: ['usb'] }
+          ]
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      const mockCredential = createMockPublicKeyCredential('get');
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(mockCredential) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.login();
+
+      const getCall = (navigator.credentials.get as jest.Mock).mock.calls[0][0];
+      expect(getCall.publicKey.allowCredentials).toHaveLength(2);
+      expect(getCall.publicKey.allowCredentials[0].id).toBeInstanceOf(ArrayBuffer);
+      expect(getCall.publicKey.allowCredentials[0].type).toBe('public-key');
+      expect(getCall.publicKey.allowCredentials[0].transports).toEqual(['internal']);
+      expect(getCall.publicKey.allowCredentials[1].id).toBeInstanceOf(ArrayBuffer);
+    });
+
+    it('should serialize assertion credential with base64url encoding', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.login();
+
+      const credential = mockAuth0Client._requestTokenForPasskey.mock.calls[0][0].credential;
+      expect(credential.rawId).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.clientDataJSON).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.authenticatorData).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.signature).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.userHandle).toMatch(/^[A-Za-z0-9_-]+$/);
     });
   });
 
@@ -374,19 +636,6 @@ describe('PasskeyApiClient', () => {
       });
     });
 
-    it('should throw PasskeyEnrollmentError with detail field', async () => {
-      const errorBody = {
-        detail: 'User not found'
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(false, errorBody)
-      );
-
-      await expect(passkeyClient.enrollmentChallenge()).rejects.toMatchObject({
-        message: 'User not found'
-      });
-    });
-
     it('should throw PasskeyEnrollmentError with default message on parse failure', async () => {
       mockFetcher.fetchWithAuth.mockResolvedValue({
         ok: false,
@@ -431,7 +680,15 @@ describe('PasskeyApiClient', () => {
 
   describe('enrollmentVerify', () => {
     it('should POST to verify endpoint with serialized credential', async () => {
-      const credential = createMockCredential();
+      const credential = {
+        id: 'cred-id',
+        rawId: 'cmF3SWQ',
+        type: 'public-key',
+        response: {
+          clientDataJSON: 'Y2xpZW50',
+          attestationObject: 'YXR0ZXN0'
+        }
+      } as any;
       mockFetcher.fetchWithAuth.mockResolvedValue(
         createMockResponse(true, {})
       );
@@ -455,7 +712,7 @@ describe('PasskeyApiClient', () => {
     });
 
     it('should resolve without returning a value on success', async () => {
-      const credential = createMockCredential();
+      const credential = { id: 'c', rawId: 'r', type: 'public-key', response: { clientDataJSON: 'c' } } as any;
       mockFetcher.fetchWithAuth.mockResolvedValue(
         createMockResponse(true, {})
       );
@@ -468,8 +725,8 @@ describe('PasskeyApiClient', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should throw PasskeyEnrollmentVerifyError on non-ok response with error_description', async () => {
-      const credential = createMockCredential();
+    it('should throw PasskeyEnrollmentVerifyError on non-ok response', async () => {
+      const credential = { id: 'c', rawId: 'r', type: 'public-key', response: { clientDataJSON: 'c' } } as any;
       const errorBody = {
         error: 'invalid_credential',
         error_description: 'The credential response is invalid'
@@ -489,24 +746,8 @@ describe('PasskeyApiClient', () => {
       });
     });
 
-    it('should throw PasskeyEnrollmentVerifyError with detail field', async () => {
-      const credential = createMockCredential();
-      const errorBody = {
-        detail: 'Auth session expired'
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(false, errorBody)
-      );
-
-      await expect(
-        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
-      ).rejects.toMatchObject({
-        message: 'Auth session expired'
-      });
-    });
-
     it('should throw PasskeyEnrollmentVerifyError with default message when json parsing fails', async () => {
-      const credential = createMockCredential();
+      const credential = { id: 'c', rawId: 'r', type: 'public-key', response: { clientDataJSON: 'c' } } as any;
       mockFetcher.fetchWithAuth.mockResolvedValue({
         ok: false,
         status: 500,
@@ -519,28 +760,6 @@ describe('PasskeyApiClient', () => {
       ).rejects.toMatchObject({
         message: 'Failed to verify passkey enrollment'
       });
-    });
-
-    it('should send the full credential object in authn_response', async () => {
-      const credential = createMockCredential({
-        authenticatorAttachment: 'cross-platform',
-        clientExtensionResults: { credProps: { rk: true } }
-      });
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, {})
-      );
-
-      await passkeyClient.enrollmentVerify({
-        authSession: TEST_AUTH_SESSION,
-        credential
-      });
-
-      const callBody = JSON.parse(
-        (mockFetcher.fetchWithAuth.mock.calls[0][1] as any).body
-      );
-      expect(callBody.authn_response).toEqual(credential);
-      expect(callBody.authn_response.authenticatorAttachment).toBe('cross-platform');
-      expect(callBody.authn_response.clientExtensionResults).toEqual({ credProps: { rk: true } });
     });
   });
 
@@ -567,13 +786,6 @@ describe('PasskeyApiClient', () => {
       expect(error.code).toBe('passkey_enrollment_verify_error');
       expect(error.message).toBe('Verify failed');
       expect(error.cause).toEqual(cause);
-    });
-
-    it('PasskeyEnrollmentError should work without cause', () => {
-      const error = new PasskeyEnrollmentError('No cause');
-
-      expect(error.cause).toBeUndefined();
-      expect(error.message).toBe('No cause');
     });
   });
 });

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -537,42 +537,6 @@ describe('PasskeyApiClient', () => {
       await expect(passkeyClient.login()).rejects.toThrow('Token exchange failed');
     });
 
-    it('should convert allowCredentials IDs from base64url to ArrayBuffer', async () => {
-      const challengeResponse = {
-        authSession: TEST_AUTH_SESSION,
-        authnParamsPublicKey: {
-          challenge: 'Y2hhbGxlbmdl',
-          rpId: 'example.auth0.com',
-          allowCredentials: [
-            { id: 'Y3JlZC0x', type: 'public-key', transports: ['internal'] },
-            { id: 'Y3JlZC0y', type: 'public-key', transports: ['usb'] }
-          ]
-        }
-      };
-      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
-
-      const mockCredential = createMockPublicKeyCredential('get');
-      Object.defineProperty(global.navigator, 'credentials', {
-        value: { get: jest.fn().mockResolvedValue(mockCredential) },
-        configurable: true
-      });
-
-      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
-        access_token: 'at_123',
-        token_type: 'Bearer',
-        expires_in: 86400
-      });
-
-      await passkeyClient.login();
-
-      const getCall = (navigator.credentials.get as jest.Mock).mock.calls[0][0];
-      expect(getCall.publicKey.allowCredentials).toHaveLength(2);
-      expect(getCall.publicKey.allowCredentials[0].id).toBeInstanceOf(ArrayBuffer);
-      expect(getCall.publicKey.allowCredentials[0].type).toBe('public-key');
-      expect(getCall.publicKey.allowCredentials[0].transports).toEqual(['internal']);
-      expect(getCall.publicKey.allowCredentials[1].id).toBeInstanceOf(ArrayBuffer);
-    });
-
     it('should serialize assertion credential with base64url encoding', async () => {
       const challengeResponse = {
         authSession: TEST_AUTH_SESSION,

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -8,28 +8,7 @@ import {
   PasskeyEnrollmentVerifyError
 } from '../../src/passkey/errors';
 
-const TEST_API_BASE = 'https://auth0_domain/api/';
 const TEST_AUTH_SESSION = 'auth-session-abc123';
-
-function createMockFetcher() {
-  return {
-    fetchWithAuth: jest.fn()
-  };
-}
-
-function createMockResponse(
-  ok: boolean,
-  body: any,
-  headers?: Record<string, string>
-): Response {
-  return {
-    ok,
-    status: ok ? 200 : 400,
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
-    headers: new Headers(headers)
-  } as unknown as Response;
-}
 
 function createMockPublicKeyCredential(type: 'create' | 'get') {
   const clientDataJSON = new Uint8Array([1, 2, 3]).buffer;
@@ -67,7 +46,6 @@ describe('PasskeyApiClient', () => {
   let passkeyClient: PasskeyApiClient;
   let mockPasskeyClient: any;
   let mockAuth0Client: any;
-  let mockFetcher: ReturnType<typeof createMockFetcher>;
 
   const originalCredentials = Object.getOwnPropertyDescriptor(
     global.navigator,
@@ -87,13 +65,9 @@ describe('PasskeyApiClient', () => {
       _requestTokenForPasskey: jest.fn()
     };
 
-    mockFetcher = createMockFetcher();
-
     passkeyClient = new PasskeyApiClient(
       mockPasskeyClient,
-      mockAuth0Client,
-      mockFetcher as any,
-      TEST_API_BASE
+      mockAuth0Client
     );
   });
 
@@ -566,238 +540,6 @@ describe('PasskeyApiClient', () => {
       expect(credential.response.authenticatorData).toMatch(/^[A-Za-z0-9_-]+$/);
       expect(credential.response.signature).toMatch(/^[A-Za-z0-9_-]+$/);
       expect(credential.response.userHandle).toMatch(/^[A-Za-z0-9_-]+$/);
-    });
-  });
-
-  describe('enrollmentChallenge', () => {
-    it('should POST to authentication-methods endpoint', async () => {
-      const mockResponseBody = {
-        auth_session: TEST_AUTH_SESSION,
-        authn_params_public_key: {
-          challenge: 'Y2hhbGxlbmdl',
-          rp: { id: 'example.auth0.com', name: 'Example App' },
-          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
-          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
-        }
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, mockResponseBody)
-      );
-
-      const result = await passkeyClient.enrollmentChallenge();
-
-      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
-        `${TEST_API_BASE}v1/authentication-methods`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ type: 'passkey' })
-        }
-      );
-      expect(result.authSession).toBe(TEST_AUTH_SESSION);
-      expect(result.authnParamsPublicKey.challenge).toBe('Y2hhbGxlbmdl');
-      expect(result.authnParamsPublicKey.rp.id).toBe('example.auth0.com');
-    });
-
-    it('should include connection when provided', async () => {
-      const mockResponseBody = {
-        auth_session: TEST_AUTH_SESSION,
-        authn_params_public_key: {
-          challenge: 'Y2hhbGxlbmdl',
-          rp: { id: 'example.auth0.com', name: 'Example App' },
-          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
-          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
-        }
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, mockResponseBody)
-      );
-
-      await passkeyClient.enrollmentChallenge({ connection: 'Username-Password-Authentication' });
-
-      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
-        `${TEST_API_BASE}v1/authentication-methods`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ type: 'passkey', connection: 'Username-Password-Authentication' })
-        }
-      );
-    });
-
-    it('should include identity when provided', async () => {
-      const mockResponseBody = {
-        auth_session: TEST_AUTH_SESSION,
-        authn_params_public_key: {
-          challenge: 'Y2hhbGxlbmdl',
-          rp: { id: 'example.auth0.com', name: 'Example App' },
-          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
-          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
-        }
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, mockResponseBody)
-      );
-
-      await passkeyClient.enrollmentChallenge({
-        connection: 'Username-Password-Authentication',
-        identity: 'auth0|user123'
-      });
-
-      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
-        `${TEST_API_BASE}v1/authentication-methods`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            type: 'passkey',
-            connection: 'Username-Password-Authentication',
-            identity: 'auth0|user123'
-          })
-        }
-      );
-    });
-
-    it('should throw PasskeyEnrollmentError on non-ok response', async () => {
-      const errorBody = {
-        error: 'invalid_request',
-        error_description: 'Connection does not support passkeys'
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(false, errorBody)
-      );
-
-      await expect(passkeyClient.enrollmentChallenge()).rejects.toThrow(PasskeyEnrollmentError);
-      await expect(passkeyClient.enrollmentChallenge()).rejects.toMatchObject({
-        message: 'Connection does not support passkeys',
-        code: 'passkey_enrollment_error'
-      });
-    });
-
-    it('should throw PasskeyEnrollmentError with default message on parse failure', async () => {
-      mockFetcher.fetchWithAuth.mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: () => Promise.resolve('Internal Server Error'),
-        headers: new Headers()
-      } as unknown as Response);
-
-      await expect(passkeyClient.enrollmentChallenge()).rejects.toThrow(PasskeyEnrollmentError);
-      await expect(passkeyClient.enrollmentChallenge()).rejects.toMatchObject({
-        message: 'Failed to create passkey enrollment challenge'
-      });
-    });
-
-    it('should transform snake_case API response to camelCase', async () => {
-      const mockResponseBody = {
-        auth_session: 'session-xyz',
-        authn_params_public_key: {
-          challenge: 'abc123',
-          rp: { id: 'rp.example.com', name: 'RP' },
-          user: { id: 'uid', name: 'u@e.com', displayName: 'U' },
-          pubKeyCredParams: [{ type: 'public-key', alg: -257 }],
-          authenticatorSelection: {
-            residentKey: 'required',
-            userVerification: 'required'
-          },
-          timeout: 120000
-        }
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, mockResponseBody)
-      );
-
-      const result = await passkeyClient.enrollmentChallenge();
-
-      expect(result).toEqual({
-        authSession: 'session-xyz',
-        authnParamsPublicKey: mockResponseBody.authn_params_public_key
-      });
-    });
-  });
-
-  describe('enrollmentVerify', () => {
-    it('should POST to verify endpoint with serialized credential', async () => {
-      const credential = {
-        id: 'cred-id',
-        rawId: 'cmF3SWQ',
-        type: 'public-key',
-        response: {
-          clientDataJSON: 'Y2xpZW50',
-          attestationObject: 'YXR0ZXN0'
-        }
-      } as any;
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, {})
-      );
-
-      await passkeyClient.enrollmentVerify({
-        authSession: TEST_AUTH_SESSION,
-        credential
-      });
-
-      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
-        `${TEST_API_BASE}v1/authentication-methods/passkey%7Cnew/verify`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            auth_session: TEST_AUTH_SESSION,
-            authn_response: credential
-          })
-        }
-      );
-    });
-
-    it('should resolve without returning a value on success', async () => {
-      const credential = { id: 'c', rawId: 'r', type: 'public-key', response: { clientDataJSON: 'c' } } as any;
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(true, {})
-      );
-
-      const result = await passkeyClient.enrollmentVerify({
-        authSession: TEST_AUTH_SESSION,
-        credential
-      });
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should throw PasskeyEnrollmentVerifyError on non-ok response', async () => {
-      const credential = { id: 'c', rawId: 'r', type: 'public-key', response: { clientDataJSON: 'c' } } as any;
-      const errorBody = {
-        error: 'invalid_credential',
-        error_description: 'The credential response is invalid'
-      };
-      mockFetcher.fetchWithAuth.mockResolvedValue(
-        createMockResponse(false, errorBody)
-      );
-
-      await expect(
-        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
-      ).rejects.toThrow(PasskeyEnrollmentVerifyError);
-      await expect(
-        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
-      ).rejects.toMatchObject({
-        message: 'The credential response is invalid',
-        code: 'passkey_enrollment_verify_error'
-      });
-    });
-
-    it('should throw PasskeyEnrollmentVerifyError with default message when json parsing fails', async () => {
-      const credential = { id: 'c', rawId: 'r', type: 'public-key', response: { clientDataJSON: 'c' } } as any;
-      mockFetcher.fetchWithAuth.mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: () => Promise.resolve('Internal Server Error'),
-        headers: new Headers()
-      } as unknown as Response);
-
-      await expect(
-        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
-      ).rejects.toMatchObject({
-        message: 'Failed to verify passkey enrollment'
-      });
     });
   });
 

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -1,0 +1,579 @@
+jest.mock('@auth0/auth0-auth-js', () => ({
+  PasskeyClient: jest.fn()
+}));
+
+import { PasskeyApiClient } from '../../src/passkey/PasskeyApiClient';
+import type { PasskeyCredentialResponse } from '../../src/passkey/types';
+import {
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError
+} from '../../src/passkey/errors';
+
+const TEST_API_BASE = 'https://auth0_domain/api/';
+const TEST_AUTH_SESSION = 'auth-session-abc123';
+
+function createMockCredential(
+  overrides?: Partial<PasskeyCredentialResponse>
+): PasskeyCredentialResponse {
+  return {
+    id: 'credential-id-123',
+    rawId: 'cmF3SWQtYmFzZTY0dXJs',
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: {
+      clientDataJSON: 'Y2xpZW50RGF0YUpTT04',
+      attestationObject: 'YXR0ZXN0YXRpb25PYmplY3Q',
+      authenticatorData: 'YXV0aGVudGljYXRvckRhdGE',
+      signature: 'c2lnbmF0dXJl',
+      userHandle: 'dXNlckhhbmRsZQ'
+    },
+    clientExtensionResults: {},
+    ...overrides
+  };
+}
+
+function createMockFetcher() {
+  return {
+    fetchWithAuth: jest.fn()
+  };
+}
+
+function createMockResponse(
+  ok: boolean,
+  body: any,
+  headers?: Record<string, string>
+): Response {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(headers)
+  } as unknown as Response;
+}
+
+describe('PasskeyApiClient', () => {
+  let passkeyClient: PasskeyApiClient;
+  let mockPasskeyClient: any;
+  let mockAuth0Client: any;
+  let mockFetcher: ReturnType<typeof createMockFetcher>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockPasskeyClient = {
+      signupChallenge: jest.fn(),
+      loginChallenge: jest.fn(),
+      signinWithPasskey: jest.fn()
+    };
+
+    mockAuth0Client = {
+      _requestTokenForPasskey: jest.fn()
+    };
+
+    mockFetcher = createMockFetcher();
+
+    passkeyClient = new PasskeyApiClient(
+      mockPasskeyClient,
+      mockAuth0Client,
+      mockFetcher as any,
+      TEST_API_BASE
+    );
+  });
+
+  describe('signupChallenge', () => {
+    it('should delegate to PasskeyClient with email', async () => {
+      const mockResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example App' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+          authenticatorSelection: { residentKey: 'preferred', userVerification: 'preferred' },
+          timeout: 60000
+        }
+      };
+      mockPasskeyClient.signupChallenge.mockResolvedValue(mockResponse);
+
+      const result = await passkeyClient.signupChallenge({ email: 'user@example.com' });
+
+      expect(mockPasskeyClient.signupChallenge).toHaveBeenCalledWith({ email: 'user@example.com' });
+      expect(result).toEqual(mockResponse);
+      expect(result.authSession).toBe(TEST_AUTH_SESSION);
+      expect(result.authnParamsPublicKey.rp.id).toBe('example.auth0.com');
+    });
+
+    it('should delegate to PasskeyClient with all options', async () => {
+      const options = {
+        email: 'user@example.com',
+        username: 'testuser',
+        name: 'Test User',
+        realm: 'Username-Password-Authentication'
+      };
+      const mockResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example App' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'Test User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.signupChallenge.mockResolvedValue(mockResponse);
+
+      const result = await passkeyClient.signupChallenge(options);
+
+      expect(mockPasskeyClient.signupChallenge).toHaveBeenCalledWith(options);
+      expect(result.authnParamsPublicKey.user.displayName).toBe('Test User');
+    });
+
+    it('should propagate errors from PasskeyClient', async () => {
+      const error = new Error('Network error');
+      mockPasskeyClient.signupChallenge.mockRejectedValue(error);
+
+      await expect(
+        passkeyClient.signupChallenge({ email: 'user@example.com' })
+      ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('loginChallenge', () => {
+    it('should delegate to PasskeyClient without options', async () => {
+      const mockResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com',
+          timeout: 60000,
+          userVerification: 'preferred'
+        }
+      };
+      mockPasskeyClient.loginChallenge.mockResolvedValue(mockResponse);
+
+      const result = await passkeyClient.loginChallenge();
+
+      expect(mockPasskeyClient.loginChallenge).toHaveBeenCalledWith(undefined);
+      expect(result).toEqual(mockResponse);
+      expect(result.authnParamsPublicKey.rpId).toBe('example.auth0.com');
+    });
+
+    it('should delegate to PasskeyClient with realm option', async () => {
+      const options = { realm: 'Username-Password-Authentication' };
+      const mockResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.loginChallenge.mockResolvedValue(mockResponse);
+
+      const result = await passkeyClient.loginChallenge(options);
+
+      expect(mockPasskeyClient.loginChallenge).toHaveBeenCalledWith(options);
+      expect(result.authSession).toBe(TEST_AUTH_SESSION);
+    });
+
+    it('should propagate errors from PasskeyClient', async () => {
+      const error = new Error('Service unavailable');
+      mockPasskeyClient.loginChallenge.mockRejectedValue(error);
+
+      await expect(passkeyClient.loginChallenge()).rejects.toThrow('Service unavailable');
+    });
+  });
+
+  describe('signinWithPasskey', () => {
+    it('should route through Auth0Client._requestTokenForPasskey', async () => {
+      const credential = createMockCredential();
+      const mockTokenResponse = {
+        id_token: 'eyJ...',
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.signinWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential
+      });
+
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential,
+        realm: undefined,
+        scope: undefined,
+        audience: undefined
+      });
+      expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should pass optional realm, scope, and audience', async () => {
+      const credential = createMockCredential();
+      const mockTokenResponse = {
+        id_token: 'eyJ...',
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400,
+        scope: 'openid profile email'
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.signinWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential,
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential,
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+      expect(result.scope).toBe('openid profile email');
+    });
+
+    it('should not call PasskeyClient.signinWithPasskey directly', async () => {
+      const credential = createMockCredential();
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        id_token: 'eyJ...',
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signinWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential
+      });
+
+      expect(mockPasskeyClient.signinWithPasskey).not.toHaveBeenCalled();
+    });
+
+    it('should propagate errors from Auth0Client._requestTokenForPasskey', async () => {
+      const credential = createMockCredential();
+      const error = new Error('Token exchange failed');
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(error);
+
+      await expect(
+        passkeyClient.signinWithPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential
+        })
+      ).rejects.toThrow('Token exchange failed');
+    });
+  });
+
+  describe('enrollmentChallenge', () => {
+    it('should POST to authentication-methods endpoint', async () => {
+      const mockResponseBody = {
+        auth_session: TEST_AUTH_SESSION,
+        authn_params_public_key: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example App' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, mockResponseBody)
+      );
+
+      const result = await passkeyClient.enrollmentChallenge();
+
+      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
+        `${TEST_API_BASE}v1/authentication-methods`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: 'passkey' })
+        }
+      );
+      expect(result.authSession).toBe(TEST_AUTH_SESSION);
+      expect(result.authnParamsPublicKey.challenge).toBe('Y2hhbGxlbmdl');
+      expect(result.authnParamsPublicKey.rp.id).toBe('example.auth0.com');
+    });
+
+    it('should include connection when provided', async () => {
+      const mockResponseBody = {
+        auth_session: TEST_AUTH_SESSION,
+        authn_params_public_key: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example App' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, mockResponseBody)
+      );
+
+      await passkeyClient.enrollmentChallenge({ connection: 'Username-Password-Authentication' });
+
+      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
+        `${TEST_API_BASE}v1/authentication-methods`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: 'passkey', connection: 'Username-Password-Authentication' })
+        }
+      );
+    });
+
+    it('should include identity when provided', async () => {
+      const mockResponseBody = {
+        auth_session: TEST_AUTH_SESSION,
+        authn_params_public_key: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example App' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, mockResponseBody)
+      );
+
+      await passkeyClient.enrollmentChallenge({
+        connection: 'Username-Password-Authentication',
+        identity: 'auth0|user123'
+      });
+
+      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
+        `${TEST_API_BASE}v1/authentication-methods`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            type: 'passkey',
+            connection: 'Username-Password-Authentication',
+            identity: 'auth0|user123'
+          })
+        }
+      );
+    });
+
+    it('should throw PasskeyEnrollmentError on non-ok response', async () => {
+      const errorBody = {
+        error: 'invalid_request',
+        error_description: 'Connection does not support passkeys'
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(false, errorBody)
+      );
+
+      await expect(passkeyClient.enrollmentChallenge()).rejects.toThrow(PasskeyEnrollmentError);
+      await expect(passkeyClient.enrollmentChallenge()).rejects.toMatchObject({
+        message: 'Connection does not support passkeys',
+        code: 'passkey_enrollment_error'
+      });
+    });
+
+    it('should throw PasskeyEnrollmentError with detail field', async () => {
+      const errorBody = {
+        detail: 'User not found'
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(false, errorBody)
+      );
+
+      await expect(passkeyClient.enrollmentChallenge()).rejects.toMatchObject({
+        message: 'User not found'
+      });
+    });
+
+    it('should throw PasskeyEnrollmentError with default message on parse failure', async () => {
+      mockFetcher.fetchWithAuth.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+        headers: new Headers()
+      } as unknown as Response);
+
+      await expect(passkeyClient.enrollmentChallenge()).rejects.toThrow(PasskeyEnrollmentError);
+      await expect(passkeyClient.enrollmentChallenge()).rejects.toMatchObject({
+        message: 'Failed to create passkey enrollment challenge'
+      });
+    });
+
+    it('should transform snake_case API response to camelCase', async () => {
+      const mockResponseBody = {
+        auth_session: 'session-xyz',
+        authn_params_public_key: {
+          challenge: 'abc123',
+          rp: { id: 'rp.example.com', name: 'RP' },
+          user: { id: 'uid', name: 'u@e.com', displayName: 'U' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -257 }],
+          authenticatorSelection: {
+            residentKey: 'required',
+            userVerification: 'required'
+          },
+          timeout: 120000
+        }
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, mockResponseBody)
+      );
+
+      const result = await passkeyClient.enrollmentChallenge();
+
+      expect(result).toEqual({
+        authSession: 'session-xyz',
+        authnParamsPublicKey: mockResponseBody.authn_params_public_key
+      });
+    });
+  });
+
+  describe('enrollmentVerify', () => {
+    it('should POST to verify endpoint with serialized credential', async () => {
+      const credential = createMockCredential();
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, {})
+      );
+
+      await passkeyClient.enrollmentVerify({
+        authSession: TEST_AUTH_SESSION,
+        credential
+      });
+
+      expect(mockFetcher.fetchWithAuth).toHaveBeenCalledWith(
+        `${TEST_API_BASE}v1/authentication-methods/passkey%7Cnew/verify`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            auth_session: TEST_AUTH_SESSION,
+            authn_response: credential
+          })
+        }
+      );
+    });
+
+    it('should resolve without returning a value on success', async () => {
+      const credential = createMockCredential();
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, {})
+      );
+
+      const result = await passkeyClient.enrollmentVerify({
+        authSession: TEST_AUTH_SESSION,
+        credential
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should throw PasskeyEnrollmentVerifyError on non-ok response with error_description', async () => {
+      const credential = createMockCredential();
+      const errorBody = {
+        error: 'invalid_credential',
+        error_description: 'The credential response is invalid'
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(false, errorBody)
+      );
+
+      await expect(
+        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
+      ).rejects.toThrow(PasskeyEnrollmentVerifyError);
+      await expect(
+        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
+      ).rejects.toMatchObject({
+        message: 'The credential response is invalid',
+        code: 'passkey_enrollment_verify_error'
+      });
+    });
+
+    it('should throw PasskeyEnrollmentVerifyError with detail field', async () => {
+      const credential = createMockCredential();
+      const errorBody = {
+        detail: 'Auth session expired'
+      };
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(false, errorBody)
+      );
+
+      await expect(
+        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
+      ).rejects.toMatchObject({
+        message: 'Auth session expired'
+      });
+    });
+
+    it('should throw PasskeyEnrollmentVerifyError with default message when json parsing fails', async () => {
+      const credential = createMockCredential();
+      mockFetcher.fetchWithAuth.mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+        headers: new Headers()
+      } as unknown as Response);
+
+      await expect(
+        passkeyClient.enrollmentVerify({ authSession: TEST_AUTH_SESSION, credential })
+      ).rejects.toMatchObject({
+        message: 'Failed to verify passkey enrollment'
+      });
+    });
+
+    it('should send the full credential object in authn_response', async () => {
+      const credential = createMockCredential({
+        authenticatorAttachment: 'cross-platform',
+        clientExtensionResults: { credProps: { rk: true } }
+      });
+      mockFetcher.fetchWithAuth.mockResolvedValue(
+        createMockResponse(true, {})
+      );
+
+      await passkeyClient.enrollmentVerify({
+        authSession: TEST_AUTH_SESSION,
+        credential
+      });
+
+      const callBody = JSON.parse(
+        (mockFetcher.fetchWithAuth.mock.calls[0][1] as any).body
+      );
+      expect(callBody.authn_response).toEqual(credential);
+      expect(callBody.authn_response.authenticatorAttachment).toBe('cross-platform');
+      expect(callBody.authn_response.clientExtensionResults).toEqual({ credProps: { rk: true } });
+    });
+  });
+
+  describe('error classes', () => {
+    it('PasskeyEnrollmentError should have correct properties', () => {
+      const cause = { error: 'invalid_request', error_description: 'Bad request' };
+      const error = new PasskeyEnrollmentError('Something went wrong', cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(PasskeyEnrollmentError);
+      expect(error.name).toBe('PasskeyEnrollmentError');
+      expect(error.code).toBe('passkey_enrollment_error');
+      expect(error.message).toBe('Something went wrong');
+      expect(error.cause).toEqual(cause);
+    });
+
+    it('PasskeyEnrollmentVerifyError should have correct properties', () => {
+      const cause = { error: 'invalid_credential', error_description: 'Invalid' };
+      const error = new PasskeyEnrollmentVerifyError('Verify failed', cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(PasskeyEnrollmentVerifyError);
+      expect(error.name).toBe('PasskeyEnrollmentVerifyError');
+      expect(error.code).toBe('passkey_enrollment_verify_error');
+      expect(error.message).toBe('Verify failed');
+      expect(error.cause).toEqual(cause);
+    });
+
+    it('PasskeyEnrollmentError should work without cause', () => {
+      const error = new PasskeyEnrollmentError('No cause');
+
+      expect(error.cause).toBeUndefined();
+      expect(error.message).toBe('No cause');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-auth-js": "1.6.0",
+    "@auth0/auth0-auth-js": "1.7.0",
     "browser-tabs-lock": "1.3.0",
     "dpop": "2.1.1",
     "es-cookie": "1.3.2"

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -309,9 +309,7 @@ export class Auth0Client {
     this.mfa = new MfaApiClient(this.authJsClient.mfa, this);
     this.passkey = new PasskeyApiClient(
       this.authJsClient.passkey,
-      this,
-      myAccountFetcher,
-      myAccountApiIdentifier
+      this
     );
 
     // Don't use web workers unless using refresh tokens in memory

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -2044,14 +2044,17 @@ export class Auth0Client {
       realm?: string;
       scope?: string;
       audience?: string;
+      organization?: string;
     }
   ): Promise<TokenEndpointResponse> {
     const audience = options.audience || this.options.authorizationParams.audience;
+    const organization = options.organization || this.options.authorizationParams.organization;
     return this._requestToken({
       grant_type: 'urn:okta:params:oauth:grant-type:webauthn',
       auth_session: options.authSession,
       authn_response: options.credential,
       ...(options.realm && { realm: options.realm }),
+      ...(organization && { organization }),
       scope: scopesToRequest(this.scope, options.scope, audience),
       audience,
     });

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -171,13 +171,11 @@ export class Auth0Client {
   public readonly mfa: MfaApiClient;
 
   /**
-   * Passkey API client for passkey authentication and enrollment.
+   * Passkey API client for passwordless authentication.
    *
-   * Provides methods for:
-   * - Requesting signup challenges (new user registration with passkey)
-   * - Requesting login challenges (existing user authentication with passkey)
-   * - Exchanging passkey credentials for tokens
-   * - Enrolling passkeys for authenticated users (My Account)
+   * Provides two single-call methods that handle the full WebAuthn flow internally:
+   * - `signup(options)` — register a new user with a passkey
+   * - `login(options?)` — authenticate an existing user with a passkey
    */
   public readonly passkey: PasskeyApiClient;
 
@@ -2114,6 +2112,7 @@ interface WebauthnRequestTokenOptions extends BaseRequestTokenOptions {
   auth_session: string;
   authn_response: PasskeyCredentialResponse;
   realm?: string;
+  organization?: string;
 }
 
 interface RequestTokenAdditionalParameters {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -122,6 +122,8 @@ import {
 } from './fetcher';
 import { MyAccountApiClient } from './MyAccountApiClient';
 import { MfaApiClient } from './mfa';
+import { PasskeyApiClient } from './passkey';
+import type { PasskeyCredentialResponse } from './passkey/types';
 import { AuthClient as Auth0AuthJsClient } from '@auth0/auth0-auth-js';
 
 /**
@@ -167,6 +169,17 @@ export class Auth0Client {
    * - Verifying MFA challenges
    */
   public readonly mfa: MfaApiClient;
+
+  /**
+   * Passkey API client for passkey authentication and enrollment.
+   *
+   * Provides methods for:
+   * - Requesting signup challenges (new user registration with passkey)
+   * - Requesting login challenges (existing user authentication with passkey)
+   * - Exchanging passkey credentials for tokens
+   * - Enrolling passkeys for authenticated users (My Account)
+   */
+  public readonly passkey: PasskeyApiClient;
 
   private worker?: Worker;
   private readonly authJsClient: Auth0AuthJsClient;
@@ -294,7 +307,12 @@ export class Auth0Client {
       clientId: this.options.clientId,
     });
     this.mfa = new MfaApiClient(this.authJsClient.mfa, this);
-
+    this.passkey = new PasskeyApiClient(
+      this.authJsClient.passkey,
+      this,
+      myAccountFetcher,
+      myAccountApiIdentifier
+    );
 
     // Don't use web workers unless using refresh tokens in memory
     if (
@@ -1633,7 +1651,8 @@ export class Auth0Client {
     options:
       | PKCERequestTokenOptions
       | RefreshTokenRequestTokenOptions
-      | TokenExchangeRequestOptions,
+      | TokenExchangeRequestOptions
+      | WebauthnRequestTokenOptions,
     additionalParameters?: RequestTokenAdditionalParameters
   ) {
     const { nonceIn, organization, scopesToRequest } = additionalParameters || {};
@@ -2015,6 +2034,31 @@ export class Auth0Client {
 
   /**
    * @internal
+   * Internal method used by PasskeyApiClient to exchange passkey credentials for tokens.
+   * Routes through _requestToken() so tokens are cached, ID token verified, and session established.
+   */
+  async _requestTokenForPasskey(
+    options: {
+      authSession: string;
+      credential: PasskeyCredentialResponse;
+      realm?: string;
+      scope?: string;
+      audience?: string;
+    }
+  ): Promise<TokenEndpointResponse> {
+    const audience = options.audience || this.options.authorizationParams.audience;
+    return this._requestToken({
+      grant_type: 'urn:okta:params:oauth:grant-type:webauthn',
+      auth_session: options.authSession,
+      authn_response: options.credential,
+      ...(options.realm && { realm: options.realm }),
+      scope: scopesToRequest(this.scope, options.scope, audience),
+      audience,
+    });
+  }
+
+  /**
+   * @internal
    * Internal method used by MfaApiClient to exchange MFA tokens for access tokens.
    * This method should not be called directly by applications.
    */
@@ -2062,6 +2106,13 @@ interface TokenExchangeRequestOptions extends BaseRequestTokenOptions {
   actor_token?: string;
   actor_token_type?: string;
   organization?: string;
+}
+
+interface WebauthnRequestTokenOptions extends BaseRequestTokenOptions {
+  grant_type: 'urn:okta:params:oauth:grant-type:webauthn';
+  auth_session: string;
+  authn_response: PasskeyCredentialResponse;
+  realm?: string;
 }
 
 interface RequestTokenAdditionalParameters {

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,18 +46,25 @@ export async function oauthToken(
   const isTokenExchange =
     options.grant_type === 'urn:ietf:params:oauth:grant-type:token-exchange';
 
+  const isWebAuthn =
+    options.grant_type === 'urn:okta:params:oauth:grant-type:webauthn';
+
   const refreshWithMrrt = options.grant_type === 'refresh_token' && useMrrt;
+
+  const includeAudienceAndScope = isTokenExchange || isWebAuthn || refreshWithMrrt;
 
   const allParams = {
     ...options,
-    ...(isTokenExchange && audience && { audience }),
-    ...(isTokenExchange && scope && { scope }),
-    ...(refreshWithMrrt && { audience, scope })
+    ...(includeAudienceAndScope && audience && { audience }),
+    ...(includeAudienceAndScope && scope && { scope }),
   };
 
-  const body = useFormData
-    ? createQueryParams(allParams)
-    : JSON.stringify(allParams);
+  // WebAuthn grant must use JSON so authn_response is sent as an object, not a string.
+  const useJson = isWebAuthn || !useFormData;
+
+  const body = useJson
+    ? JSON.stringify(allParams)
+    : createQueryParams(allParams);
 
   const isDpopSupported = dpopUtils.isGrantTypeSupported(options.grant_type);
 
@@ -70,9 +77,9 @@ export async function oauthToken(
       method: 'POST',
       body,
       headers: {
-        'Content-Type': useFormData
-          ? 'application/x-www-form-urlencoded'
-          : 'application/json',
+        'Content-Type': useJson
+          ? 'application/json'
+          : 'application/x-www-form-urlencoded',
         'Auth0-Client': btoa(
           JSON.stringify(stripAuth0Client(auth0Client || DEFAULT_AUTH0_CLIENT))
         )

--- a/src/dpop/utils.ts
+++ b/src/dpop/utils.ts
@@ -8,6 +8,7 @@ const SUPPORTED_GRANT_TYPES = [
   'authorization_code',
   'refresh_token',
   'urn:ietf:params:oauth:grant-type:token-exchange',
+  'urn:okta:params:oauth:grant-type:webauthn',
   'http://auth0.com/oauth/grant-type/mfa-oob',
   'http://auth0.com/oauth/grant-type/mfa-otp',
   'http://auth0.com/oauth/grant-type/mfa-recovery-code'

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,4 +82,24 @@ export type {
 
 export { MyAccountApiError } from './MyAccountApiClient';
 
+export { PasskeyApiClient } from './passkey';
+export {
+  PasskeyError,
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError
+} from './passkey/errors';
+export type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  SigninWithPasskeyOptions,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions,
+  PasskeyEnrollmentOptions,
+  PasskeyEnrollmentResponse,
+  PasskeyEnrollmentVerifyOptions
+} from './passkey';
+
 export type { CustomTokenExchangeOptions } from './TokenExchange';

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,15 +88,18 @@ export {
   PasskeyEnrollmentError,
   PasskeyEnrollmentVerifyError
 } from './passkey/errors';
+export type { PasskeyErrorResponse } from './passkey/errors';
 export type {
   PasskeySignupChallengeOptions,
   PasskeySignupChallengeResponse,
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  SigninWithPasskeyOptions,
+  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions,
+  PasskeySignupOptions,
+  PasskeyLoginOptions,
   PasskeyEnrollmentOptions,
   PasskeyEnrollmentResponse,
   PasskeyEnrollmentVerifyOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,14 +82,16 @@ export type {
 
 export { MyAccountApiError } from './MyAccountApiClient';
 
-export { PasskeyApiClient } from './passkey';
 export {
+  PasskeyApiClient,
   PasskeyError,
   PasskeyEnrollmentError,
-  PasskeyEnrollmentVerifyError
-} from './passkey/errors';
-export type { PasskeyErrorResponse } from './passkey/errors';
+  PasskeyEnrollmentVerifyError,
+  PasskeyRegisterError,
+  PasskeyChallengeError
+} from './passkey';
 export type {
+  PasskeyErrorResponse,
   PasskeySignupChallengeOptions,
   PasskeySignupChallengeResponse,
   PasskeyLoginChallengeOptions,
@@ -98,10 +100,7 @@ export type {
   PasskeyCreationOptions,
   PasskeyRequestOptions,
   PasskeySignupOptions,
-  PasskeyLoginOptions,
-  PasskeyEnrollmentOptions,
-  PasskeyEnrollmentResponse,
-  PasskeyEnrollmentVerifyOptions
+  PasskeyLoginOptions
 } from './passkey';
 
 export type { CustomTokenExchangeOptions } from './TokenExchange';

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,6 @@ export type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions,
   PasskeySignupOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,8 @@ export {
   PasskeyEnrollmentError,
   PasskeyEnrollmentVerifyError,
   PasskeyRegisterError,
-  PasskeyChallengeError
+  PasskeyChallengeError,
+  PasskeyGetTokenError
 } from './passkey';
 export type {
   PasskeyErrorResponse,

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -2,11 +2,11 @@ import type { Auth0Client } from '../Auth0Client';
 import type { Fetcher } from '../fetcher';
 import type { TokenEndpointResponse } from '../global';
 import type {
-  PasskeySignupChallengeOptions,
-  PasskeySignupChallengeResponse,
-  PasskeyLoginChallengeOptions,
-  PasskeyLoginChallengeResponse,
-  SigninWithPasskeyOptions,
+  PasskeySignupOptions,
+  PasskeyLoginOptions,
+  PasskeyCredentialResponse,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions,
   PasskeyEnrollmentOptions,
   PasskeyEnrollmentResponse,
   PasskeyEnrollmentVerifyOptions
@@ -17,31 +17,19 @@ import { PasskeyClient } from '@auth0/auth0-auth-js';
 /**
  * Client for Auth0 Passkey operations.
  *
- * Provides methods for:
- * - Passkey signup (challenge + token exchange)
- * - Passkey login (challenge + token exchange)
- * - Passkey enrollment (for authenticated users adding a passkey)
- *
- * Authentication operations (signup, login, signin) delegate to auth0-auth-js PasskeyClient.
- * Enrollment operations use the My Account API via the SDK's authenticated fetcher.
+ * Provides 4 public methods:
+ * - `signup` — Register a new user with a passkey (full flow: challenge → WebAuthn → token exchange)
+ * - `login` — Sign in with a passkey (full flow: challenge → WebAuthn → token exchange)
+ * - `enrollmentChallenge` — Start passkey enrollment for an authenticated user
+ * - `enrollmentVerify` — Complete passkey enrollment
  *
  * @example
  * ```typescript
- * // Signup with passkey
- * const challenge = await auth0.passkey.signupChallenge({ email: 'user@example.com' });
- * const credential = await navigator.credentials.create({ publicKey: challenge.authnParamsPublicKey });
- * const tokens = await auth0.passkey.signinWithPasskey({
- *   authSession: challenge.authSession,
- *   credential: serializeCredential(credential),
- * });
+ * // Signup — single call handles everything
+ * const tokens = await auth0.passkey.signup({ email: 'user@example.com' });
  *
- * // Login with passkey
- * const loginChallenge = await auth0.passkey.loginChallenge();
- * const assertion = await navigator.credentials.get({ publicKey: loginChallenge.authnParamsPublicKey });
- * const tokens = await auth0.passkey.signinWithPasskey({
- *   authSession: loginChallenge.authSession,
- *   credential: serializeCredential(assertion),
- * });
+ * // Login — single call handles everything
+ * const tokens = await auth0.passkey.login();
  * ```
  */
 export class PasskeyApiClient {
@@ -67,51 +55,88 @@ export class PasskeyApiClient {
   }
 
   /**
-   * Requests a passkey signup challenge for a new user.
+   * Register a new user with a passkey.
    *
-   * Returns WebAuthn public key creation options to pass to
-   * `navigator.credentials.create()`.
+   * Handles the full flow: requests a signup challenge, triggers the browser
+   * WebAuthn credential creation ceremony, serializes the result, and exchanges
+   * it for tokens.
    *
-   * @throws {PasskeySignupChallengeError} If the request fails (invalid email, misconfigured connection, etc.)
+   * @throws {PasskeyRegisterError} If the challenge request fails
+   * @throws {GenericError} If the token exchange fails
+   * @throws {Error} If the user cancels the WebAuthn prompt
    */
-  async signupChallenge(
-    options: PasskeySignupChallengeOptions
-  ): Promise<PasskeySignupChallengeResponse> {
-    return this.#passkeyClient.signupChallenge(options);
-  }
+  async signup(options: PasskeySignupOptions): Promise<TokenEndpointResponse> {
+    const { scope, audience, ...challengeOptions } = options;
 
-  /**
-   * Requests a passkey login challenge for an existing user.
-   *
-   * Returns WebAuthn public key request options to pass to
-   * `navigator.credentials.get()`.
-   *
-   * @throws {PasskeyLoginChallengeError} If the request fails (invalid realm, network error, etc.)
-   */
-  async loginChallenge(
-    options?: PasskeyLoginChallengeOptions
-  ): Promise<PasskeyLoginChallengeResponse> {
-    return this.#passkeyClient.loginChallenge(options);
-  }
+    const challenge = await this.#passkeyClient.register(challengeOptions);
 
-  /**
-   * Exchanges a passkey credential for tokens.
-   *
-   * Call this after the user completes the WebAuthn ceremony (signup or login)
-   * with the serialized credential response. Tokens are cached and the session
-   * is established (same as standard login).
-   *
-   * @throws {GenericError} If the token exchange fails (expired authSession, invalid credential, etc.)
-   */
-  async signinWithPasskey(
-    options: SigninWithPasskeyOptions
-  ): Promise<TokenEndpointResponse> {
+    const publicKeyOptions = prepareCreationOptions(
+      challenge.authnParamsPublicKey
+    );
+    const credential = await navigator.credentials.create({
+      publicKey: publicKeyOptions
+    });
+
+    if (!credential) {
+      throw new Error(
+        'Passkey creation was cancelled or no credential was returned.'
+      );
+    }
+
+    const serialized = serializeCreationCredential(
+      credential as PublicKeyCredential
+    );
+
     return this.#auth0Client._requestTokenForPasskey({
-      authSession: options.authSession,
-      credential: options.credential,
-      realm: options.realm,
-      scope: options.scope,
-      audience: options.audience
+      authSession: challenge.authSession,
+      credential: serialized,
+      realm: challengeOptions.realm,
+      scope,
+      audience
+    });
+  }
+
+  /**
+   * Sign in with an existing passkey.
+   *
+   * Handles the full flow: requests a login challenge, triggers the browser
+   * WebAuthn assertion ceremony, serializes the result, and exchanges it
+   * for tokens.
+   *
+   * @throws {PasskeyChallengeError} If the challenge request fails
+   * @throws {GenericError} If the token exchange fails
+   * @throws {Error} If the user cancels the WebAuthn prompt
+   */
+  async login(options?: PasskeyLoginOptions): Promise<TokenEndpointResponse> {
+    const { scope, audience, ...challengeOptions } = options || {};
+
+    const challenge = await this.#passkeyClient.challenge(
+      Object.keys(challengeOptions).length ? challengeOptions : undefined
+    );
+
+    const publicKeyOptions = prepareRequestOptions(
+      challenge.authnParamsPublicKey
+    );
+    const credential = await navigator.credentials.get({
+      publicKey: publicKeyOptions
+    });
+
+    if (!credential) {
+      throw new Error(
+        'Passkey authentication was cancelled or no credential was returned.'
+      );
+    }
+
+    const serialized = serializeAssertionCredential(
+      credential as PublicKeyCredential
+    );
+
+    return this.#auth0Client._requestTokenForPasskey({
+      authSession: challenge.authSession,
+      credential: serialized,
+      realm: challengeOptions.realm,
+      scope,
+      audience
     });
   }
 
@@ -168,7 +193,6 @@ export class PasskeyApiClient {
     };
 
     const res = await this.#myAccountFetcher.fetchWithAuth(
-      // %7C is the URL-encoded pipe character in "passkey|new"
       `${this.#apiBase}v1/authentication-methods/passkey%7Cnew/verify`,
       {
         method: 'POST',
@@ -216,4 +240,96 @@ export class PasskeyApiClient {
 
     return body as T;
   }
+}
+
+function bufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBuffer(base64url: string): ArrayBuffer {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function prepareCreationOptions(
+  publicKey: PasskeyCreationOptions
+): PublicKeyCredentialCreationOptions {
+  return {
+    ...publicKey,
+    challenge: base64urlToBuffer(publicKey.challenge),
+    user: {
+      ...publicKey.user,
+      id: base64urlToBuffer(publicKey.user.id)
+    },
+    pubKeyCredParams: publicKey.pubKeyCredParams as PublicKeyCredentialParameters[],
+    authenticatorSelection: publicKey.authenticatorSelection as AuthenticatorSelectionCriteria | undefined
+  };
+}
+
+function prepareRequestOptions(
+  publicKey: PasskeyRequestOptions
+): PublicKeyCredentialRequestOptions {
+  const { allowCredentials, ...rest } = publicKey;
+  const opts = {
+    ...rest,
+    challenge: base64urlToBuffer(publicKey.challenge)
+  } as unknown as PublicKeyCredentialRequestOptions;
+  if (allowCredentials && allowCredentials.length > 0) {
+    opts.allowCredentials = allowCredentials.map((c) => ({
+      ...c,
+      id: base64urlToBuffer(c.id),
+      type: c.type as 'public-key',
+      transports: c.transports as AuthenticatorTransport[] | undefined
+    }));
+  }
+  return opts;
+}
+
+function serializeCreationCredential(
+  credential: PublicKeyCredential
+): PasskeyCredentialResponse {
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      attestationObject: bufferToBase64url(response.attestationObject)
+    },
+    clientExtensionResults: credential.getClientExtensionResults() as Record<string, unknown>
+  };
+}
+
+function serializeAssertionCredential(
+  credential: PublicKeyCredential
+): PasskeyCredentialResponse {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      authenticatorData: bufferToBase64url(response.authenticatorData),
+      signature: bufferToBase64url(response.signature),
+      userHandle: response.userHandle
+        ? bufferToBase64url(response.userHandle)
+        : undefined
+    },
+    clientExtensionResults: credential.getClientExtensionResults() as Record<string, unknown>
+  };
 }

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -7,7 +7,8 @@ import type {
   PasskeyCreationOptions,
   PasskeyRequestOptions
 } from './types';
-import { PasskeyClient } from '@auth0/auth0-auth-js';
+import type { PasskeyClient } from '@auth0/auth0-auth-js';
+import { PasskeyError } from './errors';
 
 /**
  * Client for Auth0 Passkey operations.
@@ -49,7 +50,7 @@ export class PasskeyApiClient {
    * @returns A promise that resolves to the token endpoint response containing access/ID tokens
    * @throws {PasskeyRegisterError} If the challenge request fails
    * @throws {GenericError} If the token exchange fails
-   * @throws {Error} If the user cancels the WebAuthn prompt
+   * @throws {PasskeyError} If the user cancels the WebAuthn prompt
    */
   async signup(options: PasskeySignupOptions): Promise<TokenEndpointResponse> {
     const { scope, audience, ...challengeOptions } = options;
@@ -64,7 +65,8 @@ export class PasskeyApiClient {
     });
 
     if (!credential) {
-      throw new Error(
+      throw new PasskeyError(
+        'passkey_cancelled',
         'Passkey creation was cancelled or no credential was returned.'
       );
     }
@@ -94,13 +96,13 @@ export class PasskeyApiClient {
    * @returns A promise that resolves to the token endpoint response containing access/ID tokens
    * @throws {PasskeyChallengeError} If the challenge request fails
    * @throws {GenericError} If the token exchange fails
-   * @throws {Error} If the user cancels the WebAuthn prompt
+   * @throws {PasskeyError} If the user cancels the WebAuthn prompt
    */
   async login(options?: PasskeyLoginOptions): Promise<TokenEndpointResponse> {
     const { scope, audience, ...challengeOptions } = options || {};
 
     const challenge = await this.#passkeyClient.challenge(
-      Object.values(challengeOptions).some(v => v !== undefined) ? challengeOptions : undefined
+      Object.keys(challengeOptions).length > 0 ? challengeOptions : undefined
     );
 
     const publicKeyOptions = prepareRequestOptions(
@@ -111,7 +113,8 @@ export class PasskeyApiClient {
     });
 
     if (!credential) {
-      throw new Error(
+      throw new PasskeyError(
+        'passkey_cancelled',
         'Passkey authentication was cancelled or no credential was returned.'
       );
     }
@@ -134,10 +137,7 @@ export class PasskeyApiClient {
 
 function bufferToBase64url(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
+  const binary = Array.from(bytes, b => String.fromCharCode(b)).join('');
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
@@ -173,7 +173,7 @@ function prepareRequestOptions(
   return {
     ...publicKey,
     challenge: base64urlToBuffer(publicKey.challenge)
-  } as unknown as PublicKeyCredentialRequestOptions;
+  } as PublicKeyCredentialRequestOptions;
 }
 
 function serializeCreationCredential(

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -91,6 +91,7 @@ export class PasskeyApiClient {
       authSession: challenge.authSession,
       credential: serialized,
       realm: challengeOptions.realm,
+      organization: challengeOptions.organization,
       scope,
       audience
     });
@@ -135,6 +136,7 @@ export class PasskeyApiClient {
       authSession: challenge.authSession,
       credential: serialized,
       realm: challengeOptions.realm,
+      organization: challengeOptions.organization,
       scope,
       audience
     });

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -6,7 +6,6 @@ import type {
   PasskeySignupChallengeResponse,
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
-  PasskeyCredentialResponse,
   SigninWithPasskeyOptions,
   PasskeyEnrollmentOptions,
   PasskeyEnrollmentResponse,

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -1,27 +1,20 @@
 import type { Auth0Client } from '../Auth0Client';
-import type { Fetcher } from '../fetcher';
 import type { TokenEndpointResponse } from '../global';
 import type {
   PasskeySignupOptions,
   PasskeyLoginOptions,
   PasskeyCredentialResponse,
   PasskeyCreationOptions,
-  PasskeyRequestOptions,
-  PasskeyEnrollmentOptions,
-  PasskeyEnrollmentResponse,
-  PasskeyEnrollmentVerifyOptions
+  PasskeyRequestOptions
 } from './types';
-import { PasskeyEnrollmentError, PasskeyEnrollmentVerifyError } from './errors';
 import { PasskeyClient } from '@auth0/auth0-auth-js';
 
 /**
  * Client for Auth0 Passkey operations.
  *
- * Provides 4 public methods:
+ * Provides 2 public methods:
  * - `signup` — Register a new user with a passkey (full flow: challenge → WebAuthn → token exchange)
  * - `login` — Sign in with a passkey (full flow: challenge → WebAuthn → token exchange)
- * - `enrollmentChallenge` — Start passkey enrollment for an authenticated user
- * - `enrollmentVerify` — Complete passkey enrollment
  *
  * @example
  * ```typescript
@@ -35,23 +28,14 @@ import { PasskeyClient } from '@auth0/auth0-auth-js';
 export class PasskeyApiClient {
   #passkeyClient: PasskeyClient;
   #auth0Client: Auth0Client;
-  #myAccountFetcher: Fetcher<Response>;
-  #apiBase: string;
 
   /**
    * @internal
    * Do not instantiate directly. Use Auth0Client.passkey instead.
    */
-  constructor(
-    passkeyClient: PasskeyClient,
-    auth0Client: Auth0Client,
-    myAccountFetcher: Fetcher<Response>,
-    apiBase: string
-  ) {
+  constructor(passkeyClient: PasskeyClient, auth0Client: Auth0Client) {
     this.#passkeyClient = passkeyClient;
     this.#auth0Client = auth0Client;
-    this.#myAccountFetcher = myAccountFetcher;
-    this.#apiBase = apiBase;
   }
 
   /**
@@ -61,6 +45,8 @@ export class PasskeyApiClient {
    * WebAuthn credential creation ceremony, serializes the result, and exchanges
    * it for tokens.
    *
+   * @param options - Passkey signup options (user identifier, optional scope/audience)
+   * @returns A promise that resolves to the token endpoint response containing access/ID tokens
    * @throws {PasskeyRegisterError} If the challenge request fails
    * @throws {GenericError} If the token exchange fails
    * @throws {Error} If the user cancels the WebAuthn prompt
@@ -104,6 +90,8 @@ export class PasskeyApiClient {
    * WebAuthn assertion ceremony, serializes the result, and exchanges it
    * for tokens.
    *
+   * @param options - Optional passkey login options (optional scope/audience/realm/organization)
+   * @returns A promise that resolves to the token endpoint response containing access/ID tokens
    * @throws {PasskeyChallengeError} If the challenge request fails
    * @throws {GenericError} If the token exchange fails
    * @throws {Error} If the user cancels the WebAuthn prompt
@@ -112,7 +100,7 @@ export class PasskeyApiClient {
     const { scope, audience, ...challengeOptions } = options || {};
 
     const challenge = await this.#passkeyClient.challenge(
-      Object.keys(challengeOptions).length ? challengeOptions : undefined
+      Object.values(challengeOptions).some(v => v !== undefined) ? challengeOptions : undefined
     );
 
     const publicKeyOptions = prepareRequestOptions(
@@ -142,106 +130,6 @@ export class PasskeyApiClient {
     });
   }
 
-  /**
-   * Creates a passkey enrollment challenge for an authenticated user.
-   *
-   * Allows an existing user to add a passkey to their account.
-   * Returns WebAuthn public key creation options to pass to
-   * `navigator.credentials.create()`.
-   */
-  async enrollmentChallenge(
-    options?: PasskeyEnrollmentOptions
-  ): Promise<PasskeyEnrollmentResponse> {
-    const body: Record<string, unknown> = { type: 'passkey' };
-
-    if (options?.connection) body.connection = options.connection;
-    if (options?.identity) body.identity = options.identity;
-
-    const res = await this.#myAccountFetcher.fetchWithAuth(
-      `${this.#apiBase}v1/authentication-methods`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      }
-    );
-
-    const responseBody = await this.#handleResponse<{
-      auth_session: string;
-      authn_params_public_key: PasskeyEnrollmentResponse['authnParamsPublicKey'];
-    }>(
-      res,
-      'Failed to create passkey enrollment challenge',
-      PasskeyEnrollmentError
-    );
-
-    return {
-      authSession: responseBody.auth_session,
-      authnParamsPublicKey: responseBody.authn_params_public_key
-    };
-  }
-
-  /**
-   * Verifies a passkey enrollment to complete registration.
-   *
-   * Call this after the user creates a credential using the enrollment challenge.
-   */
-  async enrollmentVerify(
-    options: PasskeyEnrollmentVerifyOptions
-  ): Promise<void> {
-    const body = {
-      auth_session: options.authSession,
-      authn_response: options.credential
-    };
-
-    const res = await this.#myAccountFetcher.fetchWithAuth(
-      `${this.#apiBase}v1/authentication-methods/passkey%7Cnew/verify`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      }
-    );
-
-    await this.#handleResponse<void>(
-      res,
-      'Failed to verify passkey enrollment',
-      PasskeyEnrollmentVerifyError
-    );
-  }
-
-  async #handleResponse<T>(
-    res: Response,
-    defaultMessage: string,
-    ErrorClass:
-      | typeof PasskeyEnrollmentError
-      | typeof PasskeyEnrollmentVerifyError
-  ): Promise<T> {
-    let rawText: string | undefined;
-    let body: any;
-
-    try {
-      rawText = await res.text();
-      body = rawText ? JSON.parse(rawText) : undefined;
-    } catch {
-      if (!res.ok) {
-        throw new ErrorClass(defaultMessage, {
-          status: res.status,
-          detail: rawText
-        });
-      }
-      return undefined as T;
-    }
-
-    if (!res.ok) {
-      throw new ErrorClass(
-        body?.error_description || body?.detail || defaultMessage,
-        body
-      );
-    }
-
-    return body as T;
-  }
 }
 
 function bufferToBase64url(buffer: ArrayBuffer): string {

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -1,0 +1,220 @@
+import type { Auth0Client } from '../Auth0Client';
+import type { Fetcher } from '../fetcher';
+import type { TokenEndpointResponse } from '../global';
+import type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  SigninWithPasskeyOptions,
+  PasskeyEnrollmentOptions,
+  PasskeyEnrollmentResponse,
+  PasskeyEnrollmentVerifyOptions
+} from './types';
+import { PasskeyEnrollmentError, PasskeyEnrollmentVerifyError } from './errors';
+import { PasskeyClient } from '@auth0/auth0-auth-js';
+
+/**
+ * Client for Auth0 Passkey operations.
+ *
+ * Provides methods for:
+ * - Passkey signup (challenge + token exchange)
+ * - Passkey login (challenge + token exchange)
+ * - Passkey enrollment (for authenticated users adding a passkey)
+ *
+ * Authentication operations (signup, login, signin) delegate to auth0-auth-js PasskeyClient.
+ * Enrollment operations use the My Account API via the SDK's authenticated fetcher.
+ *
+ * @example
+ * ```typescript
+ * // Signup with passkey
+ * const challenge = await auth0.passkey.signupChallenge({ email: 'user@example.com' });
+ * const credential = await navigator.credentials.create({ publicKey: challenge.authnParamsPublicKey });
+ * const tokens = await auth0.passkey.signinWithPasskey({
+ *   authSession: challenge.authSession,
+ *   credential: serializeCredential(credential),
+ * });
+ *
+ * // Login with passkey
+ * const loginChallenge = await auth0.passkey.loginChallenge();
+ * const assertion = await navigator.credentials.get({ publicKey: loginChallenge.authnParamsPublicKey });
+ * const tokens = await auth0.passkey.signinWithPasskey({
+ *   authSession: loginChallenge.authSession,
+ *   credential: serializeCredential(assertion),
+ * });
+ * ```
+ */
+export class PasskeyApiClient {
+  #passkeyClient: PasskeyClient;
+  #auth0Client: Auth0Client;
+  #myAccountFetcher: Fetcher<Response>;
+  #apiBase: string;
+
+  /**
+   * @internal
+   * Do not instantiate directly. Use Auth0Client.passkey instead.
+   */
+  constructor(
+    passkeyClient: PasskeyClient,
+    auth0Client: Auth0Client,
+    myAccountFetcher: Fetcher<Response>,
+    apiBase: string
+  ) {
+    this.#passkeyClient = passkeyClient;
+    this.#auth0Client = auth0Client;
+    this.#myAccountFetcher = myAccountFetcher;
+    this.#apiBase = apiBase;
+  }
+
+  /**
+   * Requests a passkey signup challenge for a new user.
+   *
+   * Returns WebAuthn public key creation options to pass to
+   * `navigator.credentials.create()`.
+   *
+   * @throws {PasskeySignupChallengeError} If the request fails (invalid email, misconfigured connection, etc.)
+   */
+  async signupChallenge(
+    options: PasskeySignupChallengeOptions
+  ): Promise<PasskeySignupChallengeResponse> {
+    return this.#passkeyClient.signupChallenge(options);
+  }
+
+  /**
+   * Requests a passkey login challenge for an existing user.
+   *
+   * Returns WebAuthn public key request options to pass to
+   * `navigator.credentials.get()`.
+   *
+   * @throws {PasskeyLoginChallengeError} If the request fails (invalid realm, network error, etc.)
+   */
+  async loginChallenge(
+    options?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyLoginChallengeResponse> {
+    return this.#passkeyClient.loginChallenge(options);
+  }
+
+  /**
+   * Exchanges a passkey credential for tokens.
+   *
+   * Call this after the user completes the WebAuthn ceremony (signup or login)
+   * with the serialized credential response. Tokens are cached and the session
+   * is established (same as standard login).
+   *
+   * @throws {GenericError} If the token exchange fails (expired authSession, invalid credential, etc.)
+   */
+  async signinWithPasskey(
+    options: SigninWithPasskeyOptions
+  ): Promise<TokenEndpointResponse> {
+    return this.#auth0Client._requestTokenForPasskey({
+      authSession: options.authSession,
+      credential: options.credential,
+      realm: options.realm,
+      scope: options.scope,
+      audience: options.audience
+    });
+  }
+
+  /**
+   * Creates a passkey enrollment challenge for an authenticated user.
+   *
+   * Allows an existing user to add a passkey to their account.
+   * Returns WebAuthn public key creation options to pass to
+   * `navigator.credentials.create()`.
+   */
+  async enrollmentChallenge(
+    options?: PasskeyEnrollmentOptions
+  ): Promise<PasskeyEnrollmentResponse> {
+    const body: Record<string, unknown> = { type: 'passkey' };
+
+    if (options?.connection) body.connection = options.connection;
+    if (options?.identity) body.identity = options.identity;
+
+    const res = await this.#myAccountFetcher.fetchWithAuth(
+      `${this.#apiBase}v1/authentication-methods`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }
+    );
+
+    const responseBody = await this.#handleResponse<{
+      auth_session: string;
+      authn_params_public_key: PasskeyEnrollmentResponse['authnParamsPublicKey'];
+    }>(
+      res,
+      'Failed to create passkey enrollment challenge',
+      PasskeyEnrollmentError
+    );
+
+    return {
+      authSession: responseBody.auth_session,
+      authnParamsPublicKey: responseBody.authn_params_public_key
+    };
+  }
+
+  /**
+   * Verifies a passkey enrollment to complete registration.
+   *
+   * Call this after the user creates a credential using the enrollment challenge.
+   */
+  async enrollmentVerify(
+    options: PasskeyEnrollmentVerifyOptions
+  ): Promise<void> {
+    const body = {
+      auth_session: options.authSession,
+      authn_response: options.credential
+    };
+
+    const res = await this.#myAccountFetcher.fetchWithAuth(
+      // %7C is the URL-encoded pipe character in "passkey|new"
+      `${this.#apiBase}v1/authentication-methods/passkey%7Cnew/verify`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }
+    );
+
+    await this.#handleResponse<void>(
+      res,
+      'Failed to verify passkey enrollment',
+      PasskeyEnrollmentVerifyError
+    );
+  }
+
+  async #handleResponse<T>(
+    res: Response,
+    defaultMessage: string,
+    ErrorClass:
+      | typeof PasskeyEnrollmentError
+      | typeof PasskeyEnrollmentVerifyError
+  ): Promise<T> {
+    let rawText: string | undefined;
+    let body: any;
+
+    try {
+      rawText = await res.text();
+      body = rawText ? JSON.parse(rawText) : undefined;
+    } catch {
+      if (!res.ok) {
+        throw new ErrorClass(defaultMessage, {
+          status: res.status,
+          detail: rawText
+        });
+      }
+      return undefined as T;
+    }
+
+    if (!res.ok) {
+      throw new ErrorClass(
+        body?.error_description || body?.detail || defaultMessage,
+        body
+      );
+    }
+
+    return body as T;
+  }
+}

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -282,20 +282,10 @@ function prepareCreationOptions(
 function prepareRequestOptions(
   publicKey: PasskeyRequestOptions
 ): PublicKeyCredentialRequestOptions {
-  const { allowCredentials, ...rest } = publicKey;
-  const opts = {
-    ...rest,
+  return {
+    ...publicKey,
     challenge: base64urlToBuffer(publicKey.challenge)
   } as unknown as PublicKeyCredentialRequestOptions;
-  if (allowCredentials && allowCredentials.length > 0) {
-    opts.allowCredentials = allowCredentials.map((c) => ({
-      ...c,
-      id: base64urlToBuffer(c.id),
-      type: c.type as 'public-key',
-      transports: c.transports as AuthenticatorTransport[] | undefined
-    }));
-  }
-  return opts;
 }
 
 function serializeCreationCredential(

--- a/src/passkey/errors.ts
+++ b/src/passkey/errors.ts
@@ -1,4 +1,8 @@
-export { PasskeyRegisterError, PasskeyChallengeError } from '@auth0/auth0-auth-js';
+export {
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError
+} from '@auth0/auth0-auth-js';
 
 export interface PasskeyErrorResponse {
   type?: string;

--- a/src/passkey/errors.ts
+++ b/src/passkey/errors.ts
@@ -1,0 +1,37 @@
+export interface PasskeyErrorResponse {
+  type?: string;
+  status?: number;
+  title?: string;
+  detail?: string;
+  error?: string;
+  error_description?: string;
+}
+
+export class PasskeyError extends Error {
+  public readonly code: string;
+  public readonly cause?: PasskeyErrorResponse;
+
+  constructor(code: string, message: string, cause?: PasskeyErrorResponse) {
+    super(message);
+    this.name = 'PasskeyError';
+    this.code = code;
+    this.cause = cause;
+    Object.setPrototypeOf(this, PasskeyError.prototype);
+  }
+}
+
+export class PasskeyEnrollmentError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyErrorResponse) {
+    super('passkey_enrollment_error', message, cause);
+    this.name = 'PasskeyEnrollmentError';
+    Object.setPrototypeOf(this, PasskeyEnrollmentError.prototype);
+  }
+}
+
+export class PasskeyEnrollmentVerifyError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyErrorResponse) {
+    super('passkey_enrollment_verify_error', message, cause);
+    this.name = 'PasskeyEnrollmentVerifyError';
+    Object.setPrototypeOf(this, PasskeyEnrollmentVerifyError.prototype);
+  }
+}

--- a/src/passkey/errors.ts
+++ b/src/passkey/errors.ts
@@ -1,3 +1,5 @@
+export { PasskeyRegisterError, PasskeyChallengeError } from '@auth0/auth0-auth-js';
+
 export interface PasskeyErrorResponse {
   type?: string;
   status?: number;

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -4,7 +4,8 @@ export {
   PasskeyEnrollmentError,
   PasskeyEnrollmentVerifyError,
   PasskeyRegisterError,
-  PasskeyChallengeError
+  PasskeyChallengeError,
+  PasskeyGetTokenError
 } from './errors';
 export type { PasskeyErrorResponse } from './errors';
 export type {

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -11,7 +11,6 @@ export type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions,
   PasskeySignupOptions,

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -2,7 +2,9 @@ export { PasskeyApiClient } from './PasskeyApiClient';
 export {
   PasskeyError,
   PasskeyEnrollmentError,
-  PasskeyEnrollmentVerifyError
+  PasskeyEnrollmentVerifyError,
+  PasskeyRegisterError,
+  PasskeyChallengeError
 } from './errors';
 export type { PasskeyErrorResponse } from './errors';
 export type {
@@ -14,8 +16,5 @@ export type {
   PasskeyCreationOptions,
   PasskeyRequestOptions,
   PasskeySignupOptions,
-  PasskeyLoginOptions,
-  PasskeyEnrollmentOptions,
-  PasskeyEnrollmentResponse,
-  PasskeyEnrollmentVerifyOptions
+  PasskeyLoginOptions
 } from './types';

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -4,15 +4,18 @@ export {
   PasskeyEnrollmentError,
   PasskeyEnrollmentVerifyError
 } from './errors';
+export type { PasskeyErrorResponse } from './errors';
 export type {
   PasskeySignupChallengeOptions,
   PasskeySignupChallengeResponse,
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  SigninWithPasskeyOptions,
+  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions,
+  PasskeySignupOptions,
+  PasskeyLoginOptions,
   PasskeyEnrollmentOptions,
   PasskeyEnrollmentResponse,
   PasskeyEnrollmentVerifyOptions

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -1,0 +1,19 @@
+export { PasskeyApiClient } from './PasskeyApiClient';
+export {
+  PasskeyError,
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError
+} from './errors';
+export type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  SigninWithPasskeyOptions,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions,
+  PasskeyEnrollmentOptions,
+  PasskeyEnrollmentResponse,
+  PasskeyEnrollmentVerifyOptions
+} from './types';

--- a/src/passkey/types.ts
+++ b/src/passkey/types.ts
@@ -4,7 +4,7 @@ import type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  SigninWithPasskeyOptions,
+  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions
 } from '@auth0/auth0-auth-js';
@@ -15,9 +15,25 @@ export type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  SigninWithPasskeyOptions,
+  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions
+};
+
+/**
+ * Options for passkey signup (registering a new user with a passkey).
+ */
+export type PasskeySignupOptions = PasskeySignupChallengeOptions & {
+  scope?: string;
+  audience?: string;
+};
+
+/**
+ * Options for passkey login (authenticating with an existing passkey).
+ */
+export type PasskeyLoginOptions = PasskeyLoginChallengeOptions & {
+  scope?: string;
+  audience?: string;
 };
 
 /**

--- a/src/passkey/types.ts
+++ b/src/passkey/types.ts
@@ -1,0 +1,45 @@
+import type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  SigninWithPasskeyOptions,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions
+} from '@auth0/auth0-auth-js';
+
+export type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  SigninWithPasskeyOptions,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions
+};
+
+/**
+ * Options for creating a passkey enrollment challenge.
+ */
+export interface PasskeyEnrollmentOptions {
+  connection?: string;
+  identity?: string;
+}
+
+/**
+ * Response from a passkey enrollment challenge.
+ */
+export interface PasskeyEnrollmentResponse {
+  authSession: string;
+  authnParamsPublicKey: PasskeyCreationOptions;
+}
+
+/**
+ * Options for verifying a passkey enrollment.
+ */
+export interface PasskeyEnrollmentVerifyOptions {
+  authSession: string;
+  credential: PasskeyCredentialResponse;
+}

--- a/src/passkey/types.ts
+++ b/src/passkey/types.ts
@@ -33,27 +33,3 @@ export type PasskeyLoginOptions = PasskeyLoginChallengeOptions & {
   scope?: string;
   audience?: string;
 };
-
-/**
- * Options for creating a passkey enrollment challenge.
- */
-export interface PasskeyEnrollmentOptions {
-  connection?: string;
-  identity?: string;
-}
-
-/**
- * Response from a passkey enrollment challenge.
- */
-export interface PasskeyEnrollmentResponse {
-  authSession: string;
-  authnParamsPublicKey: PasskeyCreationOptions;
-}
-
-/**
- * Options for verifying a passkey enrollment.
- */
-export interface PasskeyEnrollmentVerifyOptions {
-  authSession: string;
-  credential: PasskeyCredentialResponse;
-}

--- a/src/passkey/types.ts
+++ b/src/passkey/types.ts
@@ -4,7 +4,6 @@ import type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions
 } from '@auth0/auth0-auth-js';
@@ -15,7 +14,6 @@ export type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions
 };


### PR DESCRIPTION
## Summary

Adds native passkey (WebAuthn) support to `auth0-spa-js` via a new `PasskeyApiClient`, exposed as `auth0Client.passkey`. Built on top of `@auth0/auth0-auth-js` v1.7.0 which ships the underlying passkey primitives.

The SDK abstracts the full WebAuthn flow — challenge fetch, browser credential ceremony, base64url serialization, and token exchange — into two single-call methods.

## API

```typescript
// Register a new user with a passkey
const tokens = await auth0Client.passkey.signup({ email: 'user@example.com' });

// Authenticate an existing user with a passkey
const tokens = await auth0Client.passkey.login();
const tokens = await auth0Client.passkey.login({ realm, organization, scope, audience });
```

## What's included

- **`PasskeyApiClient`** (`auth0Client.passkey`) with two public methods:
  - `signup(options)` — challenge → `navigator.credentials.create()` → serialize → token exchange
  - `login(options?)` — challenge → `navigator.credentials.get()` → serialize → token exchange
- WebAuthn grant type: `urn:okta:params:oauth:grant-type:webauthn`
- Built-in base64url ↔ ArrayBuffer conversion; consumers never touch WebAuthn binary formats
- Full token pipeline: caching, ID token verification, session establishment
- DPoP support for the WebAuthn grant type
- Error classes re-exported at top level: `PasskeyError`, `PasskeyRegisterError`, `PasskeyChallengeError`, `PasskeyGetTokenError`

## Notes

- `auth0-auth-js` bumped to 1.7.0 (passkeys support now published)
- Passkey enrollment for authenticated users is out of scope for this PR and will be handled separately