### PR TITLE
feat: add support for online access (Online Refresh Tokens)

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -3,6 +3,7 @@
 - [Logging Out](#logging-out)
 - [Calling an API](#calling-an-api)
 - [Refresh Tokens](#refresh-tokens)
+- [Online Access (Online Refresh Tokens)](#online-access-online-refresh-tokens)
 - [Data Caching Options](#creating-a-custom-cache)
 - [Organizations](#organizations)
 - [Native to Web SSO](#native-to-web-sso)
@@ -203,6 +204,126 @@ When using [Multi-Resource Refresh Tokens (MRRT)](#using-multi-resource-refresh-
 // With MRRT, this single call revokes the shared token and
 // cleans up all cache entries that reference it
 await auth0.revokeRefreshToken();
+```
+
+## Online Access (Online Refresh Tokens)
+
+**Online Refresh Tokens (ORTs)** are a refresh token type bound to the lifetime of the user's Auth0 session. Unlike the rotating [offline refresh tokens](#refresh-tokens) described above, an ORT is:
+
+- **Session-bound** — it is valid only while the underlying Auth0 session is active. When the session ends (logout, idle/absolute session expiry, or an admin revoking the session), the ORT stops working.
+- **Non-rotating** — refreshing an access token with an ORT does **not** issue a new refresh token. The same ORT is reused for the life of the session.
+
+This makes ORTs a good fit for SPAs that want a refresh-token renewal path whose lifetime tracks the SSO session rather than living independently of it.
+
+> [!IMPORTANT]
+> Online access requires DPoP. Sender-constraining the token via [DPoP](#device-bound-tokens-with-dpop) is mandatory because the ORT is non-rotating — binding it to the browser's key pair is what mitigates token replay if it is exfiltrated. You must set `useDpop: true` explicitly; the SDK does not enable it for you.
+
+### Enabling Online Access
+
+Set `onlineAccess: true` together with `useDpop: true`:
+
+```js
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  onlineAccess: true,
+  useDpop: true, // required — DPoP is mandatory for online access
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+```
+
+Enabling this option causes the SDK to:
+
+- Send the `online_access` scope to the authorization server (instead of `offline_access`). You do **not** need to add it to `authorizationParams.scope` yourself — the SDK injects it.
+- Route token renewal through the `refresh_token` grant against `/oauth/token` (the same path used by offline refresh tokens), rather than a hidden iframe.
+- Store the non-rotating ORT in the existing cache and reuse it on every refresh, never replacing it.
+
+> [!NOTE]
+> Online access is **opt-in**. When `onlineAccess` is unset or `false`, the SDK behaves exactly as before.
+
+> [!NOTE]
+> This feature requires the `online_refresh_tokens` flag to be enabled for your tenant and `allow_online_access` to be enabled on the resource server (on by default).
+
+### `onlineAccess` vs. `useRefreshTokens`
+
+The two options request **different, mutually exclusive** refresh-token types, and you should set only one:
+
+| | `useRefreshTokens: true` | `onlineAccess: true` |
+| --- | --- | --- |
+| Scope injected | `offline_access` | `online_access` |
+| Token lifetime | Independent of the session (survives logout until revoked/expired) | Bound to the Auth0 session |
+| Rotation | Rotating (a new RT is issued on each refresh) | Non-rotating (same RT reused) |
+| DPoP | Optional | **Required** (`useDpop: true`) |
+
+Because `useRefreshTokens` injects `offline_access` — which conflicts with `online_access` — do **not** set both. In TypeScript, setting `useRefreshTokens` alongside `onlineAccess: true` is a compile-time error.
+
+### Configuration validation
+
+The SDK enforces the DPoP requirement at two layers:
+
+1. **Compile-time (TypeScript).** `Auth0ClientOptions` is a discriminated union on `onlineAccess`. When `onlineAccess` is the literal `true`, the compiler requires `useDpop: true` and forbids `useRefreshTokens`:
+
+   ```ts
+   // ❌ compile error: `useDpop` is required when `onlineAccess: true`
+   createAuth0Client({ domain, clientId, onlineAccess: true });
+
+   // ❌ compile error: `useRefreshTokens` conflicts with `onlineAccess`
+   createAuth0Client({ domain, clientId, onlineAccess: true, useDpop: true, useRefreshTokens: true });
+
+   // ✅ valid
+   createAuth0Client({ domain, clientId, onlineAccess: true, useDpop: true });
+   ```
+
+   > [!NOTE]
+   > The compile-time check only narrows when `onlineAccess` is a **literal** `true`. A dynamically-typed value (e.g. `onlineAccess: someBoolean`), an `as any` cast, or plain JavaScript all bypass it — which is why the runtime check below exists too.
+
+2. **Runtime (all consumers, including plain JS).** The `Auth0Client` constructor throws an `InvalidConfigurationError` when `onlineAccess: true` but `useDpop` is `false` or unset. The error's message tells you to set `useDpop: true`:
+
+   ```js
+   import { InvalidConfigurationError } from '@auth0/auth0-spa-js';
+
+   try {
+     const auth0 = await createAuth0Client({
+       domain: '<AUTH0_DOMAIN>',
+       clientId: '<AUTH0_CLIENT_ID>',
+       onlineAccess: true // missing useDpop: true
+     });
+   } catch (e) {
+     if (e instanceof InvalidConfigurationError) {
+       console.error(e.error_description); // includes the suggested fix
+       console.error(e.suggestion); // 'Set `useDpop: true` (DPoP is mandatory for online access).'
+     }
+   }
+   ```
+
+### Logging out
+
+Because an ORT is bound to the Auth0 session, the way to invalidate it is to end the session with `logout()`, which clears the local cache and redirects to `/v2/logout`:
+
+```js
+await auth0.logout({ logoutParams: { returnTo: window.location.origin } });
+```
+
+After logout, the ORT is no longer valid; a subsequent `getTokenSilently()` falls through to the [iframe fallback](#refresh-token-fallback) (if `useRefreshTokensFallback` is enabled) and ultimately to an interactive login.
+
+### Using with Multi-Resource Refresh Tokens (MRRT)
+
+Online access is compatible with [MRRT](#using-multi-resource-refresh-tokens): a single ORT can be exchanged for access tokens across the audiences allowed by your refresh-token policies. The ORT remains non-rotating throughout — the same token is reused for every cross-audience exchange.
+
+```js
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  onlineAccess: true,
+  useDpop: true,
+  useMrrt: true,
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>',
+    audience: 'https://api.example.com'
+  }
+});
 ```
 
 ## Data caching options

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -154,6 +154,9 @@ The `revokeRefreshToken()` method explicitly revokes a refresh token via the `/o
 
 This method only has an effect when `useRefreshTokens` is `true`. If refresh tokens are disabled it returns immediately without doing anything.
 
+> [!NOTE]
+> In [online access](#online-access-online-refresh-tokens) mode (`refreshTokenMode: RefreshTokenMode.Online`), `revokeRefreshToken()` only clears the cached refresh token locally — it does **not** revoke the Online Refresh Token at the authorization server. Online Refresh Tokens are non-rotating and session-bound, and the server does not support token-only revocation for them. To end an online session, call `logout()` instead, which terminates the session and thereby invalidates the ORT.
+
 ```js
 // Revoke the refresh token for the default audience
 await auth0.revokeRefreshToken();
@@ -316,6 +319,9 @@ await auth0.logout({ logoutParams: { returnTo: window.location.origin } });
 ```
 
 After logout, the ORT is no longer valid; a subsequent `getTokenSilently()` falls through to the [iframe fallback](#refresh-token-fallback) (if `useRefreshTokensFallback` is enabled) and ultimately to an interactive login.
+
+> [!NOTE]
+> In online mode, [`revokeRefreshToken()`](#revoking-refresh-tokens) only clears the cached token locally — it does **not** revoke the ORT at the authorization server. The server has no token-only revocation for non-rotating ORTs, so `logout()` is the only way to invalidate an ORT.
 
 ### Using with Multi-Resource Refresh Tokens (MRRT)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -257,13 +257,13 @@ The two options request **different, mutually exclusive** refresh-token types, a
 | Rotation | Rotating (a new RT is issued on each refresh) | Non-rotating (same RT reused) |
 | DPoP | Optional | **Required** (`useDpop: true`) |
 
-Because `useRefreshTokens` injects `offline_access` — which conflicts with `online_access` — do **not** set both. In TypeScript, setting `useRefreshTokens` alongside `onlineAccess: true` is a compile-time error.
+Because `useRefreshTokens` injects `offline_access` — which conflicts with `online_access` — do **not** set both. In TypeScript, calling `createAuth0Client` with `useRefreshTokens` alongside `onlineAccess: true` is a compile-time error.
 
 ### Configuration validation
 
 The SDK enforces the DPoP requirement at two layers:
 
-1. **Compile-time (TypeScript).** `Auth0ClientOptions` is a discriminated union on `onlineAccess`. When `onlineAccess` is the literal `true`, the compiler requires `useDpop: true` and forbids `useRefreshTokens`:
+1. **Compile-time (TypeScript).** When you call `createAuth0Client` with `onlineAccess` set to the literal `true`, the compiler requires `useDpop: true` and forbids `useRefreshTokens`:
 
    ```ts
    // ❌ compile error: `useDpop` is required when `onlineAccess: true`

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -211,7 +211,7 @@ await auth0.revokeRefreshToken();
 
 ## Online Access (Online Refresh Tokens)
 
-**Online Refresh Tokens (ORTs)** are a refresh token type bound to the lifetime of the user's Auth0 session. Unlike the rotating [offline refresh tokens](#refresh-tokens) described above, an ORT is:
+**Online Refresh Tokens (ORTs)** are a refresh token type bound to the lifetime of the user's Auth0 session. See the [Auth0 documentation on Online Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens/online-refresh-tokens/online-refresh-tokens) for the full conceptual overview. Unlike the rotating [offline refresh tokens](#refresh-tokens) described above, an ORT is:
 
 - **Session-bound** — it is valid only while the underlying Auth0 session is active. When the session ends (logout, idle/absolute session expiry, or an admin revoking the session), the ORT stops working.
 - **Non-rotating** — refreshing an access token with an ORT does **not** issue a new refresh token. The same ORT is reused for the life of the session.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -220,19 +220,22 @@ This makes ORTs a good fit for SPAs that want a refresh-token renewal path whose
 
 ### Enabling Online Access
 
-Set `onlineAccess: true` together with `useDpop: true`:
+Set `refreshTokenMode: 'online'` together with `useRefreshTokens: true` and `useDpop: true`:
 
 ```js
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
-  onlineAccess: true,
+  useRefreshTokens: true, // required — online access is a refresh-token grant
+  refreshTokenMode: 'online',
   useDpop: true, // required — DPoP is mandatory for online access
   authorizationParams: {
     redirect_uri: '<MY_CALLBACK_URL>'
   }
 });
 ```
+
+`refreshTokenMode` is a sub-option of `useRefreshTokens`. It defaults to `'offline'` (the rotating [offline refresh tokens](#refresh-tokens) described above); setting it to `'online'` opts into Online Refresh Tokens.
 
 Enabling this option causes the SDK to:
 
@@ -241,45 +244,46 @@ Enabling this option causes the SDK to:
 - Store the non-rotating ORT in the existing cache and reuse it on every refresh, never replacing it.
 
 > [!NOTE]
-> Online access is **opt-in**. When `onlineAccess` is unset or `false`, the SDK behaves exactly as before.
+> Online access is **opt-in**. When `refreshTokenMode` is unset or `'offline'`, the SDK behaves exactly as before.
 
 > [!NOTE]
 > This feature requires the `online_refresh_tokens` flag to be enabled for your tenant and `allow_online_access` to be enabled on the resource server (on by default).
 
-### `onlineAccess` vs. `useRefreshTokens`
+### `refreshTokenMode: 'offline'` vs. `'online'`
 
-The two options request **different, mutually exclusive** refresh-token types, and you should set only one:
+`refreshTokenMode` selects which refresh-token type the refresh-token grant uses. It is a sub-option of `useRefreshTokens` (which must be `true` for either mode) and defaults to `'offline'`:
 
-| | `useRefreshTokens: true` | `onlineAccess: true` |
+| | `refreshTokenMode: 'offline'` (default) | `refreshTokenMode: 'online'` |
 | --- | --- | --- |
+| Requires | `useRefreshTokens: true` | `useRefreshTokens: true` + `useDpop: true` |
 | Scope injected | `offline_access` | `online_access` |
 | Token lifetime | Independent of the session (survives logout until revoked/expired) | Bound to the Auth0 session |
 | Rotation | Rotating (a new RT is issued on each refresh) | Non-rotating (same RT reused) |
 | DPoP | Optional | **Required** (`useDpop: true`) |
 
-Because `useRefreshTokens` injects `offline_access` — which conflicts with `online_access` — do **not** set both. In TypeScript, calling `createAuth0Client` with `useRefreshTokens` alongside `onlineAccess: true` is a compile-time error.
+The two modes inject mutually exclusive scopes (`offline_access` vs. `online_access`), so the SDK emits only one — it never sends both. You select between them with `refreshTokenMode`, not by combining flags.
 
 ### Configuration validation
 
 The SDK enforces the DPoP requirement at two layers:
 
-1. **Compile-time (TypeScript).** When you call `createAuth0Client` with `onlineAccess` set to the literal `true`, the compiler requires `useDpop: true` and forbids `useRefreshTokens`:
+1. **Compile-time (TypeScript).** When you call `createAuth0Client` with `refreshTokenMode` set to the literal `'online'`, the compiler requires both `useRefreshTokens: true` and `useDpop: true`:
 
    ```ts
-   // ❌ compile error: `useDpop` is required when `onlineAccess: true`
-   createAuth0Client({ domain, clientId, onlineAccess: true });
+   // ❌ compile error: `useRefreshTokens: true` and `useDpop: true` are required when `refreshTokenMode: 'online'`
+   createAuth0Client({ domain, clientId, refreshTokenMode: 'online' });
 
-   // ❌ compile error: `useRefreshTokens` conflicts with `onlineAccess`
-   createAuth0Client({ domain, clientId, onlineAccess: true, useDpop: true, useRefreshTokens: true });
+   // ❌ compile error: `useDpop: true` is still required
+   createAuth0Client({ domain, clientId, refreshTokenMode: 'online', useRefreshTokens: true });
 
    // ✅ valid
-   createAuth0Client({ domain, clientId, onlineAccess: true, useDpop: true });
+   createAuth0Client({ domain, clientId, refreshTokenMode: 'online', useRefreshTokens: true, useDpop: true });
    ```
 
    > [!NOTE]
-   > The compile-time check only narrows when `onlineAccess` is a **literal** `true`. A dynamically-typed value (e.g. `onlineAccess: someBoolean`), an `as any` cast, or plain JavaScript all bypass it — which is why the runtime check below exists too.
+   > The compile-time check only narrows when `refreshTokenMode` is the **literal** `'online'`. A dynamically-typed value (e.g. `refreshTokenMode: someString`), an `as any` cast, or plain JavaScript all bypass it — which is why the runtime check below exists too.
 
-2. **Runtime (all consumers, including plain JS).** The `Auth0Client` constructor throws an `InvalidConfigurationError` when `onlineAccess: true` but `useDpop` is `false` or unset. The error's message tells you to set `useDpop: true`:
+2. **Runtime (all consumers, including plain JS).** The `Auth0Client` constructor throws an `InvalidConfigurationError` when `refreshTokenMode: 'online'` but `useRefreshTokens` or `useDpop` is not `true`. The error's `suggestion` tells you exactly which option to set:
 
    ```js
    import { InvalidConfigurationError } from '@auth0/auth0-spa-js';
@@ -288,7 +292,8 @@ The SDK enforces the DPoP requirement at two layers:
      const auth0 = await createAuth0Client({
        domain: '<AUTH0_DOMAIN>',
        clientId: '<AUTH0_CLIENT_ID>',
-       onlineAccess: true // missing useDpop: true
+       refreshTokenMode: 'online',
+       useRefreshTokens: true // missing useDpop: true
      });
    } catch (e) {
      if (e instanceof InvalidConfigurationError) {
@@ -316,7 +321,8 @@ Online access is compatible with [MRRT](#using-multi-resource-refresh-tokens): a
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
-  onlineAccess: true,
+  useRefreshTokens: true,
+  refreshTokenMode: 'online',
   useDpop: true,
   useMrrt: true,
   authorizationParams: {

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -220,14 +220,16 @@ This makes ORTs a good fit for SPAs that want a refresh-token renewal path whose
 
 ### Enabling Online Access
 
-Set `refreshTokenMode: 'online'` together with `useRefreshTokens: true` and `useDpop: true`:
+Set `refreshTokenMode` to `RefreshTokenMode.Online` together with `useRefreshTokens: true` and `useDpop: true`:
 
 ```js
+import { createAuth0Client, RefreshTokenMode } from '@auth0/auth0-spa-js';
+
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
   useRefreshTokens: true, // required — online access is a refresh-token grant
-  refreshTokenMode: 'online',
+  refreshTokenMode: RefreshTokenMode.Online,
   useDpop: true, // required — DPoP is mandatory for online access
   authorizationParams: {
     redirect_uri: '<MY_CALLBACK_URL>'
@@ -235,7 +237,7 @@ const auth0 = await createAuth0Client({
 });
 ```
 
-`refreshTokenMode` is a sub-option of `useRefreshTokens`. It defaults to `'offline'` (the rotating [offline refresh tokens](#refresh-tokens) described above); setting it to `'online'` opts into Online Refresh Tokens.
+`refreshTokenMode` is a sub-option of `useRefreshTokens`. It defaults to `RefreshTokenMode.Offline` (the rotating [offline refresh tokens](#refresh-tokens) described above); setting it to `RefreshTokenMode.Online` opts into Online Refresh Tokens. Always reference the exported `RefreshTokenMode` enum rather than hard-coding the mode.
 
 Enabling this option causes the SDK to:
 
@@ -244,16 +246,16 @@ Enabling this option causes the SDK to:
 - Store the non-rotating ORT in the existing cache and reuse it on every refresh, never replacing it.
 
 > [!NOTE]
-> Online access is **opt-in**. When `refreshTokenMode` is unset or `'offline'`, the SDK behaves exactly as before.
+> Online access is **opt-in**. When `refreshTokenMode` is unset or `RefreshTokenMode.Offline`, the SDK behaves exactly as before.
 
 > [!NOTE]
 > This feature requires the `online_refresh_tokens` flag to be enabled for your tenant and `allow_online_access` to be enabled on the resource server (on by default).
 
-### `refreshTokenMode: 'offline'` vs. `'online'`
+### `RefreshTokenMode.Offline` vs. `RefreshTokenMode.Online`
 
-`refreshTokenMode` selects which refresh-token type the refresh-token grant uses. It is a sub-option of `useRefreshTokens` (which must be `true` for either mode) and defaults to `'offline'`:
+`refreshTokenMode` selects which refresh-token type the refresh-token grant uses. It is a sub-option of `useRefreshTokens` (which must be `true` for either mode) and defaults to `RefreshTokenMode.Offline`:
 
-| | `refreshTokenMode: 'offline'` (default) | `refreshTokenMode: 'online'` |
+| | `RefreshTokenMode.Offline` (default) | `RefreshTokenMode.Online` |
 | --- | --- | --- |
 | Requires | `useRefreshTokens: true` | `useRefreshTokens: true` + `useDpop: true` |
 | Scope injected | `offline_access` | `online_access` |
@@ -267,32 +269,34 @@ The two modes inject mutually exclusive scopes (`offline_access` vs. `online_acc
 
 The SDK enforces the DPoP requirement at two layers:
 
-1. **Compile-time (TypeScript).** When you call `createAuth0Client` with `refreshTokenMode` set to the literal `'online'`, the compiler requires both `useRefreshTokens: true` and `useDpop: true`:
+1. **Compile-time (TypeScript).** When you call `createAuth0Client` with `refreshTokenMode: RefreshTokenMode.Online`, the compiler requires both `useRefreshTokens: true` and `useDpop: true`:
 
    ```ts
-   // ❌ compile error: `useRefreshTokens: true` and `useDpop: true` are required when `refreshTokenMode: 'online'`
-   createAuth0Client({ domain, clientId, refreshTokenMode: 'online' });
+   import { createAuth0Client, RefreshTokenMode } from '@auth0/auth0-spa-js';
+
+   // ❌ compile error: `useRefreshTokens: true` and `useDpop: true` are required for online mode
+   createAuth0Client({ domain, clientId, refreshTokenMode: RefreshTokenMode.Online });
 
    // ❌ compile error: `useDpop: true` is still required
-   createAuth0Client({ domain, clientId, refreshTokenMode: 'online', useRefreshTokens: true });
+   createAuth0Client({ domain, clientId, refreshTokenMode: RefreshTokenMode.Online, useRefreshTokens: true });
 
    // ✅ valid
-   createAuth0Client({ domain, clientId, refreshTokenMode: 'online', useRefreshTokens: true, useDpop: true });
+   createAuth0Client({ domain, clientId, refreshTokenMode: RefreshTokenMode.Online, useRefreshTokens: true, useDpop: true });
    ```
 
    > [!NOTE]
-   > The compile-time check only narrows when `refreshTokenMode` is the **literal** `'online'`. A dynamically-typed value (e.g. `refreshTokenMode: someString`), an `as any` cast, or plain JavaScript all bypass it — which is why the runtime check below exists too.
+   > The compile-time check narrows on the online mode value. A dynamically-typed value (e.g. a `refreshTokenMode` read from config at runtime), an `as any` cast, or plain JavaScript all bypass it — which is why the runtime check below exists too.
 
-2. **Runtime (all consumers, including plain JS).** The `Auth0Client` constructor throws an `InvalidConfigurationError` when `refreshTokenMode: 'online'` but `useRefreshTokens` or `useDpop` is not `true`. The error's `suggestion` tells you exactly which option to set:
+2. **Runtime (all consumers, including plain JS).** The `Auth0Client` constructor throws an `InvalidConfigurationError` when online mode is requested but `useRefreshTokens` or `useDpop` is not `true`. The error's `suggestion` tells you exactly which option to set:
 
    ```js
-   import { InvalidConfigurationError } from '@auth0/auth0-spa-js';
+   import { createAuth0Client, RefreshTokenMode, InvalidConfigurationError } from '@auth0/auth0-spa-js';
 
    try {
      const auth0 = await createAuth0Client({
        domain: '<AUTH0_DOMAIN>',
        clientId: '<AUTH0_CLIENT_ID>',
-       refreshTokenMode: 'online',
+       refreshTokenMode: RefreshTokenMode.Online,
        useRefreshTokens: true // missing useDpop: true
      });
    } catch (e) {
@@ -318,11 +322,13 @@ After logout, the ORT is no longer valid; a subsequent `getTokenSilently()` fall
 Online access is compatible with [MRRT](#using-multi-resource-refresh-tokens): a single ORT can be exchanged for access tokens across the audiences allowed by your refresh-token policies. The ORT remains non-rotating throughout — the same token is reused for every cross-audience exchange.
 
 ```js
+import { createAuth0Client, RefreshTokenMode } from '@auth0/auth0-spa-js';
+
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
   useRefreshTokens: true,
-  refreshTokenMode: 'online',
+  refreshTokenMode: RefreshTokenMode.Online,
   useDpop: true,
   useMrrt: true,
   authorizationParams: {

--- a/README.md
+++ b/README.md
@@ -116,14 +116,16 @@ window.addEventListener('load', async () => {
 
 ### Online Access
 
-Set `refreshTokenMode: 'online'` (together with the required `useRefreshTokens: true` and `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
+Set `refreshTokenMode` to `RefreshTokenMode.Online` (together with the required `useRefreshTokens: true` and `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
 
 ```js
+import { createAuth0Client, RefreshTokenMode } from '@auth0/auth0-spa-js';
+
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
   useRefreshTokens: true,
-  refreshTokenMode: 'online',
+  refreshTokenMode: RefreshTokenMode.Online,
   useDpop: true,
   authorizationParams: {
     redirect_uri: '<MY_CALLBACK_URL>'
@@ -131,7 +133,7 @@ const auth0 = await createAuth0Client({
 });
 ```
 
-`refreshTokenMode` is a sub-option of `useRefreshTokens`: it defaults to `'offline'` (the rotating refresh tokens described above) and must be set to `'online'` for Online Refresh Tokens. Online mode requires both `useRefreshTokens: true` and `useDpop: true`. See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.
+`refreshTokenMode` is a sub-option of `useRefreshTokens`: it defaults to `RefreshTokenMode.Offline` (the rotating refresh tokens described above) and must be set to `RefreshTokenMode.Online` for Online Refresh Tokens. Online mode requires both `useRefreshTokens: true` and `useDpop: true`. See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.
 
 ### More Examples
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,14 @@ window.addEventListener('load', async () => {
 
 ### Online Access
 
-Pass `onlineAccess: true` (together with the required `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
+Set `refreshTokenMode: 'online'` (together with the required `useRefreshTokens: true` and `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
 
 ```js
 const auth0 = await createAuth0Client({
   domain: '<AUTH0_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
-  onlineAccess: true,
+  useRefreshTokens: true,
+  refreshTokenMode: 'online',
   useDpop: true,
   authorizationParams: {
     redirect_uri: '<MY_CALLBACK_URL>'
@@ -130,7 +131,7 @@ const auth0 = await createAuth0Client({
 });
 ```
 
-DPoP is mandatory and must be set explicitly; do not set `useRefreshTokens` (it requests `offline_access`, which conflicts with online access). See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.
+`refreshTokenMode` is a sub-option of `useRefreshTokens`: it defaults to `'offline'` (the rotating refresh tokens described above) and must be set to `'online'` for Online Refresh Tokens. Online mode requires both `useRefreshTokens: true` and `useDpop: true`. See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.
 
 ### More Examples
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,27 @@ window.addEventListener('load', async () => {
 });
 ```
 
+### Online Access
+
+Pass `onlineAccess: true` (together with the required `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
+
+```js
+const auth0 = await createAuth0Client({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  onlineAccess: true,
+  useDpop: true,
+  authorizationParams: {
+    redirect_uri: '<MY_CALLBACK_URL>'
+  }
+});
+```
+
+DPoP is mandatory and must be set explicitly; do not set `useRefreshTokens` (it requests `offline_access`, which conflicts with online access). See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md#online-access-online-refresh-tokens) in EXAMPLES.md for the full guide.
+
 ### More Examples
 
-For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.
+For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, online access, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.
 
 ## API Reference
 

--- a/__tests__/Auth0Client.utils.test.ts
+++ b/__tests__/Auth0Client.utils.test.ts
@@ -1,29 +1,43 @@
 import { getMissingScopes } from '../src/Auth0Client.utils';
 
 /**
- * `online_access` is stripped from the requested scopes in the MRRT flow only: the server
- * does not issue a new ORT for an MRRT cross-audience exchange, so the same (non-rotating)
- * ORT is reused and `online_access` is never echoed back in the response scope. Comparing
- * the injected `online_access` against the response would otherwise flag it as a spurious
- * missing scope. `offline_access` is intentionally NOT excluded — the server does echo it
- * back, so a genuinely missing `offline_access` should still be reported.
+ * `online_access` is stripped from the requested scopes only when `onlineAccess` is true:
+ * in online mode the server reuses the same (non-rotating) ORT for an MRRT cross-audience
+ * exchange and never echoes `online_access` back in the response scope, so comparing it
+ * would flag a spurious missing scope. Outside online mode the strip is not applied, so a
+ * genuinely missing `online_access` is still reported. `offline_access` is never excluded —
+ * the server echoes it back, so a genuinely missing `offline_access` should still be reported.
  */
-describe('getMissingScopes ignores online_access', () => {
-  it('does not report online_access as missing', () => {
-    expect(
-      getMissingScopes('openid online_access fs:read', 'openid fs:read')
-    ).toBe('');
+describe('getMissingScopes', () => {
+  describe('in online mode', () => {
+    it('does not report online_access as missing', () => {
+      expect(
+        getMissingScopes('openid online_access fs:read', 'openid fs:read', true)
+      ).toBe('');
+    });
+
+    it('still reports genuinely missing resource scopes', () => {
+      expect(
+        getMissingScopes(
+          'openid online_access fs:read fs:write',
+          'openid fs:read',
+          true
+        )
+      ).toBe('fs:write');
+    });
   });
 
-  it('still reports genuinely missing resource scopes', () => {
-    expect(
-      getMissingScopes('openid online_access fs:read fs:write', 'openid fs:read')
-    ).toBe('fs:write');
-  });
+  describe('outside online mode', () => {
+    it('reports a genuinely missing online_access', () => {
+      expect(
+        getMissingScopes('openid online_access fs:read', 'openid fs:read')
+      ).toBe('online_access');
+    });
 
-  it('still reports a genuinely missing offline_access', () => {
-    expect(
-      getMissingScopes('openid offline_access fs:read', 'openid fs:read')
-    ).toBe('offline_access');
+    it('still reports a genuinely missing offline_access', () => {
+      expect(
+        getMissingScopes('openid offline_access fs:read', 'openid fs:read')
+      ).toBe('offline_access');
+    });
   });
 });

--- a/__tests__/Auth0Client.utils.test.ts
+++ b/__tests__/Auth0Client.utils.test.ts
@@ -1,0 +1,29 @@
+import { getMissingScopes } from '../src/Auth0Client.utils';
+
+/**
+ * `online_access` is stripped from the requested scopes in the MRRT flow only: the server
+ * does not issue a new ORT for an MRRT cross-audience exchange, so the same (non-rotating)
+ * ORT is reused and `online_access` is never echoed back in the response scope. Comparing
+ * the injected `online_access` against the response would otherwise flag it as a spurious
+ * missing scope. `offline_access` is intentionally NOT excluded — the server does echo it
+ * back, so a genuinely missing `offline_access` should still be reported.
+ */
+describe('getMissingScopes ignores online_access', () => {
+  it('does not report online_access as missing', () => {
+    expect(
+      getMissingScopes('openid online_access fs:read', 'openid fs:read')
+    ).toBe('');
+  });
+
+  it('still reports genuinely missing resource scopes', () => {
+    expect(
+      getMissingScopes('openid online_access fs:read fs:write', 'openid fs:read')
+    ).toBe('fs:write');
+  });
+
+  it('still reports a genuinely missing offline_access', () => {
+    expect(
+      getMissingScopes('openid offline_access fs:read', 'openid fs:read')
+    ).toBe('offline_access');
+  });
+});

--- a/__tests__/Auth0Client/dpop.test.ts
+++ b/__tests__/Auth0Client/dpop.test.ts
@@ -4,7 +4,7 @@
  * @jest-environment node
  */
 
-import { Auth0Client, Auth0ClientOptionsBase } from '../../src';
+import { Auth0Client, Auth0ClientOptions } from '../../src';
 import {
   TEST_CLIENT_ID,
   TEST_DOMAIN,
@@ -16,7 +16,7 @@ import { beforeEach, describe, expect } from '@jest/globals';
 import { Dpop } from '../../src/dpop/dpop';
 
 function newTestAuth0Client(
-  extraOpts?: Partial<Auth0ClientOptionsBase>
+  extraOpts?: Partial<Auth0ClientOptions>
 ): Auth0Client {
   return new Auth0Client({
     ...extraOpts,

--- a/__tests__/Auth0Client/dpop.test.ts
+++ b/__tests__/Auth0Client/dpop.test.ts
@@ -4,7 +4,7 @@
  * @jest-environment node
  */
 
-import { Auth0Client, Auth0ClientOptions } from '../../src';
+import { Auth0Client, Auth0ClientOptionsBase } from '../../src';
 import {
   TEST_CLIENT_ID,
   TEST_DOMAIN,
@@ -16,7 +16,7 @@ import { beforeEach, describe, expect } from '@jest/globals';
 import { Dpop } from '../../src/dpop/dpop';
 
 function newTestAuth0Client(
-  extraOpts?: Partial<Auth0ClientOptions>
+  extraOpts?: Partial<Auth0ClientOptionsBase>
 ): Auth0Client {
   return new Auth0Client({
     ...extraOpts,

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -257,6 +257,36 @@ describe('Auth0Client', () => {
       ).resolves.toBeTruthy();
     });
 
+    it('preserves the cached ORT across force-refreshes in the worker (memory) path', async () => {
+      // Online mode + the default memory cache routes refreshes through the web
+      // worker, which holds its own RT store. The worker must not evict the
+      // non-rotating ORT when the response carries no refresh_token, otherwise the
+      // next force-refresh fails with MissingRefreshTokenError.
+      const auth0 = setup({
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
+        useDpop: true
+        // no cacheLocation → memory → web worker
+      } as any);
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      await getTokenSilently(
+        auth0,
+        { cacheMode: 'off' },
+        { token: { response: { refresh_token: undefined } } }
+      );
+
+      await expect(
+        getTokenSilently(
+          auth0,
+          { cacheMode: 'off' },
+          { token: { response: { refresh_token: undefined } } }
+        )
+      ).resolves.toBeTruthy();
+    });
+
     it('rotates the stored refresh token when using rotating (offline) refresh tokens', async () => {
       const auth0 = setup({
         useRefreshTokens: true,

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -84,43 +84,64 @@ describe('Auth0Client', () => {
   });
 
   describe('online access — configuration validation', () => {
-    it('throws InvalidConfigurationError when onlineAccess is true but useDpop is unset', () => {
+    it('throws InvalidConfigurationError when online but useRefreshTokens is unset', () => {
       expect(() =>
-        setup({ onlineAccess: true } as any)
+        setup({ refreshTokenMode: 'online', useDpop: true } as any)
       ).toThrow(InvalidConfigurationError);
     });
 
-    it('throws InvalidConfigurationError when onlineAccess is true but useDpop is false', () => {
+    it('error message tells the customer to pass useRefreshTokens: true', () => {
       expect(() =>
-        setup({ onlineAccess: true, useDpop: false } as any)
+        setup({ refreshTokenMode: 'online', useDpop: true } as any)
+      ).toThrow(/useRefreshTokens: true/);
+    });
+
+    it('throws InvalidConfigurationError when online but useDpop is unset', () => {
+      expect(() =>
+        setup({ refreshTokenMode: 'online', useRefreshTokens: true } as any)
+      ).toThrow(InvalidConfigurationError);
+    });
+
+    it('throws InvalidConfigurationError when online but useDpop is false', () => {
+      expect(() =>
+        setup({
+          refreshTokenMode: 'online',
+          useRefreshTokens: true,
+          useDpop: false
+        } as any)
       ).toThrow(InvalidConfigurationError);
     });
 
     it('error message tells the customer to pass useDpop: true', () => {
-      expect(() => setup({ onlineAccess: true } as any)).toThrow(
-        /useDpop: true/
-      );
+      expect(() =>
+        setup({ refreshTokenMode: 'online', useRefreshTokens: true } as any)
+      ).toThrow(/useDpop: true/);
     });
 
-    it('does not throw when onlineAccess is true and useDpop is true', () => {
+    it('does not throw when online with useRefreshTokens: true and useDpop: true', () => {
       expect(() =>
-        setup({ onlineAccess: true, useDpop: true } as any)
+        setup({
+          refreshTokenMode: 'online',
+          useRefreshTokens: true,
+          useDpop: true
+        } as any)
       ).not.toThrow();
     });
 
-    it('leaves behavior unchanged when onlineAccess is unset (no DPoP required)', () => {
+    it('leaves behavior unchanged when refreshTokenMode is unset (no DPoP required)', () => {
       expect(() => setup()).not.toThrow();
     });
 
-    it('leaves behavior unchanged when onlineAccess is false (no DPoP required)', () => {
-      expect(() => setup({ onlineAccess: false } as any)).not.toThrow();
+    it('leaves behavior unchanged when refreshTokenMode is offline (no DPoP required)', () => {
+      expect(() => setup({ refreshTokenMode: 'offline' } as any)).not.toThrow();
     });
   });
 
   describe('online access — scope injection', () => {
     it('injects online_access (and not offline_access) when online', () => {
       const auth0 = setup({
-        onlineAccess: true,
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
         useDpop: true,
         authorizationParams: {
           scope: 'profile email test-scope'
@@ -155,7 +176,8 @@ describe('Auth0Client', () => {
   describe('online access — refresh-token routing', () => {
     it('routes silent renewal through the refresh_token grant when online', async () => {
       const auth0 = setup({
-        onlineAccess: true,
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
         useDpop: true,
         cacheLocation: 'localstorage'
       } as any);
@@ -179,7 +201,8 @@ describe('Auth0Client', () => {
   describe('online access — non-rotation', () => {
     it('does NOT rotate the stored refresh token when online', async () => {
       const auth0 = setup({
-        onlineAccess: true,
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
         useDpop: true,
         cacheLocation: 'localstorage'
       } as any);

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -228,6 +228,35 @@ describe('Auth0Client', () => {
       expect(updateEntrySpy).not.toHaveBeenCalled();
     });
 
+    it('preserves the cached ORT across force-refreshes when the response carries no refresh_token', async () => {
+      const auth0 = setup({
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
+        useDpop: true,
+        cacheLocation: 'localstorage'
+      } as any);
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      // Online refresh tokens are non-rotating: the server exchanges the ORT but
+      // returns no refresh_token. The cached ORT must survive so the next
+      // force-refresh does not fail with MissingRefreshTokenError.
+      await getTokenSilently(
+        auth0,
+        { cacheMode: 'off' },
+        { token: { response: { refresh_token: undefined } } }
+      );
+
+      await expect(
+        getTokenSilently(
+          auth0,
+          { cacheMode: 'off' },
+          { token: { response: { refresh_token: undefined } } }
+        )
+      ).resolves.toBeTruthy();
+    });
+
     it('rotates the stored refresh token when using rotating (offline) refresh tokens', async () => {
       const auth0 = setup({
         useRefreshTokens: true,

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -1,0 +1,238 @@
+import { expect } from '@jest/globals';
+import { MessageChannel } from 'worker_threads';
+import * as utils from '../../src/utils';
+import * as scope from '../../src/scope';
+import * as DpopModule from '../../src/dpop/dpop';
+import { verify } from '../../src/jwt';
+
+import {
+  getTokenSilentlyFn,
+  loginWithRedirectFn,
+  setupFn
+} from './helpers';
+
+import {
+  TEST_CODE_CHALLENGE,
+  TEST_REFRESH_TOKEN
+} from '../constants';
+import { DEFAULT_AUDIENCE } from '../../src/constants';
+import { InvalidConfigurationError } from '../../src/errors';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue(TEST_CODE_CHALLENGE);
+
+const setup = setupFn(mockVerify);
+const loginWithRedirect = loginWithRedirectFn(mockWindow, mockFetch);
+const getTokenSilently = getTokenSilentlyFn(mockWindow, mockFetch);
+
+describe('Auth0Client', () => {
+  const oldWindowLocation = window.location;
+
+  beforeEach(() => {
+    delete window.location;
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: {
+          configurable: true,
+          value: jest.fn()
+        }
+      }
+    ) as Location;
+
+    mockWindow.open = jest.fn();
+    mockWindow.addEventListener = jest.fn();
+    mockWindow.removeEventListener = jest.fn();
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+    jest.spyOn(scope, 'getUniqueScopes');
+    jest.spyOn(DpopModule, 'Dpop').mockImplementation(
+      () =>
+        ({
+          calculateThumbprint: jest.fn().mockResolvedValue('test-thumbprint'),
+          generateProof: jest.fn().mockResolvedValue('test-dpop-proof'),
+          getNonce: jest.fn().mockResolvedValue(undefined),
+          setNonce: jest.fn().mockResolvedValue(undefined),
+          clear: jest.fn().mockResolvedValue(undefined)
+        } as any)
+    );
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+    window.location = oldWindowLocation;
+  });
+
+  describe('online access — configuration validation', () => {
+    it('throws InvalidConfigurationError when onlineAccess is true but useDpop is unset', () => {
+      expect(() =>
+        setup({ onlineAccess: true } as any)
+      ).toThrow(InvalidConfigurationError);
+    });
+
+    it('throws InvalidConfigurationError when onlineAccess is true but useDpop is false', () => {
+      expect(() =>
+        setup({ onlineAccess: true, useDpop: false } as any)
+      ).toThrow(InvalidConfigurationError);
+    });
+
+    it('error message tells the customer to pass useDpop: true', () => {
+      expect(() => setup({ onlineAccess: true } as any)).toThrow(
+        /useDpop: true/
+      );
+    });
+
+    it('does not throw when onlineAccess is true and useDpop is true', () => {
+      expect(() =>
+        setup({ onlineAccess: true, useDpop: true } as any)
+      ).not.toThrow();
+    });
+
+    it('leaves behavior unchanged when onlineAccess is unset (no DPoP required)', () => {
+      expect(() => setup()).not.toThrow();
+    });
+
+    it('leaves behavior unchanged when onlineAccess is false (no DPoP required)', () => {
+      expect(() => setup({ onlineAccess: false } as any)).not.toThrow();
+    });
+  });
+
+  describe('online access — scope injection', () => {
+    it('injects online_access (and not offline_access) when online', () => {
+      const auth0 = setup({
+        onlineAccess: true,
+        useDpop: true,
+        authorizationParams: {
+          scope: 'profile email test-scope'
+        }
+      } as any);
+
+      expect((<any>auth0).scope).toMatchObject({
+        [DEFAULT_AUDIENCE]: 'openid profile email test-scope online_access'
+      });
+      expect((<any>auth0).scope[DEFAULT_AUDIENCE]).not.toContain(
+        'offline_access'
+      );
+    });
+
+    it('injects offline_access (and not online_access) when using refresh tokens', () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        authorizationParams: {
+          scope: 'profile email test-scope'
+        }
+      });
+
+      expect((<any>auth0).scope).toMatchObject({
+        [DEFAULT_AUDIENCE]: 'openid profile email test-scope offline_access'
+      });
+      expect((<any>auth0).scope[DEFAULT_AUDIENCE]).not.toContain(
+        'online_access'
+      );
+    });
+  });
+
+  describe('online access — refresh-token routing', () => {
+    it('routes silent renewal through the refresh_token grant when online', async () => {
+      const auth0 = setup({
+        onlineAccess: true,
+        useDpop: true,
+        cacheLocation: 'localstorage'
+      } as any);
+
+      const refreshSpy = jest.spyOn(
+        auth0 as any,
+        '_getTokenUsingRefreshToken'
+      );
+      const iframeSpy = jest.spyOn(auth0 as any, '_getTokenFromIFrame');
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      await getTokenSilently(auth0, { cacheMode: 'off' });
+
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(iframeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('online access — non-rotation', () => {
+    it('does NOT rotate the stored refresh token when online', async () => {
+      const auth0 = setup({
+        onlineAccess: true,
+        useDpop: true,
+        cacheLocation: 'localstorage'
+      } as any);
+
+      const updateEntrySpy = jest.spyOn(
+        auth0['cacheManager'],
+        'updateEntry'
+      );
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      await getTokenSilently(
+        auth0,
+        { cacheMode: 'off' },
+        {
+          token: {
+            response: { refresh_token: 'new_refresh_token' }
+          }
+        }
+      );
+
+      expect(updateEntrySpy).not.toHaveBeenCalled();
+    });
+
+    it('rotates the stored refresh token when using rotating (offline) refresh tokens', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'localstorage'
+      });
+
+      const updateEntrySpy = jest.spyOn(
+        auth0['cacheManager'],
+        'updateEntry'
+      );
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      await getTokenSilently(
+        auth0,
+        { cacheMode: 'off' },
+        {
+          token: {
+            response: { refresh_token: 'new_refresh_token' }
+          }
+        }
+      );
+
+      expect(updateEntrySpy).toHaveBeenCalledWith(
+        TEST_REFRESH_TOKEN,
+        'new_refresh_token'
+      );
+    });
+  });
+});

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -258,4 +258,71 @@ describe('Auth0Client', () => {
       );
     });
   });
+
+  describe('online access — MRRT cross-audience scope check', () => {
+    // A cross-audience MRRT refresh injects online_access into the request, but the server
+    // strips it during the exchange and never echoes it back. The missing-scope guard must
+    // ignore it, otherwise a successful refresh throws a spurious MissingScopesError.
+    it('does not flag injected online_access as missing after an MRRT refresh', async () => {
+      const auth0 = setup({
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
+        useDpop: true,
+        useMrrt: true,
+        cacheLocation: 'localstorage'
+      } as any);
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      const result = await getTokenSilently(
+        auth0,
+        {
+          authorizationParams: {
+            audience: 'https://resource-server/',
+            scope: 'read:foo'
+          },
+          cacheMode: 'off',
+          detailedResponse: true
+        },
+        {
+          // Server echoes resource scopes but never online_access.
+          token: { response: { scope: 'openid profile email read:foo' } }
+        }
+      );
+
+      expect((result as any).access_token).toBeTruthy();
+    });
+
+    // The guard must still fire for genuinely missing resource scopes.
+    it('still throws MissingScopesError when a real resource scope is not returned', async () => {
+      const auth0 = setup({
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
+        useDpop: true,
+        useMrrt: true,
+        cacheLocation: 'localstorage'
+      } as any);
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      await expect(
+        getTokenSilently(
+          auth0,
+          {
+            authorizationParams: {
+              audience: 'https://resource-server/',
+              scope: 'read:foo write:foo'
+            },
+            cacheMode: 'off',
+            detailedResponse: true
+          },
+          {
+            token: { response: { scope: 'openid profile email read:foo' } }
+          }
+        )
+      ).rejects.toThrow(/write:foo/);
+    });
+  });
 });

--- a/__tests__/Auth0Client/onlineAccess.types.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.types.test.ts
@@ -1,74 +1,60 @@
 /**
- * Compile-time enforcement of the `onlineAccess` discriminated union.
+ * Compile-time enforcement of the online-access option, via `createAuth0Client`
+ * overloads (the interface itself stays a plain, non-breaking optional boolean).
  *
  * These assertions are validated by ts-jest's type checker at test time: each
- * `@ts-expect-error` MUST sit over a genuine type error, or TypeScript reports
- * an unused-directive error and the suite fails. The runtime safety net (the
+ * `@ts-expect-error` MUST sit over a genuine type error, or TypeScript reports an
+ * unused-directive error and the suite fails. The runtime safety net (the
  * `InvalidConfigurationError` throw) is covered separately in onlineAccess.test.ts.
  *
- * The union only narrows on a literal `onlineAccess: true`, so these cases are
- * the common literal mistakes a TS user would make. The whole object literal
- * fails assignment as a unit, so each directive sits on the declaration line.
+ * The overloads only narrow on a literal `onlineAccess: true`, so these cover the
+ * common literal mistakes a TS user would make at the call site.
  */
-import type { Auth0ClientOptions } from '../../src';
+import { createAuth0Client } from '../../src';
 
 const base = {
   domain: 'example.auth0.com',
   clientId: 'client_id'
 };
 
-describe('Auth0ClientOptions — online access type enforcement', () => {
+describe('createAuth0Client — online access type enforcement', () => {
   it('requires useDpop: true and forbids useRefreshTokens when onlineAccess is true', () => {
-    // onlineAccess: true with useDpop: true is the valid combo.
-    const valid: Auth0ClientOptions = {
-      ...base,
-      onlineAccess: true,
-      useDpop: true
-    };
-    expect(valid.onlineAccess).toBe(true);
+    // Compile-only — never invoked. Wrapped in a never-true guard so the calls
+    // are type-checked but do not execute (no DOM/crypto needed).
+    const _typecheck = async () => {
+      // Valid combo.
+      await createAuth0Client({ ...base, onlineAccess: true, useDpop: true });
 
-    // Missing useDpop → compile error.
-    // @ts-expect-error onlineAccess: true requires useDpop: true
-    const missingDpop: Auth0ClientOptions = {
-      ...base,
-      onlineAccess: true
-    };
-    void missingDpop;
+      // Missing useDpop → compile error.
+      // @ts-expect-error onlineAccess: true requires useDpop: true
+      await createAuth0Client({ ...base, onlineAccess: true });
 
-    // useDpop: false → compile error.
-    // @ts-expect-error onlineAccess: true requires useDpop: true (not false)
-    const dpopFalse: Auth0ClientOptions = {
-      ...base,
-      onlineAccess: true,
-      useDpop: false
-    };
-    void dpopFalse;
+      // useDpop: false → compile error.
+      // @ts-expect-error onlineAccess: true requires useDpop: true (not false)
+      await createAuth0Client({ ...base, onlineAccess: true, useDpop: false });
 
-    // useRefreshTokens alongside online → compile error (it injects offline_access).
-    // @ts-expect-error useRefreshTokens conflicts with onlineAccess
-    const withRefreshTokens: Auth0ClientOptions = {
-      ...base,
-      onlineAccess: true,
-      useDpop: true,
-      useRefreshTokens: true
+      // useRefreshTokens alongside online → compile error (it injects offline_access).
+      // @ts-expect-error useRefreshTokens conflicts with onlineAccess
+      await createAuth0Client({
+        ...base,
+        onlineAccess: true,
+        useDpop: true,
+        useRefreshTokens: true
+      });
     };
-    void withRefreshTokens;
+    void _typecheck;
+
+    expect(true).toBe(true);
   });
 
-  it('leaves the legacy (non-online) arm unconstrained', () => {
-    // Legacy combos (refresh tokens without DPoP, DPoP without online, etc.)
-    // remain valid — the union must not constrain the non-online arm.
-    const legacy: Auth0ClientOptions = {
-      ...base,
-      useRefreshTokens: true,
-      useDpop: false
+  it('leaves the legacy (non-online) call unconstrained', () => {
+    const _typecheck = async () => {
+      // Legacy combos remain valid — the overloads must not constrain them.
+      await createAuth0Client({ ...base, useRefreshTokens: true, useDpop: false });
+      await createAuth0Client({ ...base, onlineAccess: false, useRefreshTokens: true });
     };
-    const onlineFalse: Auth0ClientOptions = {
-      ...base,
-      onlineAccess: false,
-      useRefreshTokens: true
-    };
-    expect(legacy.useRefreshTokens).toBe(true);
-    expect(onlineFalse.onlineAccess).toBe(false);
+    void _typecheck;
+
+    expect(true).toBe(true);
   });
 });

--- a/__tests__/Auth0Client/onlineAccess.types.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.types.test.ts
@@ -1,14 +1,14 @@
 /**
  * Compile-time enforcement of the online-access option, via `createAuth0Client`
- * overloads (the interface itself stays a plain, non-breaking optional boolean).
+ * overloads (the interface itself stays plain, non-breaking optional fields).
  *
  * These assertions are validated by ts-jest's type checker at test time: each
  * `@ts-expect-error` MUST sit over a genuine type error, or TypeScript reports an
  * unused-directive error and the suite fails. The runtime safety net (the
  * `InvalidConfigurationError` throw) is covered separately in onlineAccess.test.ts.
  *
- * The overloads only narrow on a literal `onlineAccess: true`, so these cover the
- * common literal mistakes a TS user would make at the call site.
+ * The overloads only narrow on a literal `refreshTokenMode: 'online'`, so these cover
+ * the common literal mistakes a TS user would make at the call site.
  */
 import { createAuth0Client } from '../../src';
 
@@ -18,28 +18,37 @@ const base = {
 };
 
 describe('createAuth0Client — online access type enforcement', () => {
-  it('requires useDpop: true and forbids useRefreshTokens when onlineAccess is true', () => {
+  it('requires useRefreshTokens: true and useDpop: true when refreshTokenMode is online', () => {
     // Compile-only — never invoked. Wrapped in a never-true guard so the calls
     // are type-checked but do not execute (no DOM/crypto needed).
     const _typecheck = async () => {
       // Valid combo.
-      await createAuth0Client({ ...base, onlineAccess: true, useDpop: true });
-
-      // Missing useDpop → compile error.
-      // @ts-expect-error onlineAccess: true requires useDpop: true
-      await createAuth0Client({ ...base, onlineAccess: true });
-
-      // useDpop: false → compile error.
-      // @ts-expect-error onlineAccess: true requires useDpop: true (not false)
-      await createAuth0Client({ ...base, onlineAccess: true, useDpop: false });
-
-      // useRefreshTokens alongside online → compile error (it injects offline_access).
-      // @ts-expect-error useRefreshTokens conflicts with onlineAccess
       await createAuth0Client({
         ...base,
-        onlineAccess: true,
-        useDpop: true,
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
+        useDpop: true
+      });
+
+      // Missing useRefreshTokens → compile error.
+      // @ts-expect-error refreshTokenMode: 'online' requires useRefreshTokens: true
+      await createAuth0Client({ ...base, refreshTokenMode: 'online', useDpop: true });
+
+      // Missing useDpop → compile error.
+      // @ts-expect-error refreshTokenMode: 'online' requires useDpop: true
+      await createAuth0Client({
+        ...base,
+        refreshTokenMode: 'online',
         useRefreshTokens: true
+      });
+
+      // useDpop: false → compile error.
+      // @ts-expect-error refreshTokenMode: 'online' requires useDpop: true (not false)
+      await createAuth0Client({
+        ...base,
+        refreshTokenMode: 'online',
+        useRefreshTokens: true,
+        useDpop: false
       });
     };
     void _typecheck;
@@ -47,11 +56,11 @@ describe('createAuth0Client — online access type enforcement', () => {
     expect(true).toBe(true);
   });
 
-  it('leaves the legacy (non-online) call unconstrained', () => {
+  it('leaves the legacy (offline / non-online) call unconstrained', () => {
     const _typecheck = async () => {
       // Legacy combos remain valid — the overloads must not constrain them.
       await createAuth0Client({ ...base, useRefreshTokens: true, useDpop: false });
-      await createAuth0Client({ ...base, onlineAccess: false, useRefreshTokens: true });
+      await createAuth0Client({ ...base, refreshTokenMode: 'offline', useRefreshTokens: true });
     };
     void _typecheck;
 

--- a/__tests__/Auth0Client/onlineAccess.types.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.types.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Compile-time enforcement of the `onlineAccess` discriminated union.
+ *
+ * These assertions are validated by ts-jest's type checker at test time: each
+ * `@ts-expect-error` MUST sit over a genuine type error, or TypeScript reports
+ * an unused-directive error and the suite fails. The runtime safety net (the
+ * `InvalidConfigurationError` throw) is covered separately in onlineAccess.test.ts.
+ *
+ * The union only narrows on a literal `onlineAccess: true`, so these cases are
+ * the common literal mistakes a TS user would make. The whole object literal
+ * fails assignment as a unit, so each directive sits on the declaration line.
+ */
+import type { Auth0ClientOptions } from '../../src';
+
+const base = {
+  domain: 'example.auth0.com',
+  clientId: 'client_id'
+};
+
+describe('Auth0ClientOptions — online access type enforcement', () => {
+  it('requires useDpop: true and forbids useRefreshTokens when onlineAccess is true', () => {
+    // onlineAccess: true with useDpop: true is the valid combo.
+    const valid: Auth0ClientOptions = {
+      ...base,
+      onlineAccess: true,
+      useDpop: true
+    };
+    expect(valid.onlineAccess).toBe(true);
+
+    // Missing useDpop → compile error.
+    // @ts-expect-error onlineAccess: true requires useDpop: true
+    const missingDpop: Auth0ClientOptions = {
+      ...base,
+      onlineAccess: true
+    };
+    void missingDpop;
+
+    // useDpop: false → compile error.
+    // @ts-expect-error onlineAccess: true requires useDpop: true (not false)
+    const dpopFalse: Auth0ClientOptions = {
+      ...base,
+      onlineAccess: true,
+      useDpop: false
+    };
+    void dpopFalse;
+
+    // useRefreshTokens alongside online → compile error (it injects offline_access).
+    // @ts-expect-error useRefreshTokens conflicts with onlineAccess
+    const withRefreshTokens: Auth0ClientOptions = {
+      ...base,
+      onlineAccess: true,
+      useDpop: true,
+      useRefreshTokens: true
+    };
+    void withRefreshTokens;
+  });
+
+  it('leaves the legacy (non-online) arm unconstrained', () => {
+    // Legacy combos (refresh tokens without DPoP, DPoP without online, etc.)
+    // remain valid — the union must not constrain the non-online arm.
+    const legacy: Auth0ClientOptions = {
+      ...base,
+      useRefreshTokens: true,
+      useDpop: false
+    };
+    const onlineFalse: Auth0ClientOptions = {
+      ...base,
+      onlineAccess: false,
+      useRefreshTokens: true
+    };
+    expect(legacy.useRefreshTokens).toBe(true);
+    expect(onlineFalse.onlineAccess).toBe(false);
+  });
+});

--- a/__tests__/Auth0Client/onlineAccess.types.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.types.test.ts
@@ -1,16 +1,9 @@
 /**
- * Compile-time enforcement of the online-access option, via `createAuth0Client`
- * overloads (the interface itself stays plain, non-breaking optional fields).
- *
- * These assertions are validated by ts-jest's type checker at test time: each
- * `@ts-expect-error` MUST sit over a genuine type error, or TypeScript reports an
- * unused-directive error and the suite fails. The runtime safety net (the
- * `InvalidConfigurationError` throw) is covered separately in onlineAccess.test.ts.
- *
- * The overloads only narrow on a literal `refreshTokenMode: 'online'`, so these cover
- * the common literal mistakes a TS user would make at the call site.
+ * Compile-time enforcement of the online-access overloads, type-checked by ts-jest:
+ * each `@ts-expect-error` must sit over a genuine type error. The runtime safety net
+ * is covered in onlineAccess.test.ts.
  */
-import { createAuth0Client } from '../../src';
+import { createAuth0Client, RefreshTokenMode } from '../../src';
 
 const base = {
   domain: 'example.auth0.com',
@@ -19,10 +12,17 @@ const base = {
 
 describe('createAuth0Client — online access type enforcement', () => {
   it('requires useRefreshTokens: true and useDpop: true when refreshTokenMode is online', () => {
-    // Compile-only — never invoked. Wrapped in a never-true guard so the calls
-    // are type-checked but do not execute (no DOM/crypto needed).
+    // Compile-only — type-checked but never executed.
     const _typecheck = async () => {
-      // Valid combo.
+      // Valid combo, using the RefreshTokenMode enum.
+      await createAuth0Client({
+        ...base,
+        refreshTokenMode: RefreshTokenMode.Online,
+        useRefreshTokens: true,
+        useDpop: true
+      });
+
+      // Raw string still accepted for backward compatibility.
       await createAuth0Client({
         ...base,
         refreshTokenMode: 'online',
@@ -31,22 +31,22 @@ describe('createAuth0Client — online access type enforcement', () => {
       });
 
       // Missing useRefreshTokens → compile error.
-      // @ts-expect-error refreshTokenMode: 'online' requires useRefreshTokens: true
-      await createAuth0Client({ ...base, refreshTokenMode: 'online', useDpop: true });
+      // @ts-expect-error online mode requires useRefreshTokens: true
+      await createAuth0Client({ ...base, refreshTokenMode: RefreshTokenMode.Online, useDpop: true });
 
       // Missing useDpop → compile error.
-      // @ts-expect-error refreshTokenMode: 'online' requires useDpop: true
+      // @ts-expect-error online mode requires useDpop: true
       await createAuth0Client({
         ...base,
-        refreshTokenMode: 'online',
+        refreshTokenMode: RefreshTokenMode.Online,
         useRefreshTokens: true
       });
 
       // useDpop: false → compile error.
-      // @ts-expect-error refreshTokenMode: 'online' requires useDpop: true (not false)
+      // @ts-expect-error online mode requires useDpop: true (not false)
       await createAuth0Client({
         ...base,
-        refreshTokenMode: 'online',
+        refreshTokenMode: RefreshTokenMode.Online,
         useRefreshTokens: true,
         useDpop: false
       });
@@ -60,6 +60,8 @@ describe('createAuth0Client — online access type enforcement', () => {
     const _typecheck = async () => {
       // Legacy combos remain valid — the overloads must not constrain them.
       await createAuth0Client({ ...base, useRefreshTokens: true, useDpop: false });
+      await createAuth0Client({ ...base, refreshTokenMode: RefreshTokenMode.Offline, useRefreshTokens: true });
+      // Raw string still accepted for backward compatibility.
       await createAuth0Client({ ...base, refreshTokenMode: 'offline', useRefreshTokens: true });
     };
     void _typecheck;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Auth0ClientOptionsBase } from '../src/global';
+import { Auth0ClientOptions } from '../src/global';
 import * as scope from '../src/scope';
 import { expect } from '@jest/globals';
 
@@ -38,7 +38,7 @@ jest.mock('../src/storage', () => ({
 }));
 
 const setup = async (
-  clientOptions: Partial<Auth0ClientOptionsBase> = {},
+  clientOptions: Partial<Auth0ClientOptions> = {},
   callConstructor = true
 ) => {
   const tokenVerifier = require('../src/jwt').verify;

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -86,12 +86,14 @@ const setup = async (
     close: jest.fn()
   };
 
+  const opts = {
+    domain: TEST_DOMAIN,
+    clientId: TEST_CLIENT_ID,
+    ...clientOptions
+  } as Auth0ClientOptions & { onlineAccess?: false };
+
   const auth0 = callConstructor
-    ? await createAuth0Client({
-        domain: TEST_DOMAIN,
-        clientId: TEST_CLIENT_ID,
-        ...clientOptions
-      })
+    ? await createAuth0Client(opts)
     : undefined;
 
   const transactionManager =

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -90,7 +90,7 @@ const setup = async (
     domain: TEST_DOMAIN,
     clientId: TEST_CLIENT_ID,
     ...clientOptions
-  } as Auth0ClientOptions & { onlineAccess?: false };
+  } as Auth0ClientOptions & { refreshTokenMode?: 'offline' };
 
   const auth0 = callConstructor
     ? await createAuth0Client(opts)

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { Auth0ClientOptions } from '../src/global';
+import { Auth0ClientOptionsBase } from '../src/global';
 import * as scope from '../src/scope';
 import { expect } from '@jest/globals';
 
@@ -38,7 +38,7 @@ jest.mock('../src/storage', () => ({
 }));
 
 const setup = async (
-  clientOptions: Partial<Auth0ClientOptions> = {},
+  clientOptions: Partial<Auth0ClientOptionsBase> = {},
   callConstructor = true
 ) => {
   const tokenVerifier = require('../src/jwt').verify;

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -179,6 +179,64 @@ describe('token worker', () => {
     });
   });
 
+  it(`keeps a non-rotating token when the refresh response carries no refresh_token`, async () => {
+    // Seed a non-rotating (online) refresh token via the initial code exchange.
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: true,
+        json: () => ({ refresh_token: 'ort' }),
+        headers: new Headers()
+      })
+    );
+    await messageHandlerAsync({
+      fetchUrl: TOKEN_ENDPOINT,
+      fetchOptions: {
+        method: 'POST',
+        body: JSON.stringify({ grant_type: 'authorization_code' })
+      }
+    });
+
+    // First refresh: server exchanges the ORT but returns no new refresh_token.
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: true,
+        json: () => ({ access_token: 'at' }),
+        headers: new Headers()
+      })
+    );
+    await messageHandlerAsync({
+      fetchUrl: TOKEN_ENDPOINT,
+      fetchOptions: {
+        method: 'POST',
+        body: JSON.stringify({ grant_type: 'refresh_token' })
+      },
+      nonRotating: true
+    });
+
+    // Second refresh: the stored ORT must still be injected (not evicted).
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: true,
+        json: () => ({ access_token: 'at2' }),
+        headers: new Headers()
+      })
+    );
+    const response = await messageHandlerAsync({
+      fetchUrl: TOKEN_ENDPOINT,
+      fetchOptions: {
+        method: 'POST',
+        body: JSON.stringify({ grant_type: 'refresh_token' })
+      },
+      nonRotating: true
+    });
+
+    expect(response.json.error).toBeUndefined();
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body)).toEqual({
+      grant_type: 'refresh_token',
+      refresh_token: 'ort'
+    });
+  });
+
   it(`errors with grant_type='refresh_token' and no token is stored`, async () => {
     const response = await messageHandlerAsync({
       fetchUrl: TOKEN_ENDPOINT,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -38,6 +38,7 @@ import {
   AuthenticationError,
   ConnectError,
   GenericError,
+  InvalidConfigurationError,
   MfaRequiredError,
   MissingRefreshTokenError,
   MissingScopesError,
@@ -59,6 +60,7 @@ import {
   MISSING_REFRESH_TOKEN_ERROR_MESSAGE,
   MFA_STEP_UP_ERROR_DESCRIPTION,
   DEFAULT_SCOPE,
+  ONLINE_ACCESS_SCOPE,
   DEFAULT_SESSION_CHECK_EXPIRY_DAYS,
   DEFAULT_AUTH0_CLIENT,
   INVALID_REFRESH_TOKEN_ERROR_MESSAGE,
@@ -71,6 +73,7 @@ import {
 
 import {
   Auth0ClientOptions,
+  Auth0ClientOptionsBase,
   AuthorizationParams,
   AuthorizeOptions,
   RedirectLoginOptions,
@@ -155,7 +158,8 @@ export class Auth0Client {
   private readonly isAuthenticatedCookieName: string;
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
-  private readonly options: Auth0ClientOptions & {
+  private readonly onlineAccess: boolean;
+  private readonly options: Auth0ClientOptionsBase & {
     authorizationParams: ClientAuthorizationParams,
   };
   private readonly userCache: ICache = new InMemoryCache().enclosedCache;
@@ -184,7 +188,7 @@ export class Auth0Client {
   private worker?: Worker;
   private readonly authJsClient: Auth0AuthJsClient;
 
-  private readonly defaultOptions: Partial<Auth0ClientOptions> = {
+  private readonly defaultOptions: Partial<Auth0ClientOptionsBase> = {
     authorizationParams: {
       scope: DEFAULT_SCOPE
     },
@@ -192,7 +196,31 @@ export class Auth0Client {
     useFormData: true
   };
 
+  /**
+   * Validates the online-access configuration and returns whether online mode is enabled.
+   *
+   * Online access requires DPoP. The TypeScript types already forbid the invalid combinations
+   * when `onlineAccess` is a literal `true`, but this runtime check covers dynamically-built
+   * config, `as any` casts, and plain-JS consumers that bypass the compiler.
+   */
+  private resolveOnlineAccess(options: Auth0ClientOptions): boolean {
+    if (options.onlineAccess !== true) {
+      return false;
+    }
+
+    if (options.useDpop !== true) {
+      throw new InvalidConfigurationError(
+        '`onlineAccess: true` requires DPoP, which is missing or disabled.',
+        'Set `useDpop: true` (DPoP is mandatory for online access).'
+      );
+    }
+
+    return true;
+  }
+
   constructor(options: Auth0ClientOptions) {
+    this.onlineAccess = this.resolveOnlineAccess(options);
+
     this.options = {
       ...this.defaultOptions,
       ...options,
@@ -254,11 +282,17 @@ export class Auth0Client {
     // Construct the scopes based on the following:
     // 1. Always include `openid`
     // 2. Include the scopes provided in `authorizationParams. This defaults to `profile email`
-    // 3. Add `offline_access` if `useRefreshTokens` is enabled
+    // 3. Add `online_access` when in online-access mode, otherwise `offline_access` if
+    //    `useRefreshTokens` is enabled. Online and offline are mutually exclusive — online
+    //    must never inject `offline_access`.
     this.scope = injectDefaultScopes(
       this.options.authorizationParams.scope,
       'openid',
-      this.options.useRefreshTokens ? 'offline_access' : ''
+      this.onlineAccess
+        ? ONLINE_ACCESS_SCOPE
+        : this.options.useRefreshTokens
+        ? 'offline_access'
+        : ''
     );
 
     this.transactionManager = new TransactionManager(
@@ -316,7 +350,7 @@ export class Auth0Client {
     if (
       typeof window !== 'undefined' &&
       window.Worker &&
-      this.options.useRefreshTokens &&
+      (this.options.useRefreshTokens || this.onlineAccess) &&
       cacheLocation === CACHE_LOCATION_MEMORY
     ) {
       if (this.options.workerUrl) {
@@ -994,7 +1028,7 @@ export class Auth0Client {
           }
         }
 
-        const authResult = this.options.useRefreshTokens
+        const authResult = (this.options.useRefreshTokens || this.onlineAccess)
           ? await this._getTokenUsingRefreshToken(getTokenOptions)
           : await this._getTokenFromIFrame(getTokenOptions);
 
@@ -1211,7 +1245,7 @@ export class Auth0Client {
    * await auth0.revokeRefreshToken({ audience: 'https://api2.example.com' });
    */
   public async revokeRefreshToken(options: RevokeRefreshTokenOptions = {}): Promise<void> {
-    if (!this.options.useRefreshTokens) {
+    if (!this.options.useRefreshTokens && !this.onlineAccess) {
       return;
     }
 
@@ -1455,8 +1489,13 @@ export class Auth0Client {
       );
 
       // If is refreshed with MRRT, we update all entries that have the old
-      // refresh_token with the new one if the server responded with one
-      if (tokenResult.refresh_token && cache?.refresh_token) {
+      // refresh_token with the new one if the server responded with one.
+      // Online Refresh Tokens are non-rotating, so the stored RT is never replaced.
+      if (
+        !this.onlineAccess &&
+        tokenResult.refresh_token &&
+        cache?.refresh_token
+      ) {
         await this.cacheManager.updateEntry(
           cache.refresh_token,
           tokenResult.refresh_token

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1785,9 +1785,18 @@ export class Auth0Client {
           };
         }
       }
+      // Online refresh tokens are non-rotating: the server returns no refresh_token, so
+      // carry the ORT forward to avoid evicting it on save. Online-only: in offline mode
+      // a refresh token is single-use and reusing it would trip reuse detection.
+      const refresh_token =
+        authResult.refresh_token ||
+        (this.onlineAccess && options.grant_type === 'refresh_token'
+          ? options.refresh_token
+          : undefined);
 
       await this._saveEntryInCache({
         ...authResult,
+        ...(refresh_token ? { refresh_token } : null),
         decodedToken,
         scope: options.scope,
         audience: options.audience || DEFAULT_AUDIENCE,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -281,14 +281,17 @@ export class Auth0Client {
       : SessionStorage;
 
     // `online_access` and `offline_access` are mutually exclusive — inject at most one.
+    let sessionScope = '';
+    if (this.onlineAccess) {
+      sessionScope = ONLINE_ACCESS_SCOPE;
+    } else if (this.options.useRefreshTokens) {
+      sessionScope = 'offline_access';
+    }
+
     this.scope = injectDefaultScopes(
       this.options.authorizationParams.scope,
       'openid',
-      this.onlineAccess
-        ? ONLINE_ACCESS_SCOPE
-        : this.options.useRefreshTokens
-          ? 'offline_access'
-          : ''
+      sessionScope
     );
 
     this.transactionManager = new TransactionManager(

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -73,7 +73,6 @@ import {
 
 import {
   Auth0ClientOptions,
-  Auth0ClientOptionsBase,
   AuthorizationParams,
   AuthorizeOptions,
   RedirectLoginOptions,
@@ -159,7 +158,7 @@ export class Auth0Client {
   private readonly nowProvider: () => number | Promise<number>;
   private readonly httpTimeoutMs: number;
   private readonly onlineAccess: boolean;
-  private readonly options: Auth0ClientOptionsBase & {
+  private readonly options: Auth0ClientOptions & {
     authorizationParams: ClientAuthorizationParams,
   };
   private readonly userCache: ICache = new InMemoryCache().enclosedCache;
@@ -188,7 +187,7 @@ export class Auth0Client {
   private worker?: Worker;
   private readonly authJsClient: Auth0AuthJsClient;
 
-  private readonly defaultOptions: Partial<Auth0ClientOptionsBase> = {
+  private readonly defaultOptions: Partial<Auth0ClientOptions> = {
     authorizationParams: {
       scope: DEFAULT_SCOPE
     },
@@ -199,9 +198,7 @@ export class Auth0Client {
   /**
    * Validates the online-access configuration and returns whether online mode is enabled.
    *
-   * Online access requires DPoP. The TypeScript types already forbid the invalid combinations
-   * when `onlineAccess` is a literal `true`, but this runtime check covers dynamically-built
-   * config, `as any` casts, and plain-JS consumers that bypass the compiler.
+   * Online access requires DPoP, so `onlineAccess: true` without `useDpop: true` throws.
    */
   private resolveOnlineAccess(options: Auth0ClientOptions): boolean {
     if (options.onlineAccess !== true) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1519,6 +1519,7 @@ export class Auth0Client {
           const missingScopes = getMissingScopes(
             scopesToRequest,
             tokenResult.scope,
+            this.onlineAccess
           );
 
           if (missingScopes) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -192,30 +192,32 @@ export class Auth0Client {
       scope: DEFAULT_SCOPE
     },
     useRefreshTokensFallback: false,
-    useFormData: true
+    useFormData: true,
+    refreshTokenMode: 'offline',
   };
 
   /**
    * Validates the online-access configuration and returns whether online mode is enabled.
    *
-   * Online access requires DPoP, so `onlineAccess: true` without `useDpop: true` throws.
+   * Online mode (`refreshTokenMode: 'online'`) is a refresh-token grant, so it requires
+   * `useRefreshTokens: true`, and it requires DPoP, so `useDpop: true` is mandatory.
    */
   private resolveOnlineAccess(options: Auth0ClientOptions): boolean {
 
-    if (options.onlineAccess !== true) {
+    if (options.refreshTokenMode !== 'online') {
       return false;
     }
 
-    if (options.useRefreshTokens == true) {
+    if (options.useRefreshTokens !== true) {
       throw new InvalidConfigurationError(
-        '`onlineAccess: true` requires useRefreshTokens to be false.',
-        'Set `useRefreshTokens: false`.'
+        '`refreshTokenMode: "online"` requires the refresh-token grant.',
+        'Set `useRefreshTokens: true`.'
       );
     }
 
     if (options.useDpop !== true) {
       throw new InvalidConfigurationError(
-        '`onlineAccess: true` requires DPoP, which is missing or disabled.',
+        '`refreshTokenMode: "online"` requires DPoP, which is missing or disabled.',
         'Set `useDpop: true` (DPoP is mandatory for online access).'
       );
     }
@@ -351,11 +353,12 @@ export class Auth0Client {
       this
     );
 
-    // Don't use web workers unless using refresh tokens in memory
+    // Don't use web workers unless using refresh tokens in memory.
+    // Online mode requires `useRefreshTokens: true`, so it is covered here too.
     if (
       typeof window !== 'undefined' &&
       window.Worker &&
-      (this.options.useRefreshTokens || this.onlineAccess) &&
+      this.options.useRefreshTokens &&
       cacheLocation === CACHE_LOCATION_MEMORY
     ) {
       if (this.options.workerUrl) {
@@ -1033,7 +1036,7 @@ export class Auth0Client {
           }
         }
 
-        const authResult = (this.options.useRefreshTokens || this.onlineAccess)
+        const authResult = this.options.useRefreshTokens
           ? await this._getTokenUsingRefreshToken(getTokenOptions)
           : await this._getTokenFromIFrame(getTokenOptions);
 
@@ -1250,7 +1253,7 @@ export class Auth0Client {
    * await auth0.revokeRefreshToken({ audience: 'https://api2.example.com' });
    */
   public async revokeRefreshToken(options: RevokeRefreshTokenOptions = {}): Promise<void> {
-    if (!this.options.useRefreshTokens && !this.onlineAccess) {
+    if (!this.options.useRefreshTokens) {
       return;
     }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -196,12 +196,7 @@ export class Auth0Client {
     refreshTokenMode: 'offline',
   };
 
-  /**
-   * Validates the online-access configuration and returns whether online mode is enabled.
-   *
-   * Online mode (`refreshTokenMode: 'online'`) is a refresh-token grant, so it requires
-   * `useRefreshTokens: true`, and it requires DPoP, so `useDpop: true` is mandatory.
-   */
+  /** Validates online-access config and returns whether online mode is enabled. */
   private resolveOnlineAccess(options: Auth0ClientOptions): boolean {
 
     if (options.refreshTokenMode !== 'online') {
@@ -286,12 +281,7 @@ export class Auth0Client {
       ? this.cookieStorage
       : SessionStorage;
 
-    // Construct the scopes based on the following:
-    // 1. Always include `openid`
-    // 2. Include the scopes provided in `authorizationParams. This defaults to `profile email`
-    // 3. Add `online_access` when in online-access mode, otherwise `offline_access` if
-    //    `useRefreshTokens` is enabled. Online and offline are mutually exclusive — online
-    //    must never inject `offline_access`.
+    // `online_access` and `offline_access` are mutually exclusive — inject at most one.
     this.scope = injectDefaultScopes(
       this.options.authorizationParams.scope,
       'openid',
@@ -354,7 +344,6 @@ export class Auth0Client {
     );
 
     // Don't use web workers unless using refresh tokens in memory.
-    // Online mode requires `useRefreshTokens: true`, so it is covered here too.
     if (
       typeof window !== 'undefined' &&
       window.Worker &&
@@ -1496,9 +1485,8 @@ export class Auth0Client {
         }
       );
 
-      // If is refreshed with MRRT, we update all entries that have the old
-      // refresh_token with the new one if the server responded with one.
-      // Online Refresh Tokens are non-rotating, so the stored RT is never replaced.
+      // Propagate a rotated RT to all MRRT entries. Skipped for online mode,
+      // where ORTs are non-rotating.
       if (
         !this.onlineAccess &&
         tokenResult.refresh_token &&

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1219,6 +1219,12 @@ export class Auth0Client {
    *
    * If `useRefreshTokens` is disabled, this method does nothing.
    *
+   * **Online mode:** when `refreshTokenMode` is `'online'` this method only clears the
+   * cached refresh token locally — it does **not** revoke the Online Refresh Token at the
+   * authorization server. Online Refresh Tokens are non-rotating and session-bound, and the
+   * server does not support token-only revocation for them. To end an online session, use
+   * `logout()` instead, which terminates the session and thereby invalidates the ORT.
+   *
    * **Important:** This method revokes the refresh token for a single audience. If your
    * application requests tokens for multiple audiences, each audience may have its own
    * refresh token. To fully revoke all refresh tokens, call this method once per audience.

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -112,7 +112,6 @@ import {
   OLD_IS_AUTHENTICATED_COOKIE_NAME,
   patchOpenUrlWithOnRedirect,
   getScopeToRequest,
-  allScopesAreIncluded,
   isRefreshWithMrrt,
   getMissingScopes
 } from './Auth0Client.utils';
@@ -1511,12 +1510,12 @@ export class Auth0Client {
         );
 
         if (isRefreshMrrt) {
-          const tokenHasAllScopes = allScopesAreIncluded(
+          const missingScopes = getMissingScopes(
             scopesToRequest,
             tokenResult.scope,
           );
 
-          if (!tokenHasAllScopes) {
+          if (missingScopes) {
             if (this.options.useRefreshTokensFallback) {
               return await this._getTokenFromIFrame(options);
             }
@@ -1527,11 +1526,6 @@ export class Auth0Client {
               this.options.clientId,
               options.authorizationParams.audience,
               options.authorizationParams.scope,
-            );
-
-            const missingScopes = getMissingScopes(
-              scopesToRequest,
-              tokenResult.scope,
             );
 
             throw new MissingScopesError(

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -201,8 +201,16 @@ export class Auth0Client {
    * Online access requires DPoP, so `onlineAccess: true` without `useDpop: true` throws.
    */
   private resolveOnlineAccess(options: Auth0ClientOptions): boolean {
+
     if (options.onlineAccess !== true) {
       return false;
+    }
+
+    if (options.useRefreshTokens == true) {
+      throw new InvalidConfigurationError(
+        '`onlineAccess: true` requires useRefreshTokens to be false.',
+        'Set `useRefreshTokens: false`.'
+      );
     }
 
     if (options.useDpop !== true) {
@@ -288,8 +296,8 @@ export class Auth0Client {
       this.onlineAccess
         ? ONLINE_ACCESS_SCOPE
         : this.options.useRefreshTokens
-        ? 'offline_access'
-        : ''
+          ? 'offline_access'
+          : ''
     );
 
     this.transactionManager = new TransactionManager(

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1754,6 +1754,7 @@ export class Auth0Client {
           timeout: this.httpTimeoutMs,
           useMrrt: this.options.useMrrt,
           dpop: this.dpop,
+          nonRotating: this.onlineAccess,
           ...options,
           scope: scopesToRequest || options.scope,
         },

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -148,14 +148,21 @@ export const allScopesAreIncluded = (scopeToInclude?: string, scopes?: string): 
  *
  * Returns the scopes that are missing after a refresh.
  *
- * `online_access` is stripped from the requested scopes because this only runs in the MRRT
- * flow: the server does not issue a new ORT for an MRRT cross-audience exchange, so the same
- * (non-rotating) ORT is reused and `online_access` is never echoed back in the response scope.
- * Comparing the injected `online_access` against the response would otherwise flag it as a
- * spurious missing scope.
+ * When `onlineAccess` is true, `online_access` is stripped from the requested scopes before
+ * comparing: in online mode the server reuses the same (non-rotating) ORT for an MRRT
+ * cross-audience exchange and never echoes `online_access` back in the response scope, so
+ * comparing it would flag a spurious missing scope. Outside online mode the strip is not
+ * applied, so a genuinely missing `online_access` is still reported.
  */
-export const getMissingScopes = (requestedScope?: string, respondedScope?: string): string => {
-  const requestedScopes = withoutOnlineAccessScope(requestedScope?.split(" ") || []);
+export const getMissingScopes = (
+  requestedScope?: string,
+  respondedScope?: string,
+  onlineAccess?: boolean
+): string => {
+  const splitRequested = requestedScope?.split(" ") || [];
+  const requestedScopes = onlineAccess
+    ? withoutOnlineAccessScope(splitRequested)
+    : splitRequested;
   const respondedScopes = respondedScope?.split(" ") || [];
 
   const missingScopes = requestedScopes.filter((scope) => respondedScopes.indexOf(scope) == -1);

--- a/src/Auth0Client.utils.ts
+++ b/src/Auth0Client.utils.ts
@@ -7,6 +7,7 @@ import {
   LogoutOptions
 } from './global';
 import { scopesToRequest } from './scope';
+import { ONLINE_ACCESS_SCOPE } from './constants';
 
 /**
  * @ignore
@@ -123,7 +124,17 @@ export const patchOpenUrlWithOnRedirect = <
 
 /**
  * @ignore
- * 
+ *
+ * Function used to trim the `online_access` scope from a list of scopes. 
+ * This is used in the MRRT flow to avoid spurious missing scope errors, 
+ * since `online_access` is never echoed back in the response.
+ */
+const withoutOnlineAccessScope = (scopes: string[]): string[] =>
+  scopes.filter((scope) => scope !== ONLINE_ACCESS_SCOPE);
+
+/**
+ * @ignore
+ *
  * Checks if all scopes are included inside other array of scopes
  */
 export const allScopesAreIncluded = (scopeToInclude?: string, scopes?: string): boolean => {
@@ -134,11 +145,17 @@ export const allScopesAreIncluded = (scopeToInclude?: string, scopes?: string): 
 
 /**
  * @ignore
- * 
- * Returns the scopes that are missing after a refresh
+ *
+ * Returns the scopes that are missing after a refresh.
+ *
+ * `online_access` is stripped from the requested scopes because this only runs in the MRRT
+ * flow: the server does not issue a new ORT for an MRRT cross-audience exchange, so the same
+ * (non-rotating) ORT is reused and `online_access` is never echoed back in the response scope.
+ * Comparing the injected `online_access` against the response would otherwise flag it as a
+ * spurious missing scope.
  */
 export const getMissingScopes = (requestedScope?: string, respondedScope?: string): string => {
-  const requestedScopes = requestedScope?.split(" ") || [];
+  const requestedScopes = withoutOnlineAccessScope(requestedScope?.split(" ") || []);
   const respondedScopes = respondedScope?.split(" ") || [];
 
   const missingScopes = requestedScopes.filter((scope) => respondedScopes.indexOf(scope) == -1);

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,6 +38,7 @@ export async function oauthToken(
     useFormData,
     useMrrt,
     dpop,
+    nonRotating,
     ...options
   }: TokenEndpointOptions,
   worker?: Worker,
@@ -90,7 +91,8 @@ export async function oauthToken(
     useMrrt,
     isDpopSupported ? dpop : undefined,
     undefined,
-    skipTokenStorage
+    skipTokenStorage,
+    nonRotating
   );
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,12 @@ export const DEFAULT_SCOPE = 'openid profile email';
 
 /**
  * @ignore
+ * The scope that requests an Online Refresh Token (non-rotating, session-bound).
+ */
+export const ONLINE_ACCESS_SCOPE = 'online_access';
+
+/**
+ * @ignore
  */
 export const DEFAULT_SESSION_CHECK_EXPIRY_DAYS = 1;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -30,7 +30,7 @@ export class GenericError extends Error {
 
 /**
  * Thrown at construction time when the Auth0Client is configured with an invalid combination
- * of options (e.g. `onlineAccess: true` without `useDpop: true`). Carries a `suggestion` with
+ * of options (e.g. `refreshTokenMode: 'online'` without `useDpop: true`). Carries a `suggestion` with
  * the exact configuration change to make.
  */
 export class InvalidConfigurationError extends GenericError {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,9 +29,8 @@ export class GenericError extends Error {
 }
 
 /**
- * Thrown at construction time when the Auth0Client is configured with an invalid combination
- * of options (e.g. `refreshTokenMode: 'online'` without `useDpop: true`). Carries a `suggestion` with
- * the exact configuration change to make.
+ * Thrown at construction time for an invalid option combination (e.g.
+ * `refreshTokenMode: 'online'` without `useDpop: true`). The `suggestion` names the fix.
  */
 export class InvalidConfigurationError extends GenericError {
   constructor(message: string, public suggestion: string) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,6 +29,18 @@ export class GenericError extends Error {
 }
 
 /**
+ * Thrown at construction time when the Auth0Client is configured with an invalid combination
+ * of options (e.g. `onlineAccess: true` without `useDpop: true`). Carries a `suggestion` with
+ * the exact configuration change to make.
+ */
+export class InvalidConfigurationError extends GenericError {
+  constructor(message: string, public suggestion: string) {
+    super('invalid_configuration', `${message} ${suggestion}`);
+    Object.setPrototypeOf(this, InvalidConfigurationError.prototype);
+  }
+}
+
+/**
  * Thrown when handling the redirect callback fails, will be one of Auth0's
  * Authentication API's Standard Error Responses: https://auth0.com/docs/api/authentication?javascript#standard-error-responses
  */

--- a/src/global.ts
+++ b/src/global.ts
@@ -141,7 +141,7 @@ interface BaseLoginOptions {
   authorizationParams?: AuthorizationParams;
 }
 
-export interface Auth0ClientOptionsBase {
+export interface Auth0ClientOptions {
   /**
    * Your Auth0 account domain such as `'example.auth0.com'`,
    * `'example.eu.auth0.com'` or , `'example.mycompany.com'`
@@ -313,6 +313,20 @@ export interface Auth0ClientOptionsBase {
   useDpop?: boolean;
 
   /**
+   * Opt in to Online Refresh Tokens (ORTs): non-rotating refresh tokens bound to
+   * the Auth0 session lifetime. When `true`, the SDK injects the `online_access`
+   * scope, routes token renewal through the refresh_token grant, and stores the
+   * (non-rotating) refresh token in the existing cache.
+   *
+   * Online access requires DPoP — you must also set `useDpop: true`. Do NOT set
+   * `useRefreshTokens` alongside it: that injects `offline_access`, which conflicts
+   * with `online_access`.
+   *
+   * Defaults to `false` — when unset or `false` the SDK behaves exactly as before.
+   */
+  onlineAccess?: boolean;
+
+  /**
    * Configures automatic handling of interactive authentication errors.
    *
    * When set, the SDK intercepts `mfa_required` errors from `getTokenSilently()`
@@ -369,44 +383,6 @@ export interface Auth0ClientOptionsBase {
    */
   sessionTransferTokenQueryParamName?: string;
 }
-
-/**
- * Configuration options for the Auth0Client.
- *
- * This is a discriminated union on `onlineAccess`:
- * - When `onlineAccess: true`, the SDK uses Online Refresh Tokens. DPoP is mandatory and must
- *   be set explicitly (`useDpop: true`); `useRefreshTokens` must not be set (online injects
- *   `online_access`, not `offline_access`). The compiler enforces both constraints.
- * - Otherwise (`onlineAccess` unset or `false`), behavior is exactly as before — `useDpop` and
- *   `useRefreshTokens` are independent optional booleans.
- *
- * The compile-time check only narrows when `onlineAccess` is a literal `true`. The Auth0Client
- * constructor performs an equivalent runtime check that also covers dynamic config and plain JS.
- *
- * @category Main
- */
-export type Auth0ClientOptions =
-  | (Auth0ClientOptionsBase & {
-      /**
-       * Opt in to Online Refresh Tokens. Injects the `online_access` scope, routes renewal
-       * through the refresh_token grant, and stores the non-rotating refresh token in the
-       * existing cache. Requires `useDpop: true` (DPoP is mandatory for online access and must
-       * be set explicitly). Do NOT set `useRefreshTokens` — it injects `offline_access`, which
-       * conflicts with online access.
-       */
-      onlineAccess: true;
-      useDpop: true;
-      useRefreshTokens?: never;
-    })
-  | (Auth0ClientOptionsBase & {
-      /**
-       * Opt in to Online Refresh Tokens. Defaults to `false` — when unset or `false` the SDK
-       * behaves exactly as before.
-       */
-      onlineAccess?: false;
-      useDpop?: boolean;
-      useRefreshTokens?: boolean;
-    });
 
 /**
  * Configuration details exposed by the Auth0Client after initialization.

--- a/src/global.ts
+++ b/src/global.ts
@@ -9,6 +9,22 @@ import { CompleteResponse } from './myaccount';
  */
 export type InteractiveErrorHandler = 'popup';
 
+/**
+ * The refresh-token variant used when `useRefreshTokens: true`.
+ *
+ * - {@link RefreshTokenMode.Offline} (default): rotating offline refresh tokens.
+ * - {@link RefreshTokenMode.Online}: non-rotating Online Refresh Tokens (ORTs).
+ */
+// `const` object, not a TS `enum`, so members stay string-literal types and
+// remain assignable to the `createAuth0Client` overloads.
+export const RefreshTokenMode = {
+  Offline: 'offline',
+  Online: 'online'
+} as const;
+
+export type RefreshTokenMode =
+  (typeof RefreshTokenMode)[keyof typeof RefreshTokenMode];
+
 export interface AuthorizationParams {
   /**
    * - `'page'`: displays the UI with a full page view
@@ -314,21 +330,15 @@ export interface Auth0ClientOptions {
 
   /**
    * Selects the refresh-token variant used when `useRefreshTokens: true`.
+   * Defaults to {@link RefreshTokenMode.Offline}.
    *
-   * - `'offline'` (default): rotating offline refresh tokens, requested via the
-   *   `offline_access` scope. This is the existing behavior.
-   * - `'online'`: non-rotating Online Refresh Tokens (ORTs), bound to the Auth0
-   *   session lifetime, requested via the `online_access` scope. When the session
-   *   ends or is revoked, the ORT becomes invalid.
+   * - {@link RefreshTokenMode.Offline} (default): rotating offline refresh tokens (`offline_access`).
+   * - {@link RefreshTokenMode.Online}: non-rotating, session-bound Online Refresh Tokens (`online_access`).
    *
-   * Online mode requires `useRefreshTokens: true` (it is a kind of refresh-token
-   * grant) and `useDpop: true` (DPoP is mandatory for online access). The
-   * `online_access` and `offline_access` scopes are mutually exclusive — online
-   * mode never injects `offline_access`.
-   *
-   * Defaults to `'offline'` — when unset the SDK behaves exactly as before.
+   * Online mode requires `useRefreshTokens: true` and `useDpop: true`. The
+   * `online_access` and `offline_access` scopes are mutually exclusive.
    */
-  refreshTokenMode?: 'offline' | 'online';
+  refreshTokenMode?: RefreshTokenMode;
 
   /**
    * Configures automatic handling of interactive authentication errors.

--- a/src/global.ts
+++ b/src/global.ts
@@ -313,18 +313,22 @@ export interface Auth0ClientOptions {
   useDpop?: boolean;
 
   /**
-   * Opt in to Online Refresh Tokens (ORTs): non-rotating refresh tokens bound to
-   * the Auth0 session lifetime. When `true`, the SDK injects the `online_access`
-   * scope, routes token renewal through the refresh_token grant, and stores the
-   * (non-rotating) refresh token in the existing cache.
+   * Selects the refresh-token variant used when `useRefreshTokens: true`.
    *
-   * Online access requires DPoP — you must also set `useDpop: true`. Do NOT set
-   * `useRefreshTokens` alongside it: that injects `offline_access`, which conflicts
-   * with `online_access`.
+   * - `'offline'` (default): rotating offline refresh tokens, requested via the
+   *   `offline_access` scope. This is the existing behavior.
+   * - `'online'`: non-rotating Online Refresh Tokens (ORTs), bound to the Auth0
+   *   session lifetime, requested via the `online_access` scope. When the session
+   *   ends or is revoked, the ORT becomes invalid.
    *
-   * Defaults to `false` — when unset or `false` the SDK behaves exactly as before.
+   * Online mode requires `useRefreshTokens: true` (it is a kind of refresh-token
+   * grant) and `useDpop: true` (DPoP is mandatory for online access). The
+   * `online_access` and `offline_access` scopes are mutually exclusive — online
+   * mode never injects `offline_access`.
+   *
+   * Defaults to `'offline'` — when unset the SDK behaves exactly as before.
    */
-  onlineAccess?: boolean;
+  refreshTokenMode?: 'offline' | 'online';
 
   /**
    * Configures automatic handling of interactive authentication errors.

--- a/src/global.ts
+++ b/src/global.ts
@@ -141,7 +141,7 @@ interface BaseLoginOptions {
   authorizationParams?: AuthorizationParams;
 }
 
-export interface Auth0ClientOptions {
+export interface Auth0ClientOptionsBase {
   /**
    * Your Auth0 account domain such as `'example.auth0.com'`,
    * `'example.eu.auth0.com'` or , `'example.mycompany.com'`
@@ -369,6 +369,44 @@ export interface Auth0ClientOptions {
    */
   sessionTransferTokenQueryParamName?: string;
 }
+
+/**
+ * Configuration options for the Auth0Client.
+ *
+ * This is a discriminated union on `onlineAccess`:
+ * - When `onlineAccess: true`, the SDK uses Online Refresh Tokens. DPoP is mandatory and must
+ *   be set explicitly (`useDpop: true`); `useRefreshTokens` must not be set (online injects
+ *   `online_access`, not `offline_access`). The compiler enforces both constraints.
+ * - Otherwise (`onlineAccess` unset or `false`), behavior is exactly as before — `useDpop` and
+ *   `useRefreshTokens` are independent optional booleans.
+ *
+ * The compile-time check only narrows when `onlineAccess` is a literal `true`. The Auth0Client
+ * constructor performs an equivalent runtime check that also covers dynamic config and plain JS.
+ *
+ * @category Main
+ */
+export type Auth0ClientOptions =
+  | (Auth0ClientOptionsBase & {
+      /**
+       * Opt in to Online Refresh Tokens. Injects the `online_access` scope, routes renewal
+       * through the refresh_token grant, and stores the non-rotating refresh token in the
+       * existing cache. Requires `useDpop: true` (DPoP is mandatory for online access and must
+       * be set explicitly). Do NOT set `useRefreshTokens` — it injects `offline_access`, which
+       * conflicts with online access.
+       */
+      onlineAccess: true;
+      useDpop: true;
+      useRefreshTokens?: never;
+    })
+  | (Auth0ClientOptionsBase & {
+      /**
+       * Opt in to Online Refresh Tokens. Defaults to `false` — when unset or `false` the SDK
+       * behaves exactly as before.
+       */
+      onlineAccess?: false;
+      useDpop?: boolean;
+      useRefreshTokens?: boolean;
+    });
 
 /**
  * Configuration details exposed by the Auth0Client after initialization.

--- a/src/http.ts
+++ b/src/http.ts
@@ -73,7 +73,8 @@ const fetchWithWorker = async (
   worker: Worker,
   useFormData?: boolean,
   useMrrt?: boolean,
-  skipTokenStorage?: boolean
+  skipTokenStorage?: boolean,
+  nonRotating?: boolean
 ) => {
   return sendMessage(
     {
@@ -87,7 +88,8 @@ const fetchWithWorker = async (
       fetchOptions,
       useFormData,
       useMrrt,
-      skipTokenStorage
+      skipTokenStorage,
+      nonRotating
     },
     worker
   );
@@ -102,7 +104,8 @@ export const switchFetch = async (
   useFormData?: boolean,
   timeout = DEFAULT_FETCH_TIMEOUT_MS,
   useMrrt?: boolean,
-  skipTokenStorage?: boolean
+  skipTokenStorage?: boolean,
+  nonRotating?: boolean
 ): Promise<any> => {
   if (worker) {
     return fetchWithWorker(
@@ -114,7 +117,8 @@ export const switchFetch = async (
       worker,
       useFormData,
       useMrrt,
-      skipTokenStorage
+      skipTokenStorage,
+      nonRotating
     );
   } else {
     return fetchWithoutWorker(fetchUrl, fetchOptions, timeout);
@@ -132,7 +136,8 @@ export async function getJSON<T>(
   useMrrt?: boolean,
   dpop?: Pick<Dpop, 'generateProof' | 'getNonce' | 'setNonce'>,
   isDpopRetry?: boolean,
-  skipTokenStorage?: boolean
+  skipTokenStorage?: boolean,
+  nonRotating?: boolean
 ): Promise<T> {
   if (dpop) {
     const dpopProof = await dpop.generateProof({
@@ -158,7 +163,8 @@ export async function getJSON<T>(
         useFormData,
         timeout,
         useMrrt,
-        skipTokenStorage
+        skipTokenStorage,
+        nonRotating
       );
       fetchError = null;
       break;
@@ -232,7 +238,8 @@ export async function getJSON<T>(
         useMrrt,
         dpop,
         true, // !
-        skipTokenStorage
+        skipTokenStorage,
+        nonRotating
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,21 +6,21 @@ import './global';
 export * from './global';
 
 /**
- * Online access requires DPoP and is incompatible with `useRefreshTokens` (which
- * requests `offline_access`). When `onlineAccess` is the literal `true`, the compiler
- * requires `useDpop: true` and forbids `useRefreshTokens`. This only narrows on a literal
- * `true`; dynamic values, casts, and plain JS are covered by the runtime check in the
+ * Online mode (`refreshTokenMode: 'online'`) is a refresh-token grant and requires DPoP.
+ * When `refreshTokenMode` is the literal `'online'`, the compiler requires both
+ * `useRefreshTokens: true` and `useDpop: true`. This only narrows on the literal `'online'`;
+ * dynamic values, casts, and plain JS are covered by the runtime check in the
  * `Auth0Client` constructor.
  */
 export async function createAuth0Client(
   options: Auth0ClientOptions & {
-    onlineAccess: true;
+    refreshTokenMode: 'online';
+    useRefreshTokens: true;
     useDpop: true;
-    useRefreshTokens?: never;
   }
 ): Promise<Auth0Client>;
 export async function createAuth0Client(
-  options: Auth0ClientOptions & { onlineAccess?: false }
+  options: Auth0ClientOptions & { refreshTokenMode?: 'offline' }
 ): Promise<Auth0Client>;
 /**
  * Asynchronously creates the Auth0Client instance and calls `checkSession`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { Auth0Client };
 export {
   ConnectError,
   GenericError,
+  InvalidConfigurationError,
   AuthenticationError,
   TimeoutError,
   PopupTimeoutError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,23 @@ import './global';
 export * from './global';
 
 /**
+ * Online access requires DPoP and is incompatible with `useRefreshTokens` (which
+ * requests `offline_access`). When `onlineAccess` is the literal `true`, the compiler
+ * requires `useDpop: true` and forbids `useRefreshTokens`. This only narrows on a literal
+ * `true`; dynamic values, casts, and plain JS are covered by the runtime check in the
+ * `Auth0Client` constructor.
+ */
+export async function createAuth0Client(
+  options: Auth0ClientOptions & {
+    onlineAccess: true;
+    useDpop: true;
+    useRefreshTokens?: never;
+  }
+): Promise<Auth0Client>;
+export async function createAuth0Client(
+  options: Auth0ClientOptions & { onlineAccess?: false }
+): Promise<Auth0Client>;
+/**
  * Asynchronously creates the Auth0Client instance and calls `checkSession`.
  *
  * **Note:** There are caveats to using this in a private browser tab, which may not silently authenticate

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,9 @@ import './global';
 export * from './global';
 
 /**
- * Online mode (`refreshTokenMode: 'online'`) is a refresh-token grant and requires DPoP.
- * When `refreshTokenMode` is the literal `'online'`, the compiler requires both
- * `useRefreshTokens: true` and `useDpop: true`. This only narrows on the literal `'online'`;
- * dynamic values, casts, and plain JS are covered by the runtime check in the
- * `Auth0Client` constructor.
+ * Online mode requires `useRefreshTokens: true` and `useDpop: true`, enforced here at
+ * compile time. Dynamic values, casts, and plain JS are covered by the runtime check in
+ * the `Auth0Client` constructor.
  */
 export async function createAuth0Client(
   options: Auth0ClientOptions & {

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -82,7 +82,7 @@ const checkDownscoping = (scope: string, audience: string): boolean => {
 }
 
 const messageHandler = async ({
-  data: { timeout, auth, fetchUrl, fetchOptions, useFormData, useMrrt, skipTokenStorage },
+  data: { timeout, auth, fetchUrl, fetchOptions, useFormData, useMrrt, skipTokenStorage, nonRotating },
   ports: [port]
 }: MessageEvent<WorkerRefreshTokenMessage>) => {
   let headers: FetchResponse['headers'] = {};
@@ -188,7 +188,9 @@ const messageHandler = async ({
 
       setRefreshToken(json.refresh_token, audience, scope);
       delete json.refresh_token;
-    } else {
+    } else if (!nonRotating) {
+      // Non-rotating (online) refresh tokens come back without a replacement;
+      // keep the stored ORT instead of evicting it.
       deleteRefreshToken(audience, scope);
     }
 

--- a/src/worker/worker.types.ts
+++ b/src/worker/worker.types.ts
@@ -20,6 +20,11 @@ export type WorkerRefreshTokenMessage = WorkerTokenMessage & {
   type: 'refresh';
   useMrrt?: boolean;
   skipTokenStorage?: boolean;
+  /**
+   * Non-rotating refresh token (Online Refresh Token). When set, the worker keeps
+   * the stored token if the response carries no replacement, instead of deleting it.
+   */
+  nonRotating?: boolean;
 };
 
 export type WorkerRevokeTokenMessage = Omit<WorkerTokenMessage, 'auth'> & {

--- a/static/online-access.html
+++ b/static/online-access.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>auth0-spa-js · Online Access sample</title>
+  <!-- Loads the local dev bundle served by `npm run dev` from /dist. -->
+  <script src="/auth0-spa-js.development.js"></script>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 760px;
+      margin: 40px auto;
+      padding: 0 20px;
+      line-height: 1.5;
+    }
+    button {
+      font-size: 0.95rem;
+      padding: 8px 14px;
+      margin: 0 8px 8px 0;
+      cursor: pointer;
+    }
+    pre {
+      background: #f4f4f4;
+      padding: 16px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.85rem;
+    }
+    .hidden { display: none; }
+    .mode-bar {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      background: #eef2ff;
+      border: 1px solid #c7d2fe;
+      border-radius: 6px;
+      padding: 10px 14px;
+      margin-bottom: 20px;
+    }
+    .mode-bar a {
+      text-decoration: none;
+      padding: 4px 10px;
+      border-radius: 4px;
+      border: 1px solid #6366f1;
+      color: #4338ca;
+    }
+    .mode-bar a.active { background: #6366f1; color: #fff; }
+    .diag table { border-collapse: collapse; width: 100%; font-size: 0.85rem; }
+    .diag th, .diag td {
+      border: 1px solid #ddd;
+      padding: 6px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    .diag th { background: #fafafa; width: 220px; }
+    .ok { color: #15803d; font-weight: 600; }
+    .bad { color: #b91c1c; font-weight: 600; }
+    code { background: #f0f0f0; padding: 1px 5px; border-radius: 3px; }
+    h2 { margin-top: 32px; }
+    .config input {
+      font-size: 0.9rem;
+      padding: 6px 8px;
+      margin: 0 6px 8px 0;
+      width: 280px;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>auth0-spa-js · Online Access sample</h1>
+  <p>Using the local dev bundle at <code>/auth0-spa-js.development.js</code></p>
+
+  <div class="mode-bar">
+    <strong>Refresh-token mode:</strong>
+    <a id="mode-offline" href="?mode=offline">offline (default)</a>
+    <a id="mode-online" href="?mode=online">online (ORT)</a>
+    <span id="mode-note"></span>
+  </div>
+
+  <!-- Config (static files have no build step / env vars; persisted to localStorage). -->
+  <section id="config-form" class="config hidden">
+    <h2>Configuration</h2>
+    <div>
+      <input id="cfg-domain" placeholder="domain (your-tenant.auth0.com)" />
+      <input id="cfg-clientId" placeholder="client ID" />
+    </div>
+    <div>
+      <input id="cfg-audience" placeholder="login audience (DPoP-enabled API)" />
+      <button id="cfg-save">Save config</button>
+    </div>
+  </section>
+
+  <div id="controls">
+    <button id="login">Log in</button>
+    <button id="logout" class="hidden">Log out</button>
+    <button id="token-first" class="hidden">Token: first resource (MRRT)</button>
+    <button id="token-second" class="hidden">Token: second resource (MRRT)</button>
+    <button id="force-refresh" class="hidden">Force refresh (compare RT)</button>
+    <button id="session-continuity" class="hidden">Session continuity (refresh &times;2)</button>
+    <button id="revoke" class="hidden">Revoke refresh token</button>
+  </div>
+
+  <p id="status">Loading&hellip;</p>
+
+  <section id="config-error" class="hidden">
+    <h2>Configuration error</h2>
+    <pre id="config-error-json"></pre>
+  </section>
+
+  <section id="diag" class="diag">
+    <h2>Diagnostics</h2>
+    <table>
+      <tbody>
+        <tr><th>Mode (<code>refreshTokenMode</code>)</th><td id="diag-mode">&mdash;</td></tr>
+        <tr><th>Injected scope</th><td id="diag-scope">&mdash;</td></tr>
+        <tr><th>Scope mutual exclusivity</th><td id="diag-exclusivity">&mdash;</td></tr>
+        <tr><th>DPoP keypair (IndexedDB)</th><td id="diag-dpop">&mdash;</td></tr>
+        <tr><th>Refresh token (cache)</th><td id="diag-rt">&mdash;</td></tr>
+        <tr><th>Non-rotation check</th><td id="diag-rotation">&mdash;</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="profile" class="hidden">
+    <h2>User profile</h2>
+    <pre id="profile-json"></pre>
+  </section>
+
+  <section id="token-section">
+    <h2>Access token (last exchange)</h2>
+    <pre id="token-out"></pre>
+  </section>
+
+  <script>
+    // ---- Config (replaces the Vite env vars; persisted to localStorage) ----
+    var CONFIG_KEY = 'online-access-config';
+    function loadConfig() {
+      try { return JSON.parse(localStorage.getItem(CONFIG_KEY) || '{}'); }
+      catch (e) { return {}; }
+    }
+    var cfg = loadConfig();
+    var domain = cfg.domain || '';
+    var clientId = cfg.clientId || '';
+    var LOGIN_AUDIENCE = cfg.audience || '';
+
+    // Mode selected via ?mode=online|offline to test both paths without editing code.
+    var mode =
+      new URLSearchParams(window.location.search).get('mode') === 'online'
+        ? 'online'
+        : 'offline';
+
+    var RESOURCE_SERVERS = {
+      firstResourceServer: { audience: 'https://firstresourceserver/', scope: 'fs:write fs:read' },
+      secondResourceServer: { audience: 'https://secondresourceserver/', scope: 'fs:read' }
+    };
+
+    var $ = function (id) { return document.getElementById(id); };
+
+    var loginBtn = $('login');
+    var logoutBtn = $('logout');
+    var firstBtn = $('token-first');
+    var secondBtn = $('token-second');
+    var forceRefreshBtn = $('force-refresh');
+    var sessionContinuityBtn = $('session-continuity');
+    var revokeBtn = $('revoke');
+    var statusEl = $('status');
+    var profileEl = $('profile');
+    var profileJsonEl = $('profile-json');
+    var tokenOutEl = $('token-out');
+    var configErrorEl = $('config-error');
+    var configErrorJsonEl = $('config-error-json');
+
+    var diagModeEl = $('diag-mode');
+    var diagScopeEl = $('diag-scope');
+    var diagExclusivityEl = $('diag-exclusivity');
+    var diagDpopEl = $('diag-dpop');
+    var diagRtEl = $('diag-rt');
+    var diagRotationEl = $('diag-rotation');
+
+    function markModeBar() {
+      $('mode-' + mode).classList.add('active');
+      $('mode-note').textContent =
+        mode === 'online'
+          ? '→ useRefreshTokens: true + refreshTokenMode: "online" + useDpop: true'
+          : '→ useRefreshTokens: true + refreshTokenMode: "offline" (rotating RTs)';
+    }
+
+    function wireConfigForm() {
+      var form = $('config-form');
+      form.classList.remove('hidden');
+      $('cfg-domain').value = domain;
+      $('cfg-clientId').value = clientId;
+      $('cfg-audience').value = LOGIN_AUDIENCE;
+      $('cfg-save').addEventListener('click', function () {
+        localStorage.setItem(CONFIG_KEY, JSON.stringify({
+          domain: $('cfg-domain').value.trim(),
+          clientId: $('cfg-clientId').value.trim(),
+          audience: $('cfg-audience').value.trim()
+        }));
+        window.location.reload();
+      });
+    }
+
+    function createClient() {
+      // Online mode mandates useRefreshTokens + useDpop. The SDK throws
+      // InvalidConfigurationError at construction otherwise.
+      var shared = {
+        domain: domain,
+        clientId: clientId,
+        useRefreshTokensFallback: true,
+        useMrrt: true,
+        cacheLocation: 'memory'
+      };
+      if (mode === 'online') {
+        return new auth0.Auth0Client(Object.assign({}, shared, {
+          useRefreshTokens: true,
+          refreshTokenMode: 'online',
+          useDpop: true
+        }));
+      }
+      return new auth0.Auth0Client(Object.assign({}, shared, {
+        useRefreshTokens: true,
+        refreshTokenMode: 'offline',
+        useDpop: true
+      }));
+    }
+
+    async function main() {
+      markModeBar();
+      wireConfigForm();
+
+      if (!domain || !clientId) {
+        statusEl.textContent = 'Missing config. Fill in domain and client ID above and click "Save config".';
+        return;
+      }
+
+      var client;
+      try {
+        client = createClient();
+      } catch (err) {
+        // Online mode without the required options throws InvalidConfigurationError.
+        showConfigError(err);
+        return;
+      }
+
+      // Handle the redirect back from Auth0 after login.
+      if (window.location.search.indexOf('code=') !== -1 && window.location.search.indexOf('state=') !== -1) {
+        await client.handleRedirectCallback();
+        window.history.replaceState({}, document.title, window.location.pathname + '?mode=' + mode);
+      }
+
+      await render(client);
+
+      loginBtn.addEventListener('click', function () {
+        client.loginWithRedirect({
+          authorizationParams: Object.assign(
+            {
+              redirect_uri: window.location.origin + '/online-access.html?mode=' + mode,
+              scope: 'openid profile email'
+            },
+            LOGIN_AUDIENCE ? { audience: LOGIN_AUDIENCE } : {}
+          )
+        });
+      });
+
+      logoutBtn.addEventListener('click', function () {
+        client.logout({
+          logoutParams: { returnTo: window.location.origin + '/online-access.html?mode=' + mode }
+        });
+      });
+
+      firstBtn.addEventListener('click', function () { getCredentialsForResource(client, 'firstResourceServer'); });
+      secondBtn.addEventListener('click', function () { getCredentialsForResource(client, 'secondResourceServer'); });
+      forceRefreshBtn.addEventListener('click', function () { forceRefresh(client); });
+      sessionContinuityBtn.addEventListener('click', function () { sessionContinuity(client); });
+      revokeBtn.addEventListener('click', function () { revoke(client); });
+    }
+
+    function showConfigError(err) {
+      configErrorEl.classList.remove('hidden');
+      if (err && err.error === 'invalid_configuration') {
+        statusEl.textContent = 'Auth0Client construction failed (InvalidConfigurationError).';
+        configErrorJsonEl.textContent = JSON.stringify(
+          { name: 'InvalidConfigurationError', error: err.error, error_description: err.error_description, suggestion: err.suggestion },
+          null, 2
+        );
+      } else {
+        statusEl.textContent = 'Auth0Client construction failed.';
+        configErrorJsonEl.textContent = err instanceof Error ? err.name + ': ' + err.message : String(err);
+      }
+    }
+
+    // Exchanges the refresh token for an access token for a different audience (MRRT).
+    async function getCredentialsForResource(client, resourceKey) {
+      var resource = RESOURCE_SERVERS[resourceKey];
+      tokenOutEl.textContent = 'Requesting token for ' + resource.audience + ' via MRRT…';
+
+      try {
+        var detailed = await client.getTokenSilently({
+          authorizationParams: { audience: resource.audience, scope: resource.scope },
+          cacheMode: 'off',
+          detailedResponse: true
+        });
+        tokenOutEl.textContent = JSON.stringify(
+          { audience: resource.audience, requestedScope: resource.scope, response: detailed },
+          null, 2
+        );
+      } catch (err) {
+        tokenOutEl.textContent =
+          'Failed to get token for ' + resource.audience + ':\n' +
+          (err instanceof Error ? err.message : String(err)) + '\n\n' +
+          'Make sure:\n' +
+          '1. You logged in in this mode (online_access for an ORT, or offline_access).\n' +
+          '2. The resource-server API is configured in the Auth0 Dashboard and DPoP-enabled.\n' +
+          '3. `online_refresh_tokens` (tenant) and `allow_online_access` (resource server) are enabled.';
+      }
+
+      await refreshDiagnostics(client);
+    }
+
+    // Compares the cached RT before/after a forced exchange: online = unchanged, offline = rotated.
+    async function forceRefresh(client) {
+      var before = readRefreshTokenFromCache();
+      tokenOutEl.textContent = 'Forcing a refresh-token exchange…';
+
+      try {
+        await client.getTokenSilently(Object.assign(
+          { cacheMode: 'off' },
+          LOGIN_AUDIENCE ? { authorizationParams: { audience: LOGIN_AUDIENCE } } : {}
+        ));
+      } catch (err) {
+        tokenOutEl.textContent = 'Force refresh failed:\n' + (err instanceof Error ? err.message : String(err));
+        return;
+      }
+
+      var after = readRefreshTokenFromCache();
+      var unchanged = before && after && before === after;
+      var expectedUnchanged = mode === 'online';
+
+      diagRotationEl.innerHTML =
+        before == null || after == null
+          ? '<span class="bad">No refresh token found in cache (memory mode keeps the RT in the worker).</span>'
+          : unchanged
+            ? '<span class="' + (expectedUnchanged ? 'ok' : 'bad') + '">RT UNCHANGED after refresh' +
+              (expectedUnchanged ? ' ✓ (expected for online/ORT)' : ' ✗ (offline should rotate)') + '</span>'
+            : '<span class="' + (expectedUnchanged ? 'bad' : 'ok') + '">RT CHANGED after refresh' +
+              (expectedUnchanged ? ' ✗ (online ORT should NOT rotate)' : ' ✓ (expected for offline)') + '</span>';
+
+      tokenOutEl.textContent = JSON.stringify(
+        { mode: mode, refreshTokenBefore: mask(before), refreshTokenAfter: mask(after), changed: !unchanged },
+        null, 2
+      );
+
+      await refreshDiagnostics(client);
+    }
+
+    // Two back-to-back forced refreshes. In online + memory cache (the default), the RT lives
+    // only inside the Web Worker. A non-rotating ORT exchange returns no replacement token; if
+    // the worker evicts its stored ORT on that empty response, the SECOND refresh throws
+    // MissingRefreshTokenError. Refresh #1 succeeds, refresh #2 is the canary.
+    async function sessionContinuity(client) {
+      tokenOutEl.textContent = 'Refreshing twice to test session continuity…';
+
+      var opts = Object.assign(
+        { cacheMode: 'off' },
+        LOGIN_AUDIENCE ? { authorizationParams: { audience: LOGIN_AUDIENCE } } : {}
+      );
+
+      var results = [];
+      for (var attempt = 1; attempt <= 2; attempt++) {
+        try {
+          await client.getTokenSilently(opts);
+          results.push({ refresh: attempt, ok: true });
+        } catch (err) {
+          results.push({ refresh: attempt, ok: false, error: err instanceof Error ? err.message : String(err) });
+          break;
+        }
+      }
+
+      var allOk = results.every(function (r) { return r.ok; });
+      var firstFail = results.find(function (r) { return !r.ok; });
+      diagRotationEl.innerHTML = allOk
+        ? '<span class="ok">Session survived 2 refreshes ✓ (ORT preserved)</span>'
+        : '<span class="bad">Session broke on refresh #' + (firstFail && firstFail.refresh) + ' ✗ (worker evicted the ORT)</span>';
+
+      tokenOutEl.textContent = JSON.stringify({ mode: mode, results: results }, null, 2);
+
+      await refreshDiagnostics(client);
+    }
+
+    // Calls revokeRefreshToken and reports the raw outcome. Online: clears the local cache only,
+    // the ORT is NOT revoked server-side. Offline: revokes the rotating RT at the server.
+    async function revoke(client) {
+      var before = readRefreshTokenFromCache();
+      tokenOutEl.textContent = 'Revoking refresh token…';
+
+      var error;
+      try {
+        // The RT is cached under the login audience; pass it so the lookup finds the token.
+        // With no audience the SDK defaults to DEFAULT_AUDIENCE and finds nothing.
+        await client.revokeRefreshToken(LOGIN_AUDIENCE ? { audience: LOGIN_AUDIENCE } : {});
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+
+      var after = readRefreshTokenFromCache();
+
+      tokenOutEl.textContent = JSON.stringify(
+        Object.assign(
+          {
+            mode: mode,
+            note: mode === 'online'
+              ? 'Online: local cache cleared only; ORT NOT revoked server-side. Use logout() to end the session.'
+              : 'Offline: rotating refresh token revoked at the server.',
+            refreshTokenBefore: mask(before),
+            refreshTokenAfter: mask(after),
+            changed: before !== after
+          },
+          error ? { error: error } : null
+        ),
+        null, 2
+      );
+
+      await refreshDiagnostics(client);
+    }
+
+    // Reads the first refresh token from the localStorage cache (keys: `@@auth0spajs@@…`).
+    // Note: in memory/worker mode the RT lives in the worker, so this returns undefined.
+    function readRefreshTokenFromCache() {
+      for (var i = 0; i < localStorage.length; i++) {
+        var key = localStorage.key(i);
+        if (!key || key.indexOf('@@auth0spajs@@') !== 0) continue;
+        try {
+          var entry = JSON.parse(localStorage.getItem(key));
+          var rt = entry && entry.body && entry.body.refresh_token;
+          if (rt) return rt;
+        } catch (e) { /* ignore non-JSON entries */ }
+      }
+      return undefined;
+    }
+
+    function mask(token) {
+      if (!token) return token;
+      return token.length <= 12 ? token : token.slice(0, 6) + '…' + token.slice(-6) + ' (len ' + token.length + ')';
+    }
+
+    // Reflectively reads the SDK's private injected scope — diagnostics only.
+    function readInjectedScope(client) {
+      var scopeMap = client.scope;
+      if (!scopeMap) return '(unavailable)';
+      return Object.values(scopeMap).join(' | ') || '(empty)';
+    }
+
+    async function dpopKeypairPresent() {
+      return new Promise(function (resolve) {
+        var req = window.indexedDB.open('auth0-spa-js');
+        req.onerror = function () { resolve(false); };
+        req.onsuccess = function () {
+          var db = req.result;
+          if (!db.objectStoreNames.contains('keypair')) { db.close(); return resolve(false); }
+          var tx = db.transaction('keypair', 'readonly');
+          var count = tx.objectStore('keypair').count();
+          count.onsuccess = function () { resolve(count.result > 0); db.close(); };
+          count.onerror = function () { resolve(false); db.close(); };
+        };
+      });
+    }
+
+    async function refreshDiagnostics(client) {
+      diagModeEl.innerHTML = '<code>' + mode + '</code>';
+
+      var injected = readInjectedScope(client);
+      diagScopeEl.innerHTML = '<code>' + injected + '</code>';
+
+      var hasOnline = injected.indexOf('online_access') !== -1;
+      var hasOffline = injected.indexOf('offline_access') !== -1;
+      var exclusive = hasOnline !== hasOffline;
+      var correct = mode === 'online' ? hasOnline && !hasOffline : hasOffline && !hasOnline;
+      diagExclusivityEl.innerHTML = !exclusive
+        ? '<span class="bad">BOTH or NEITHER scope present ✗</span>'
+        : correct
+          ? '<span class="ok">Only ' + (mode === 'online' ? 'online_access' : 'offline_access') + ' present ✓</span>'
+          : '<span class="bad">Wrong scope for this mode ✗</span>';
+
+      var dpop = await dpopKeypairPresent();
+      diagDpopEl.innerHTML =
+        mode === 'online'
+          ? dpop
+            ? '<span class="ok">keypair present ✓ (required for online)</span>'
+            : '<span class="bad">no keypair ✗ (online requires DPoP)</span>'
+          : dpop
+            ? 'keypair present (DPoP enabled)'
+            : 'no keypair (DPoP not enabled — fine for offline)';
+
+      var rt = readRefreshTokenFromCache();
+      diagRtEl.innerHTML = rt
+        ? '<code>' + mask(rt) + '</code>'
+        : '<span class="bad">none in localStorage (memory mode keeps it in the worker)</span>';
+    }
+
+    async function render(client) {
+      var isAuthenticated = await client.isAuthenticated();
+
+      loginBtn.classList.toggle('hidden', isAuthenticated);
+      logoutBtn.classList.toggle('hidden', !isAuthenticated);
+      firstBtn.classList.toggle('hidden', !isAuthenticated);
+      secondBtn.classList.toggle('hidden', !isAuthenticated);
+      forceRefreshBtn.classList.toggle('hidden', !isAuthenticated);
+      sessionContinuityBtn.classList.toggle('hidden', !isAuthenticated);
+      revokeBtn.classList.toggle('hidden', !isAuthenticated);
+      profileEl.classList.toggle('hidden', !isAuthenticated);
+
+      if (isAuthenticated) {
+        var user = await client.getUser();
+        statusEl.textContent = 'Logged in as ' + ((user && (user.name || user.email)) || 'unknown') + ' (mode: ' + mode + ')';
+        profileJsonEl.textContent = JSON.stringify(user, null, 2);
+      } else {
+        statusEl.textContent = 'You are not logged in. (mode: ' + mode + ')';
+        profileJsonEl.textContent = '';
+      }
+
+      await refreshDiagnostics(client);
+    }
+
+    main().catch(function (err) {
+      statusEl.textContent = 'Error: ' + (err instanceof Error ? err.message : String(err));
+      console.error(err);
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
  ## Summary
Adds support for **Online Refresh Tokens (ORTs)** — non-rotating refresh tokens bound to the Auth0 session lifetime (unlike the existing rotating offline refresh tokens).
                                                                                                                                       
Opt in via the new `refreshTokenMode` option:                                                
                                                    
  ```ts                                                                                                                                        
  const auth0 = await createAuth0Client({
    domain,                                                                                                                                    
    clientId,                                                                                  
    useRefreshTokens: true,                         
    refreshTokenMode: RefreshTokenMode.Online, // defaults to Offline
    useDpop: true                              // required for online access
  });
  ```

  `refreshTokenMode` defaults to `RefreshTokenMode.Offline`, so **existing apps are unaffected**. 

  ## What it does

  - Injects `online_access` (instead of `offline_access`) and routes renewal through the refresh-token grant.                                  
  - Reuses the same ORT on every refresh (non-rotating).
  - Requires `useDpop: true`, enforced at compile time (typed overloads) and runtime (`InvalidConfigurationError`).                            
                                                                                               
  Requires `online_refresh_tokens` (tenant) and `allow_online_access` (resource server, on by default). See                                    
  [EXAMPLES.md](./EXAMPLES.md#online-access-online-refresh-tokens).