### PR TITLE
feat: support resource field in MRRT token responses

### DIFF
--- a/__tests__/Auth0Client/mrrt-resource-field.test.ts
+++ b/__tests__/Auth0Client/mrrt-resource-field.test.ts
@@ -1,0 +1,332 @@
+import { verify } from '../../src/jwt';
+import { MessageChannel } from 'worker_threads';
+import * as utils from '../../src/utils';
+
+import {
+  fetchResponse,
+  setupFn,
+  loginWithRedirectFn
+} from './helpers';
+
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_ID_TOKEN,
+  TEST_REFRESH_TOKEN,
+  TEST_TOKEN_TYPE
+} from '../constants';
+
+import { MrrtResourceMismatchError } from '../../src/errors';
+import { expect } from '@jest/globals';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue('TEST_CODE_CHALLENGE');
+
+const setup = setupFn(mockVerify);
+const loginWithRedirect = loginWithRedirectFn(mockWindow, mockFetch);
+
+describe('Auth0Client - MRRT resource field', () => {
+  const oldWindowLocation = window.location;
+
+  beforeEach(() => {
+    delete (window as any).location;
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: { configurable: true, value: jest.fn() },
+        replace: { configurable: true, value: jest.fn() }
+      }
+    ) as Location;
+
+    mockWindow.open = jest.fn();
+    mockWindow.addEventListener = jest.fn();
+    mockWindow.crypto = {
+      subtle: { digest: () => 'foo' },
+      getRandomValues() { return '123'; }
+    };
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+    window.location = oldWindowLocation;
+  });
+
+  describe('resource field in verbose response', () => {
+    it('includes resource in detailedResponse when server returns it on a fresh fetch', async () => {
+      const audience = 'https://api.example.com';
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400,
+          resource: audience
+        })
+      );
+
+      const result = await auth0.getTokenSilently({
+        cacheMode: 'off',
+        detailedResponse: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      expect(result.resource).toBe(audience);
+    });
+
+    it('includes resource in detailedResponse when served from cache', async () => {
+      const audience = 'https://api.example.com';
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      // Prime the cache with a resource field
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400,
+          resource: audience
+        })
+      );
+
+      await auth0.getTokenSilently({
+        cacheMode: 'off',
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      // Second call should come from cache
+      const result = await auth0.getTokenSilently({
+        detailedResponse: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      expect(result.resource).toBe(audience);
+    });
+
+    it('omits resource from detailedResponse when server does not return it', async () => {
+      const audience = 'https://api.example.com';
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400
+          // no resource field
+        })
+      );
+
+      const result = await auth0.getTokenSilently({
+        cacheMode: 'off',
+        detailedResponse: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      expect(result.resource).toBeUndefined();
+    });
+  });
+
+  describe('resource field audience validation', () => {
+    it('throws MrrtResourceMismatchError when resource does not match requested audience', async () => {
+      const requestedAudience = 'https://api.example.com';
+      const receivedResource = 'https://api.other.com';
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience: requestedAudience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400,
+          resource: receivedResource
+        })
+      );
+
+      await expect(
+        auth0.getTokenSilently({
+          cacheMode: 'off',
+          authorizationParams: { audience: requestedAudience, scope: 'openid profile' }
+        })
+      ).rejects.toThrow(MrrtResourceMismatchError);
+    });
+
+    it('MrrtResourceMismatchError carries requested and received audiences', async () => {
+      const requestedAudience = 'https://api.example.com';
+      const receivedResource = 'https://api.other.com';
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience: requestedAudience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400,
+          resource: receivedResource
+        })
+      );
+
+      const error = await auth0
+        .getTokenSilently({
+          cacheMode: 'off',
+          authorizationParams: { audience: requestedAudience, scope: 'openid profile' }
+        })
+        .catch(e => e);
+
+      expect(error).toBeInstanceOf(MrrtResourceMismatchError);
+      expect(error.requested).toBe(requestedAudience);
+      expect(error.received).toBe(receivedResource);
+      expect(error.error).toBe('mrrt_resource_mismatch');
+    });
+
+    it('does not throw when resource matches requested audience', async () => {
+      const audience = 'https://api.example.com';
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400,
+          resource: audience
+        })
+      );
+
+      await expect(
+        auth0.getTokenSilently({
+          cacheMode: 'off',
+          authorizationParams: { audience, scope: 'openid profile' }
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('skips validation when useMrrt is false even if server returns resource', async () => {
+      const requestedAudience = 'https://api.example.com';
+      const receivedResource = 'https://api.other.com';
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: false,
+        authorizationParams: { audience: requestedAudience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400,
+          resource: receivedResource
+        })
+      );
+
+      await expect(
+        auth0.getTokenSilently({
+          cacheMode: 'off',
+          authorizationParams: { audience: requestedAudience, scope: 'openid profile' }
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('skips validation when resource is absent', async () => {
+      const audience = 'https://api.example.com';
+
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        authorizationParams: { audience, scope: 'openid profile' }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          refresh_token: TEST_REFRESH_TOKEN,
+          token_type: TEST_TOKEN_TYPE,
+          expires_in: 86400
+          // no resource
+        })
+      );
+
+      await expect(
+        auth0.getTokenSilently({
+          cacheMode: 'off',
+          authorizationParams: { audience, scope: 'openid profile' }
+        })
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -41,6 +41,7 @@ import {
   MfaRequiredError,
   MissingRefreshTokenError,
   MissingScopesError,
+  MrrtResourceMismatchError,
   PopupOpenError,
   TimeoutError
 } from './errors';
@@ -985,7 +986,7 @@ export class Auth0Client {
           ? await this._getTokenUsingRefreshToken(getTokenOptions)
           : await this._getTokenFromIFrame(getTokenOptions);
 
-        const { id_token, token_type, access_token, oauthTokenScope, expires_in } =
+        const { id_token, token_type, access_token, oauthTokenScope, expires_in, resource } =
           authResult;
 
         return {
@@ -993,7 +994,8 @@ export class Auth0Client {
           token_type,
           access_token,
           ...(oauthTokenScope ? { scope: oauthTokenScope } : null),
-          expires_in
+          expires_in,
+          ...(resource ? { resource } : null)
         };
       });
     } catch (error) {
@@ -1629,7 +1631,7 @@ export class Auth0Client {
     );
 
     if (entry && entry.access_token) {
-      const { token_type, access_token, oauthTokenScope, expires_in } =
+      const { token_type, access_token, oauthTokenScope, expires_in, resource } =
         entry as CacheEntry;
       const cache = await this._getIdTokenFromCache();
       return (
@@ -1638,7 +1640,8 @@ export class Auth0Client {
           token_type: token_type ? token_type : 'Bearer',
           access_token,
           ...(oauthTokenScope ? { scope: oauthTokenScope } : null),
-          expires_in
+          expires_in,
+          ...(resource ? { resource } : null)
         }
       );
     }
@@ -1667,6 +1670,12 @@ export class Auth0Client {
       },
       this.worker
     );
+
+    if (this.options.useMrrt && authResult.resource && options.audience) {
+      if (authResult.resource !== options.audience) {
+        throw new MrrtResourceMismatchError(options.audience, authResult.resource);
+      }
+    }
 
     const decodedToken = await this._verifyIdToken(
       authResult.id_token,

--- a/src/cache/shared.ts
+++ b/src/cache/shared.ts
@@ -82,6 +82,8 @@ export type CacheEntry = {
   client_id: string;
   refresh_token?: string;
   oauthTokenScope?: string;
+  /** Resource server audience from an MRRT exchange response. Only present when `useMrrt: true`. */
+  resource?: string;
 };
 
 export type WrappedCacheEntry = {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -149,6 +149,20 @@ export class MissingScopesError extends GenericError {
 }
 
 /**
+ * Error thrown when the `resource` field in an MRRT token response does not match
+ * the requested audience, indicating the server returned a token for the wrong resource.
+ */
+export class MrrtResourceMismatchError extends GenericError {
+  constructor(public requested: string, public received: string) {
+    super(
+      'mrrt_resource_mismatch',
+      `MRRT resource mismatch: requested '${requested}' but server returned '${received}'`
+    );
+    Object.setPrototypeOf(this, MrrtResourceMismatchError.prototype);
+  }
+}
+
+/**
  * Error thrown when the wrong DPoP nonce is used and a potential subsequent retry wasn't able to fix it.
  */
 export class UseDpopNonceError extends GenericError {

--- a/src/global.ts
+++ b/src/global.ts
@@ -778,6 +778,13 @@ export type TokenEndpointResponse = {
   refresh_token?: string;
   expires_in: number;
   scope?: string;
+  /**
+   * The audience (resource server) associated with the issued access token.
+   * Only present when exchanging a Multi-Resource Refresh Token (MRRT), i.e.,
+   * when `useMrrt: true` is configured. The value matches the `aud` claim of
+   * the returned access token.
+   */
+  resource?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `resource?: string` to `TokenEndpointResponse` and `CacheEntry`. The field is returned by the server when exchanging a Multi-Resource Refresh Token (MRRT) and indicates the audience the issued access token is scoped for
- Validates the `resource` field against the requested audience before caching; throws `MrrtResourceMismatchError` if they diverge, preventing a mismatched token from ever being stored
- Propagates `resource` through `getTokenSilently({ detailedResponse: true })`, both from a fresh token fetch and from a cache hit

## Behaviour

- Only active when `useMrrt: true` and the server includes `resource` in the response (MRRT exchanges only); non-MRRT flows are unaffected
- `MrrtResourceMismatchError` (extends `GenericError`, error code `mrrt_resource_mismatch`) carries the `requested` and `received` audiences for debugging

## Test plan

- [ ] `useMrrt: true` + server returns matching `resource` -> token cached and returned normally, `resource` present in verbose response
- [ ] `useMrrt: true` + server returns mismatched `resource` -> `MrrtResourceMismatchError` thrown, nothing written to cache
- [ ] `useMrrt: true` + server omits `resource` -> no validation, existing behaviour unchanged
- [ ] `useMrrt: false` -> `resource` field ignored even if server sends it