### PR TITLE
feat: add passkey authentication support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,6 +10,7 @@
 - [Device-bound tokens with DPoP](#device-bound-tokens-with-dpop)
 - [Connect Accounts for using Token Vault](#connect-accounts-for-using-token-vault)
 - [Accessing SDK Configuration](#accessing-sdk-configuration)
+- [Passkeys](#passkeys)
 - [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
 - [Step-Up Authentication](#step-up-authentication)
 
@@ -898,7 +899,6 @@ You can now [call the API](#calling-an-api) with your access token and the API c
 > [!IMPORTANT]
 > You must enable `Offline Access` from the Connection Permissions settings to be able to use the connection with Connected Accounts.
 
-
 ## Accessing SDK Configuration
 
 After initializing the Auth0Client, you can retrieve the configuration details:
@@ -923,12 +923,170 @@ This is useful when you need to:
 - Pass configuration to other services or analytics
 - Verify the SDK is configured correctly
 
+## Passkeys
+
+Passkeys provide password-less authentication using platform biometrics (Face ID, Touch ID, Windows Hello) or security keys via the WebAuthn standard. The SDK supports two flows:
+
+1. **Signup**: Register a new user with a passkey
+2. **Login**: Authenticate an existing user with a passkey
+
+- [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys)
+- [Signup with Passkey](#signup-with-passkey)
+- [Login with Passkey](#login-with-passkey)
+- [Complete Passkey Flow Example](#complete-passkey-flow-example)
+- [Error Handling](#passkey-error-handling)
+
+### Setup
+
+Before using passkeys, enable the Database Connection with passkey support in your [Auth0 Dashboard](https://manage.auth0.com) under **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
+
+### Important: Use Refresh Tokens with Passkeys
+
+> [!IMPORTANT]
+> When using passkeys, you **must** configure the SDK with `useRefreshTokens: true`.
+
+Passkey authentication uses a direct token exchange (`/oauth/token` with the WebAuthn grant type). It does **not** create an Auth0 session cookie because there is no redirect to `/authorize`. This means that when the access token expires, the SDK cannot silently obtain a new one using an iframe (which relies on the Auth0 session cookie via `prompt=none`).
+
+Without refresh tokens, `getTokenSilently()` will either:
+- Fail with a `login_required` error (if no Auth0 session exists), or
+- Return tokens for a **different user** if a separate Auth0 session cookie exists from a prior redirect-based login, causing an unintended session swap.
+
+To avoid this, always enable refresh tokens:
+
+```js
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  useRefreshTokens: true, // Required for passkey-based sessions
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+```
+
+You must also enable **Refresh Token Rotation** in your Auth0 Dashboard under **Applications** > your app > **Settings** > **Refresh Token Rotation**.
+
+### Signup with Passkey
+
+Register a new user with a passkey. The SDK handles the entire flow internally: requesting a challenge from Auth0, triggering the browser's WebAuthn credential creation ceremony, serializing the result, and exchanging it for tokens.
+
+```js
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+
+// One call handles everything — the user sees the biometric prompt
+const tokens = await auth0.passkey.signup({
+  email: 'user@example.com',
+  name: 'Jane Doe' // optional display name
+});
+
+// User is now logged in — getUser() works immediately
+const user = await auth0.getUser();
+console.log('Signed up:', user);
+```
+
+You can also pass `scope` and `audience` to control the access token:
+
+```js
+const tokens = await auth0.passkey.signup({
+  email: 'user@example.com',
+  scope: 'openid profile email read:products',
+  audience: 'https://api.example.com'
+});
+```
+
+#### Organization-Scoped Signup
+
+To register a user within an organization context:
+
+```js
+const tokens = await auth0.passkey.signup({
+  email: 'user@example.com',
+  organization: 'org_abc123'
+});
+```
+
+> [!NOTE]
+> `passkey.signup()` and `passkey.login()` cache tokens and establish a session automatically, just like `loginWithRedirect()`. After calling them, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` all work as expected.
+>
+> Remember to configure `useRefreshTokens: true`. See [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys).
+
+### Login with Passkey
+
+Authenticate an existing user with their registered passkey. Like signup, a single call handles the entire flow.
+
+```js
+const tokens = await auth0.passkey.login();
+
+const user = await auth0.getUser();
+console.log('Logged in:', user);
+```
+
+#### Specifying a Realm
+
+If your tenant has multiple database connections with passkeys enabled, specify the `realm`:
+
+```js
+const tokens = await auth0.passkey.login({
+  realm: 'Username-Password-Authentication'
+});
+```
+
+#### Organization-Scoped Login
+
+To authenticate within an organization context:
+
+```js
+const tokens = await auth0.passkey.login({
+  organization: 'org_abc123'
+});
+```
+
+### Complete Passkey Flow Example
+
+```js
+import { createAuth0Client } from '@auth0/auth0-spa-js';
+
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  useRefreshTokens: true,
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+
+// --- Signup (single call) ---
+async function signupWithPasskey(email, displayName) {
+  await auth0.passkey.signup({ email, name: displayName });
+  return await auth0.getUser();
+}
+
+// --- Login (single call) ---
+async function loginWithPasskey() {
+  await auth0.passkey.login();
+  return await auth0.getUser();
+}
+```
+
+### Passkey Error Handling
+
+> [!TIP]
+> Both `signup()` and `login()` throw an `Error` with a descriptive message if the user cancels the biometric prompt (i.e., the WebAuthn API returns `null`). Wrap calls in try/catch to handle cancellation, network failures, or misconfigured connections.
+
 ## Multi-Factor Authentication (MFA)
 
 The MFA API allows you to manage multi-factor authentication for users. The SDK automatically handles MFA context, eliminating the need for manual parsing of error payloads.
+
 > [!NOTE]
 > Multi Factor Authentication support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
-
 
 - [Understanding the MFA Response](#understanding-the-mfa-response)
 - [Handling MFA required errors](#handling-mfa-required-errors)
@@ -1011,7 +1169,6 @@ try {
   await auth0.getTokenSilently();
 } catch (error) {
   if (error instanceof MfaRequiredError) {
-
     // Check if enrollment is required
     const enrollmentFactors = await auth0.mfa.getEnrollmentFactors(error.mfa_token);
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1021,11 +1021,26 @@ const tokens = await auth0.passkey.signup({
 
 ```js
 const tokens = await auth0.passkey.signup({
-  email: 'user@example.com',        // required: user identifier
-  realm: 'my-db-connection',        // optional: target database connection
-  organization: 'org_abc123',       // optional: organization context
-  scope: 'openid profile email',    // optional: access token scopes
-  audience: 'https://api.example.com' // optional: API audience
+  // At least one identifier is required
+  email: 'user@example.com',
+  phoneNumber: '+1234567890',       // optional: E.164 format
+  username: 'janedoe',              // optional
+
+  // Profile fields (all optional)
+  name: 'Jane Doe',
+  givenName: 'Jane',
+  familyName: 'Doe',
+  nickname: 'janie',
+  picture: 'https://example.com/avatar.png',
+  userMetadata: { plan: 'pro' },
+
+  // Connection and org
+  realm: 'my-db-connection',
+  organization: 'org_abc123',
+
+  // Token options
+  scope: 'openid profile email',
+  audience: 'https://api.example.com'
 });
 ```
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -938,7 +938,11 @@ Passkeys provide password-less authentication using platform biometrics (Face ID
 
 ### Setup
 
-Before using passkeys, enable the Database Connection with passkey support in your [Auth0 Dashboard](https://manage.auth0.com) under **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
+Before using passkeys, ensure the following are configured in your [Auth0 Dashboard](https://manage.auth0.com):
+
+1. **Enable passkey authentication method**: Go to **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
+2. **Enable the WebAuthn passkey grant**: Go to your **Application** > **Advanced Settings** > **Grant Types** and enable the **Passkey** grant.
+3. **Custom domain required**: Passkeys are bound to an origin (domain). A [custom domain](https://auth0.com/docs/customize/custom-domains) must be configured — passkeys will not work on the default `*.auth0.com` domain.
 
 ### Important: Use Refresh Tokens with Passkeys
 
@@ -1010,6 +1014,18 @@ To register a user within an organization context:
 const tokens = await auth0.passkey.signup({
   email: 'user@example.com',
   organization: 'org_abc123'
+});
+```
+
+#### All Supported Signup Properties
+
+```js
+const tokens = await auth0.passkey.signup({
+  email: 'user@example.com',        // required: user identifier
+  realm: 'my-db-connection',        // optional: target database connection
+  organization: 'org_abc123',       // optional: organization context
+  scope: 'openid profile email',    // optional: access token scopes
+  audience: 'https://api.example.com' // optional: API audience
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ window.addEventListener('load', async () => {
 
 ### More Examples
 
-For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, organizations, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.
+For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.
 
 ## API Reference
 

--- a/__tests__/Auth0Client/requestTokenForPasskey.test.ts
+++ b/__tests__/Auth0Client/requestTokenForPasskey.test.ts
@@ -8,6 +8,8 @@ import { fetchResponse, setupFn } from './helpers';
 import {
   TEST_ACCESS_TOKEN,
   TEST_CODE_CHALLENGE,
+  TEST_DPOP_NONCE,
+  TEST_DPOP_PROOF,
   TEST_ID_TOKEN,
   TEST_REFRESH_TOKEN
 } from '../constants';
@@ -310,6 +312,32 @@ describe('Auth0Client', () => {
       expect(body.auth_session).toBe(TEST_AUTH_SESSION);
       expect(body.authn_response).toEqual(TEST_CREDENTIAL);
       expect(body.realm).toBe('my-connection');
+    });
+
+    it('sends DPoP-Proof header when DPoP is enabled', async () => {
+      const auth0 = setup({ useDpop: true });
+      const dpop = auth0['dpop']!;
+
+      jest.spyOn(dpop, 'getNonce').mockResolvedValue(TEST_DPOP_NONCE);
+      jest.spyOn(dpop, 'generateProof').mockResolvedValue(TEST_DPOP_PROOF);
+      jest.spyOn(dpop, 'setNonce').mockResolvedValue();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      const [, fetchOptions] = mockFetch.mock.calls[0];
+      expect(fetchOptions.headers['dpop']).toBe(TEST_DPOP_PROOF);
     });
   });
 });

--- a/__tests__/Auth0Client/requestTokenForPasskey.test.ts
+++ b/__tests__/Auth0Client/requestTokenForPasskey.test.ts
@@ -1,0 +1,315 @@
+import { verify } from '../../src/jwt';
+import { MessageChannel } from 'worker_threads';
+import * as utils from '../../src/utils';
+import * as scope from '../../src/scope';
+
+import { fetchResponse, setupFn } from './helpers';
+
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_CODE_CHALLENGE,
+  TEST_ID_TOKEN,
+  TEST_REFRESH_TOKEN
+} from '../constants';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue(TEST_CODE_CHALLENGE);
+
+jest.spyOn(utils, 'runPopup');
+
+const setup = setupFn(mockVerify);
+
+const TEST_CREDENTIAL = {
+  id: 'credential-id-123',
+  rawId: 'cmF3SWQtYmFzZTY0dXJs',
+  type: 'public-key',
+  authenticatorAttachment: 'platform',
+  response: {
+    clientDataJSON: 'Y2xpZW50RGF0YUpTT04',
+    authenticatorData: 'YXV0aGVudGljYXRvckRhdGE',
+    signature: 'c2lnbmF0dXJl',
+    userHandle: 'dXNlckhhbmRsZQ'
+  },
+  clientExtensionResults: {}
+};
+
+const TEST_AUTH_SESSION = 'auth-session-abc123';
+
+describe('Auth0Client', () => {
+  beforeEach(() => {
+    mockWindow.open = jest.fn();
+    mockWindow.addEventListener = jest.fn();
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+    jest.spyOn(scope, 'getUniqueScopes');
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+  });
+
+  describe('_requestTokenForPasskey', () => {
+    it('passes correct parameters to _requestToken', async () => {
+      const auth0 = setup({
+        authorizationParams: {
+          audience: 'https://default-api.com',
+          scope: 'openid profile'
+        }
+      });
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any,
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(capturedOptions.grant_type).toBe(
+        'urn:okta:params:oauth:grant-type:webauthn'
+      );
+      expect(capturedOptions.auth_session).toBe(TEST_AUTH_SESSION);
+      expect(capturedOptions.authn_response).toEqual(TEST_CREDENTIAL);
+      expect(capturedOptions.audience).toBe('https://api.example.com');
+      expect(capturedOptions.scope).toContain('openid');
+      expect(capturedOptions.scope).toContain('profile');
+      expect(capturedOptions.scope).toContain('email');
+    });
+
+    it('uses default audience when none provided', async () => {
+      const auth0 = setup({
+        authorizationParams: {
+          audience: 'https://default-api.com',
+          scope: 'openid profile'
+        }
+      });
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(capturedOptions.audience).toBe('https://default-api.com');
+    });
+
+    it('includes realm when provided', async () => {
+      const auth0 = setup();
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any,
+        realm: 'Username-Password-Authentication'
+      });
+
+      expect(capturedOptions.realm).toBe('Username-Password-Authentication');
+    });
+
+    it('does not include realm when not provided', async () => {
+      const auth0 = setup();
+
+      let capturedOptions: any;
+      auth0['_requestToken'] = async function (options: any) {
+        capturedOptions = options;
+        return {
+          decodedToken: {
+            encoded: { header: 'h', payload: 'p', signature: 's' },
+            header: {},
+            claims: { sub: 'me', __raw: 'raw' },
+            user: { sub: 'me' }
+          },
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: options.scope
+        };
+      };
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(capturedOptions.realm).toBeUndefined();
+    });
+
+    it('caches tokens and establishes session via _requestToken', async () => {
+      const auth0 = setup();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      const result = await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(result.access_token).toBe(TEST_ACCESS_TOKEN);
+      expect(result.id_token).toBe(TEST_ID_TOKEN);
+
+      // Verify user is now authenticated (session established)
+      const isAuthenticated = await auth0.isAuthenticated();
+      expect(isAuthenticated).toBe(true);
+
+      // Verify user claims are accessible
+      const user = await auth0.getUser();
+      expect(user.sub).toBe('me');
+    });
+
+    it('verifies the ID token', async () => {
+      const auth0 = setup();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any
+      });
+
+      expect(mockVerify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id_token: TEST_ID_TOKEN
+        })
+      );
+    });
+
+    it('propagates token endpoint errors', async () => {
+      const auth0 = setup();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'invalid_grant',
+          error_description: 'Auth session has expired'
+        })
+      );
+
+      await expect(
+        auth0._requestTokenForPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: TEST_CREDENTIAL as any
+        })
+      ).rejects.toMatchObject({
+        error: 'invalid_grant',
+        error_description: 'Auth session has expired'
+      });
+    });
+
+    it('sends JSON body to /oauth/token endpoint (not form-encoded)', async () => {
+      const auth0 = setup({ useFormData: true });
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400
+        })
+      );
+
+      await auth0._requestTokenForPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: TEST_CREDENTIAL as any,
+        realm: 'my-connection'
+      });
+
+      const [url, fetchOptions] = mockFetch.mock.calls[0];
+      expect(url).toContain('/oauth/token');
+      expect(fetchOptions.method).toBe('POST');
+      expect(fetchOptions.headers['Content-Type']).toBe('application/json');
+
+      const body = JSON.parse(fetchOptions.body);
+      expect(body.grant_type).toBe(
+        'urn:okta:params:oauth:grant-type:webauthn'
+      );
+      expect(body.auth_session).toBe(TEST_AUTH_SESSION);
+      expect(body.authn_response).toEqual(TEST_CREDENTIAL);
+      expect(body.realm).toBe('my-connection');
+    });
+  });
+});

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -249,6 +249,14 @@ describe('PasskeyApiClient', () => {
 
       await passkeyClient.signup({
         email: 'user@example.com',
+        phoneNumber: '+1234567890',
+        username: 'janedoe',
+        name: 'Jane Doe',
+        givenName: 'Jane',
+        familyName: 'Doe',
+        nickname: 'janie',
+        picture: 'https://example.com/avatar.png',
+        userMetadata: { plan: 'pro' },
         realm: 'Username-Password-Authentication',
         organization: 'org_abc123',
         scope: 'openid profile email',
@@ -257,6 +265,14 @@ describe('PasskeyApiClient', () => {
 
       expect(mockPasskeyClient.register).toHaveBeenCalledWith({
         email: 'user@example.com',
+        phoneNumber: '+1234567890',
+        username: 'janedoe',
+        name: 'Jane Doe',
+        givenName: 'Jane',
+        familyName: 'Doe',
+        nickname: 'janie',
+        picture: 'https://example.com/avatar.png',
+        userMetadata: { plan: 'pro' },
         realm: 'Username-Password-Authentication',
         organization: 'org_abc123'
       });

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -1,0 +1,571 @@
+jest.mock('@auth0/auth0-auth-js', () => ({
+  PasskeyClient: jest.fn()
+}));
+
+import { PasskeyApiClient } from '../../src/passkey/PasskeyApiClient';
+import {
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError
+} from '../../src/passkey/errors';
+
+const TEST_AUTH_SESSION = 'auth-session-abc123';
+
+function createMockPublicKeyCredential(type: 'create' | 'get') {
+  const clientDataJSON = new Uint8Array([1, 2, 3]).buffer;
+
+  if (type === 'create') {
+    return {
+      id: 'credential-id-123',
+      rawId: new Uint8Array([10, 20, 30]).buffer,
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: {
+        clientDataJSON,
+        attestationObject: new Uint8Array([40, 50, 60]).buffer
+      },
+      getClientExtensionResults: () => ({})
+    };
+  }
+
+  return {
+    id: 'credential-id-456',
+    rawId: new Uint8Array([10, 20, 30]).buffer,
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: {
+      clientDataJSON,
+      authenticatorData: new Uint8Array([70, 80, 90]).buffer,
+      signature: new Uint8Array([100, 110, 120]).buffer,
+      userHandle: new Uint8Array([130, 140, 150]).buffer
+    },
+    getClientExtensionResults: () => ({})
+  };
+}
+
+describe('PasskeyApiClient', () => {
+  let passkeyClient: PasskeyApiClient;
+  let mockPasskeyClient: any;
+  let mockAuth0Client: any;
+
+  const originalCredentials = Object.getOwnPropertyDescriptor(
+    global.navigator,
+    'credentials'
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockPasskeyClient = {
+      register: jest.fn(),
+      challenge: jest.fn(),
+      getTokenByPasskey: jest.fn()
+    };
+
+    mockAuth0Client = {
+      _requestTokenForPasskey: jest.fn()
+    };
+
+    passkeyClient = new PasskeyApiClient(
+      mockPasskeyClient,
+      mockAuth0Client
+    );
+  });
+
+  afterEach(() => {
+    if (originalCredentials) {
+      Object.defineProperty(global.navigator, 'credentials', originalCredentials);
+    }
+  });
+
+  describe('signup', () => {
+    it('should handle full flow: challenge → WebAuthn → serialize → token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+          timeout: 60000
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      const mockCredential = createMockPublicKeyCredential('create');
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(mockCredential) },
+        configurable: true
+      });
+
+      const mockTokenResponse = {
+        id_token: 'eyJ...',
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.signup({ email: 'user@example.com' });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({ email: 'user@example.com' });
+      expect(navigator.credentials.create).toHaveBeenCalledWith({
+        publicKey: expect.objectContaining({
+          challenge: expect.any(ArrayBuffer),
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: expect.objectContaining({
+            id: expect.any(ArrayBuffer)
+          })
+        })
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential: expect.objectContaining({
+          id: 'credential-id-123',
+          rawId: expect.any(String),
+          type: 'public-key',
+          response: expect.objectContaining({
+            clientDataJSON: expect.any(String),
+            attestationObject: expect.any(String)
+          })
+        }),
+        realm: undefined,
+        organization: undefined,
+        scope: undefined,
+        audience: undefined
+      });
+      expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should pass organization to both challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({
+        email: 'user@example.com',
+        organization: 'org_abc123'
+      });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        organization: 'org_abc123'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: 'org_abc123'
+        })
+      );
+    });
+
+    it('should pass scope and audience to token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          realm: 'Username-Password-Authentication',
+          scope: 'openid profile email',
+          audience: 'https://api.example.com'
+        })
+      );
+    });
+
+    it('should throw if user cancels WebAuthn prompt', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(null) },
+        configurable: true
+      });
+
+      await expect(
+        passkeyClient.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('Passkey creation was cancelled or no credential was returned.');
+    });
+
+    it('should propagate errors from PasskeyClient.register', async () => {
+      mockPasskeyClient.register.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        passkeyClient.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('Network error');
+    });
+
+    it('should propagate errors from token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(
+        new Error('Token exchange failed')
+      );
+
+      await expect(
+        passkeyClient.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('Token exchange failed');
+    });
+
+    it('should not call PasskeyClient.getTokenByPasskey directly', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({ email: 'user@example.com' });
+
+      expect(mockPasskeyClient.getTokenByPasskey).not.toHaveBeenCalled();
+    });
+
+    it('should serialize credential with base64url encoding', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({ email: 'user@example.com' });
+
+      const credential = mockAuth0Client._requestTokenForPasskey.mock.calls[0][0].credential;
+      expect(credential.rawId).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.clientDataJSON).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.attestationObject).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  describe('login', () => {
+    it('should handle full flow: challenge → WebAuthn → serialize → token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com',
+          timeout: 60000,
+          userVerification: 'preferred'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      const mockCredential = createMockPublicKeyCredential('get');
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(mockCredential) },
+        configurable: true
+      });
+
+      const mockTokenResponse = {
+        id_token: 'eyJ...',
+        access_token: 'at_456',
+        token_type: 'Bearer',
+        expires_in: 86400
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.login();
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith(undefined);
+      expect(navigator.credentials.get).toHaveBeenCalledWith({
+        publicKey: expect.objectContaining({
+          challenge: expect.any(ArrayBuffer),
+          rpId: 'example.auth0.com'
+        })
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential: expect.objectContaining({
+          id: 'credential-id-456',
+          rawId: expect.any(String),
+          type: 'public-key',
+          response: expect.objectContaining({
+            clientDataJSON: expect.any(String),
+            authenticatorData: expect.any(String),
+            signature: expect.any(String),
+            userHandle: expect.any(String)
+          })
+        }),
+        realm: undefined,
+        organization: undefined,
+        scope: undefined,
+        audience: undefined
+      });
+      expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should pass organization to both challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.login({ organization: 'org_abc123' });
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith({
+        organization: 'org_abc123'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: 'org_abc123'
+        })
+      );
+    });
+
+    it('should pass realm option to challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.login({
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile',
+        audience: 'https://api.example.com'
+      });
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith({
+        realm: 'Username-Password-Authentication'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          realm: 'Username-Password-Authentication',
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      );
+    });
+
+    it('should throw if user cancels WebAuthn prompt', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(null) },
+        configurable: true
+      });
+
+      await expect(passkeyClient.login()).rejects.toThrow(
+        'Passkey authentication was cancelled or no credential was returned.'
+      );
+    });
+
+    it('should propagate errors from PasskeyClient.challenge', async () => {
+      mockPasskeyClient.challenge.mockRejectedValue(new Error('Service unavailable'));
+
+      await expect(passkeyClient.login()).rejects.toThrow('Service unavailable');
+    });
+
+    it('should propagate errors from token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(
+        new Error('Token exchange failed')
+      );
+
+      await expect(passkeyClient.login()).rejects.toThrow('Token exchange failed');
+    });
+
+    it('should serialize assertion credential with base64url encoding', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.login();
+
+      const credential = mockAuth0Client._requestTokenForPasskey.mock.calls[0][0].credential;
+      expect(credential.rawId).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.clientDataJSON).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.authenticatorData).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.signature).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.userHandle).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  describe('error classes', () => {
+    it('PasskeyEnrollmentError should have correct properties', () => {
+      const cause = { error: 'invalid_request', error_description: 'Bad request' };
+      const error = new PasskeyEnrollmentError('Something went wrong', cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(PasskeyEnrollmentError);
+      expect(error.name).toBe('PasskeyEnrollmentError');
+      expect(error.code).toBe('passkey_enrollment_error');
+      expect(error.message).toBe('Something went wrong');
+      expect(error.cause).toEqual(cause);
+    });
+
+    it('PasskeyEnrollmentVerifyError should have correct properties', () => {
+      const cause = { error: 'invalid_credential', error_description: 'Invalid' };
+      const error = new PasskeyEnrollmentVerifyError('Verify failed', cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(PasskeyEnrollmentVerifyError);
+      expect(error.name).toBe('PasskeyEnrollmentVerifyError');
+      expect(error.code).toBe('passkey_enrollment_verify_error');
+      expect(error.message).toBe('Verify failed');
+      expect(error.cause).toEqual(cause);
+    });
+  });
+});

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -55,6 +55,12 @@ describe('PasskeyApiClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    Object.defineProperty(window, 'PublicKeyCredential', {
+      value: jest.fn(),
+      writable: true,
+      configurable: true
+    });
+
     mockPasskeyClient = {
       register: jest.fn(),
       challenge: jest.fn(),
@@ -216,6 +222,65 @@ describe('PasskeyApiClient', () => {
           audience: 'https://api.example.com'
         })
       );
+    });
+
+    it('should pass all supported properties to challenge and token exchange', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.signup({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123'
+      });
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authSession: TEST_AUTH_SESSION,
+          realm: 'Username-Password-Authentication',
+          organization: 'org_abc123',
+          scope: 'openid profile email',
+          audience: 'https://api.example.com'
+        })
+      );
+    });
+
+    it('should throw if WebAuthn is not supported', async () => {
+      Object.defineProperty(window, 'PublicKeyCredential', {
+        value: undefined,
+        writable: true,
+        configurable: true
+      });
+
+      await expect(
+        passkeyClient.signup({ email: 'user@example.com' })
+      ).rejects.toThrow('WebAuthn is not supported in this browser.');
     });
 
     it('should throw if user cancels WebAuthn prompt', async () => {
@@ -460,6 +525,18 @@ describe('PasskeyApiClient', () => {
           scope: 'openid profile',
           audience: 'https://api.example.com'
         })
+      );
+    });
+
+    it('should throw if WebAuthn is not supported', async () => {
+      Object.defineProperty(window, 'PublicKeyCredential', {
+        value: undefined,
+        writable: true,
+        configurable: true
+      });
+
+      await expect(passkeyClient.login()).rejects.toThrow(
+        'WebAuthn is not supported in this browser.'
       );
     });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-auth-js": "1.6.0",
+    "@auth0/auth0-auth-js": "1.7.0",
     "browser-tabs-lock": "1.3.0",
     "dpop": "2.1.1",
     "es-cookie": "1.3.2"

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -122,6 +122,8 @@ import {
 } from './fetcher';
 import { MyAccountApiClient } from './MyAccountApiClient';
 import { MfaApiClient } from './mfa';
+import { PasskeyApiClient } from './passkey';
+import type { PasskeyCredentialResponse } from './passkey/types';
 import { AuthClient as Auth0AuthJsClient } from '@auth0/auth0-auth-js';
 
 /**
@@ -167,6 +169,15 @@ export class Auth0Client {
    * - Verifying MFA challenges
    */
   public readonly mfa: MfaApiClient;
+
+  /**
+   * Passkey API client for passwordless authentication.
+   *
+   * Provides two single-call methods that handle the full WebAuthn flow internally:
+   * - `signup(options)` — register a new user with a passkey
+   * - `login(options?)` — authenticate an existing user with a passkey
+   */
+  public readonly passkey: PasskeyApiClient;
 
   private worker?: Worker;
   private readonly authJsClient: Auth0AuthJsClient;
@@ -294,7 +305,10 @@ export class Auth0Client {
       clientId: this.options.clientId,
     });
     this.mfa = new MfaApiClient(this.authJsClient.mfa, this);
-
+    this.passkey = new PasskeyApiClient(
+      this.authJsClient.passkey,
+      this
+    );
 
     // Don't use web workers unless using refresh tokens in memory
     if (
@@ -1633,7 +1647,8 @@ export class Auth0Client {
     options:
       | PKCERequestTokenOptions
       | RefreshTokenRequestTokenOptions
-      | TokenExchangeRequestOptions,
+      | TokenExchangeRequestOptions
+      | WebauthnRequestTokenOptions,
     additionalParameters?: RequestTokenAdditionalParameters
   ) {
     const { nonceIn, organization, scopesToRequest } = additionalParameters || {};
@@ -2015,6 +2030,34 @@ export class Auth0Client {
 
   /**
    * @internal
+   * Internal method used by PasskeyApiClient to exchange passkey credentials for tokens.
+   * Routes through _requestToken() so tokens are cached, ID token verified, and session established.
+   */
+  async _requestTokenForPasskey(
+    options: {
+      authSession: string;
+      credential: PasskeyCredentialResponse;
+      realm?: string;
+      scope?: string;
+      audience?: string;
+      organization?: string;
+    }
+  ): Promise<TokenEndpointResponse> {
+    const audience = options.audience || this.options.authorizationParams.audience;
+    const organization = options.organization || this.options.authorizationParams.organization;
+    return this._requestToken({
+      grant_type: 'urn:okta:params:oauth:grant-type:webauthn',
+      auth_session: options.authSession,
+      authn_response: options.credential,
+      ...(options.realm && { realm: options.realm }),
+      ...(organization && { organization }),
+      scope: scopesToRequest(this.scope, options.scope, audience),
+      audience,
+    });
+  }
+
+  /**
+   * @internal
    * Internal method used by MfaApiClient to exchange MFA tokens for access tokens.
    * This method should not be called directly by applications.
    */
@@ -2061,6 +2104,14 @@ interface TokenExchangeRequestOptions extends BaseRequestTokenOptions {
   subject_token_type: string;
   actor_token?: string;
   actor_token_type?: string;
+  organization?: string;
+}
+
+interface WebauthnRequestTokenOptions extends BaseRequestTokenOptions {
+  grant_type: 'urn:okta:params:oauth:grant-type:webauthn';
+  auth_session: string;
+  authn_response: PasskeyCredentialResponse;
+  realm?: string;
   organization?: string;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,18 +46,25 @@ export async function oauthToken(
   const isTokenExchange =
     options.grant_type === 'urn:ietf:params:oauth:grant-type:token-exchange';
 
+  const isWebAuthn =
+    options.grant_type === 'urn:okta:params:oauth:grant-type:webauthn';
+
   const refreshWithMrrt = options.grant_type === 'refresh_token' && useMrrt;
+
+  const includeAudienceAndScope = isTokenExchange || isWebAuthn || refreshWithMrrt;
 
   const allParams = {
     ...options,
-    ...(isTokenExchange && audience && { audience }),
-    ...(isTokenExchange && scope && { scope }),
-    ...(refreshWithMrrt && { audience, scope })
+    ...(includeAudienceAndScope && audience && { audience }),
+    ...(includeAudienceAndScope && scope && { scope }),
   };
 
-  const body = useFormData
-    ? createQueryParams(allParams)
-    : JSON.stringify(allParams);
+  // WebAuthn grant must use JSON so authn_response is sent as an object, not a string.
+  const useJson = isWebAuthn || !useFormData;
+
+  const body = useJson
+    ? JSON.stringify(allParams)
+    : createQueryParams(allParams);
 
   const isDpopSupported = dpopUtils.isGrantTypeSupported(options.grant_type);
 
@@ -70,9 +77,9 @@ export async function oauthToken(
       method: 'POST',
       body,
       headers: {
-        'Content-Type': useFormData
-          ? 'application/x-www-form-urlencoded'
-          : 'application/json',
+        'Content-Type': useJson
+          ? 'application/json'
+          : 'application/x-www-form-urlencoded',
         'Auth0-Client': btoa(
           JSON.stringify(stripAuth0Client(auth0Client || DEFAULT_AUTH0_CLIENT))
         )

--- a/src/dpop/utils.ts
+++ b/src/dpop/utils.ts
@@ -8,6 +8,7 @@ const SUPPORTED_GRANT_TYPES = [
   'authorization_code',
   'refresh_token',
   'urn:ietf:params:oauth:grant-type:token-exchange',
+  'urn:okta:params:oauth:grant-type:webauthn',
   'http://auth0.com/oauth/grant-type/mfa-oob',
   'http://auth0.com/oauth/grant-type/mfa-otp',
   'http://auth0.com/oauth/grant-type/mfa-recovery-code'

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,4 +82,26 @@ export type {
 
 export { MyAccountApiError } from './MyAccountApiClient';
 
+export {
+  PasskeyApiClient,
+  PasskeyError,
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError,
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError
+} from './passkey';
+export type {
+  PasskeyErrorResponse,
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions,
+  PasskeySignupOptions,
+  PasskeyLoginOptions
+} from './passkey';
+
 export type { CustomTokenExchangeOptions } from './TokenExchange';

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -48,11 +48,16 @@ export class PasskeyApiClient {
    *
    * @param options - Passkey signup options (user identifier, optional scope/audience)
    * @returns A promise that resolves to the token endpoint response containing access/ID tokens
+   * @throws {PasskeyError} If WebAuthn is not supported in the browser
    * @throws {PasskeyRegisterError} If the challenge request fails
    * @throws {GenericError} If the token exchange fails
    * @throws {PasskeyError} If the user cancels the WebAuthn prompt
    */
   async signup(options: PasskeySignupOptions): Promise<TokenEndpointResponse> {
+    if (!window.PublicKeyCredential) {
+      throw new PasskeyError('passkey_not_supported', 'WebAuthn is not supported in this browser.');
+    }
+
     const { scope, audience, ...challengeOptions } = options;
 
     const challenge = await this.#passkeyClient.register(challengeOptions);
@@ -94,11 +99,16 @@ export class PasskeyApiClient {
    *
    * @param options - Optional passkey login options (optional scope/audience/realm/organization)
    * @returns A promise that resolves to the token endpoint response containing access/ID tokens
+   * @throws {PasskeyError} If WebAuthn is not supported in the browser
    * @throws {PasskeyChallengeError} If the challenge request fails
    * @throws {GenericError} If the token exchange fails
    * @throws {PasskeyError} If the user cancels the WebAuthn prompt
    */
   async login(options?: PasskeyLoginOptions): Promise<TokenEndpointResponse> {
+    if (!window.PublicKeyCredential) {
+      throw new PasskeyError('passkey_not_supported', 'WebAuthn is not supported in this browser.');
+    }
+
     const { scope, audience, ...challengeOptions } = options || {};
 
     const challenge = await this.#passkeyClient.challenge(

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -1,0 +1,215 @@
+import type { Auth0Client } from '../Auth0Client';
+import type { TokenEndpointResponse } from '../global';
+import type {
+  PasskeySignupOptions,
+  PasskeyLoginOptions,
+  PasskeyCredentialResponse,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions
+} from './types';
+import type { PasskeyClient } from '@auth0/auth0-auth-js';
+import { PasskeyError } from './errors';
+
+/**
+ * Client for Auth0 Passkey operations.
+ *
+ * Provides 2 public methods:
+ * - `signup` — Register a new user with a passkey (full flow: challenge → WebAuthn → token exchange)
+ * - `login` — Sign in with a passkey (full flow: challenge → WebAuthn → token exchange)
+ *
+ * @example
+ * ```typescript
+ * // Signup — single call handles everything
+ * const tokens = await auth0.passkey.signup({ email: 'user@example.com' });
+ *
+ * // Login — single call handles everything
+ * const tokens = await auth0.passkey.login();
+ * ```
+ */
+export class PasskeyApiClient {
+  #passkeyClient: PasskeyClient;
+  #auth0Client: Auth0Client;
+
+  /**
+   * @internal
+   * Do not instantiate directly. Use Auth0Client.passkey instead.
+   */
+  constructor(passkeyClient: PasskeyClient, auth0Client: Auth0Client) {
+    this.#passkeyClient = passkeyClient;
+    this.#auth0Client = auth0Client;
+  }
+
+  /**
+   * Register a new user with a passkey.
+   *
+   * Handles the full flow: requests a signup challenge, triggers the browser
+   * WebAuthn credential creation ceremony, serializes the result, and exchanges
+   * it for tokens.
+   *
+   * @param options - Passkey signup options (user identifier, optional scope/audience)
+   * @returns A promise that resolves to the token endpoint response containing access/ID tokens
+   * @throws {PasskeyRegisterError} If the challenge request fails
+   * @throws {GenericError} If the token exchange fails
+   * @throws {PasskeyError} If the user cancels the WebAuthn prompt
+   */
+  async signup(options: PasskeySignupOptions): Promise<TokenEndpointResponse> {
+    const { scope, audience, ...challengeOptions } = options;
+
+    const challenge = await this.#passkeyClient.register(challengeOptions);
+
+    const publicKeyOptions = prepareCreationOptions(
+      challenge.authnParamsPublicKey
+    );
+    const credential = await navigator.credentials.create({
+      publicKey: publicKeyOptions
+    });
+
+    if (!credential) {
+      throw new PasskeyError(
+        'passkey_cancelled',
+        'Passkey creation was cancelled or no credential was returned.'
+      );
+    }
+
+    const serialized = serializeCreationCredential(
+      credential as PublicKeyCredential
+    );
+
+    return this.#auth0Client._requestTokenForPasskey({
+      authSession: challenge.authSession,
+      credential: serialized,
+      realm: challengeOptions.realm,
+      organization: challengeOptions.organization,
+      scope,
+      audience
+    });
+  }
+
+  /**
+   * Sign in with an existing passkey.
+   *
+   * Handles the full flow: requests a login challenge, triggers the browser
+   * WebAuthn assertion ceremony, serializes the result, and exchanges it
+   * for tokens.
+   *
+   * @param options - Optional passkey login options (optional scope/audience/realm/organization)
+   * @returns A promise that resolves to the token endpoint response containing access/ID tokens
+   * @throws {PasskeyChallengeError} If the challenge request fails
+   * @throws {GenericError} If the token exchange fails
+   * @throws {PasskeyError} If the user cancels the WebAuthn prompt
+   */
+  async login(options?: PasskeyLoginOptions): Promise<TokenEndpointResponse> {
+    const { scope, audience, ...challengeOptions } = options || {};
+
+    const challenge = await this.#passkeyClient.challenge(
+      Object.keys(challengeOptions).length > 0 ? challengeOptions : undefined
+    );
+
+    const publicKeyOptions = prepareRequestOptions(
+      challenge.authnParamsPublicKey
+    );
+    const credential = await navigator.credentials.get({
+      publicKey: publicKeyOptions
+    });
+
+    if (!credential) {
+      throw new PasskeyError(
+        'passkey_cancelled',
+        'Passkey authentication was cancelled or no credential was returned.'
+      );
+    }
+
+    const serialized = serializeAssertionCredential(
+      credential as PublicKeyCredential
+    );
+
+    return this.#auth0Client._requestTokenForPasskey({
+      authSession: challenge.authSession,
+      credential: serialized,
+      realm: challengeOptions.realm,
+      organization: challengeOptions.organization,
+      scope,
+      audience
+    });
+  }
+
+}
+
+function bufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const binary = Array.from(bytes, b => String.fromCharCode(b)).join('');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBuffer(base64url: string): ArrayBuffer {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function prepareCreationOptions(
+  publicKey: PasskeyCreationOptions
+): PublicKeyCredentialCreationOptions {
+  return {
+    ...publicKey,
+    challenge: base64urlToBuffer(publicKey.challenge),
+    user: {
+      ...publicKey.user,
+      id: base64urlToBuffer(publicKey.user.id)
+    },
+    pubKeyCredParams: publicKey.pubKeyCredParams as PublicKeyCredentialParameters[],
+    authenticatorSelection: publicKey.authenticatorSelection as AuthenticatorSelectionCriteria | undefined
+  };
+}
+
+function prepareRequestOptions(
+  publicKey: PasskeyRequestOptions
+): PublicKeyCredentialRequestOptions {
+  return {
+    ...publicKey,
+    challenge: base64urlToBuffer(publicKey.challenge)
+  } as PublicKeyCredentialRequestOptions;
+}
+
+function serializeCreationCredential(
+  credential: PublicKeyCredential
+): PasskeyCredentialResponse {
+  const response = credential.response as AuthenticatorAttestationResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      attestationObject: bufferToBase64url(response.attestationObject)
+    },
+    clientExtensionResults: credential.getClientExtensionResults() as Record<string, unknown>
+  };
+}
+
+function serializeAssertionCredential(
+  credential: PublicKeyCredential
+): PasskeyCredentialResponse {
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment ?? undefined,
+    response: {
+      clientDataJSON: bufferToBase64url(response.clientDataJSON),
+      authenticatorData: bufferToBase64url(response.authenticatorData),
+      signature: bufferToBase64url(response.signature),
+      userHandle: response.userHandle
+        ? bufferToBase64url(response.userHandle)
+        : undefined
+    },
+    clientExtensionResults: credential.getClientExtensionResults() as Record<string, unknown>
+  };
+}

--- a/src/passkey/errors.ts
+++ b/src/passkey/errors.ts
@@ -5,12 +5,9 @@ export {
 } from '@auth0/auth0-auth-js';
 
 export interface PasskeyErrorResponse {
-  type?: string;
-  status?: number;
-  title?: string;
-  detail?: string;
-  error?: string;
-  error_description?: string;
+  error: string;
+  error_description: string;
+  message?: string;
 }
 
 export class PasskeyError extends Error {

--- a/src/passkey/errors.ts
+++ b/src/passkey/errors.ts
@@ -1,0 +1,43 @@
+export {
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError
+} from '@auth0/auth0-auth-js';
+
+export interface PasskeyErrorResponse {
+  type?: string;
+  status?: number;
+  title?: string;
+  detail?: string;
+  error?: string;
+  error_description?: string;
+}
+
+export class PasskeyError extends Error {
+  public readonly code: string;
+  public readonly cause?: PasskeyErrorResponse;
+
+  constructor(code: string, message: string, cause?: PasskeyErrorResponse) {
+    super(message);
+    this.name = 'PasskeyError';
+    this.code = code;
+    this.cause = cause;
+    Object.setPrototypeOf(this, PasskeyError.prototype);
+  }
+}
+
+export class PasskeyEnrollmentError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyErrorResponse) {
+    super('passkey_enrollment_error', message, cause);
+    this.name = 'PasskeyEnrollmentError';
+    Object.setPrototypeOf(this, PasskeyEnrollmentError.prototype);
+  }
+}
+
+export class PasskeyEnrollmentVerifyError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyErrorResponse) {
+    super('passkey_enrollment_verify_error', message, cause);
+    this.name = 'PasskeyEnrollmentVerifyError';
+    Object.setPrototypeOf(this, PasskeyEnrollmentVerifyError.prototype);
+  }
+}

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -1,0 +1,21 @@
+export { PasskeyApiClient } from './PasskeyApiClient';
+export {
+  PasskeyError,
+  PasskeyEnrollmentError,
+  PasskeyEnrollmentVerifyError,
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError
+} from './errors';
+export type { PasskeyErrorResponse } from './errors';
+export type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions,
+  PasskeySignupOptions,
+  PasskeyLoginOptions
+} from './types';

--- a/src/passkey/types.ts
+++ b/src/passkey/types.ts
@@ -1,0 +1,35 @@
+import type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions
+} from '@auth0/auth0-auth-js';
+
+export type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions
+};
+
+/**
+ * Options for passkey signup (registering a new user with a passkey).
+ */
+export type PasskeySignupOptions = PasskeySignupChallengeOptions & {
+  scope?: string;
+  audience?: string;
+};
+
+/**
+ * Options for passkey login (authenticating with an existing passkey).
+ */
+export type PasskeyLoginOptions = PasskeyLoginChallengeOptions & {
+  scope?: string;
+  audience?: string;
+};


### PR DESCRIPTION
## Summary

Adds native passkey (WebAuthn) support to `auth0-spa-js` via a new `PasskeyApiClient`, exposed as `auth0Client.passkey`. Built on top of `@auth0/auth0-auth-js` v1.7.0 which ships the underlying passkey primitives.

The SDK abstracts the full WebAuthn flow (challenge fetch, browser credential ceremony, base64url serialization, and token exchange) into two single-call methods.

## API

```typescript
// Register a new user with a passkey
const tokens = await auth0Client.passkey.signup({ email: 'user@example.com' });

// Authenticate an existing user with a passkey
const tokens = await auth0Client.passkey.login();
const tokens = await auth0Client.passkey.login({ realm, organization, scope, audience });
```

## What's included

- **`PasskeyApiClient`** (`auth0Client.passkey`) with two public methods:
  - `signup(options)`: challenge -> `navigator.credentials.create()` -> serialize -> token exchange
  - `login(options?)`: challenge -> `navigator.credentials.get()` -> serialize -> token exchange
- WebAuthn grant type: `urn:okta:params:oauth:grant-type:webauthn`
- Built-in base64url <-> ArrayBuffer conversion; consumers never touch WebAuthn binary formats
- Full token pipeline: caching, ID token verification, session establishment
- DPoP support for the WebAuthn grant type
- Error classes re-exported at top level: `PasskeyError`, `PasskeyRegisterError`, `PasskeyChallengeError`, `PasskeyGetTokenError`

## Notes

- `auth0-auth-js` bumped to 1.7.0 (passkeys support now published)
- Passkey enrollment for authenticated users is out of scope for this PR and will be handled separately