### PR TITLE
refactor: centralise MFA context storage across all token grant types

### DIFF
--- a/__tests__/Auth0Client/exchangeToken.test.ts
+++ b/__tests__/Auth0Client/exchangeToken.test.ts
@@ -3,6 +3,7 @@ import { MessageChannel } from 'worker_threads';
 import * as utils from '../../src/utils';
 import * as scope from '../../src/scope';
 import * as api from '../../src/api';
+import { MfaRequiredError } from '../../src/errors';
 
 // @ts-ignore
 
@@ -749,6 +750,59 @@ describe('Auth0Client', () => {
 
       expect(capturedRequestOptions.organization).toEqual('org_12345');
     });
+
+    it('stores MFA context and re-throws MfaRequiredError', async () => {
+      const auth0 = setup({
+        authorizationParams: {
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        }
+      });
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'Multifactor authentication required',
+          mfa_token: 'mfa-token-123',
+          mfa_requirements: { challenge: [{ type: 'otp' }] }
+        })
+      );
+
+      const setMFAAuthDetailsSpy = jest.spyOn(auth0.mfa, 'setMFAAuthDetails');
+
+      await expect(
+        auth0.loginWithCustomTokenExchange({
+          subject_token: 'external_token_value',
+          subject_token_type: 'urn:acme:legacy-system-token',
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      ).rejects.toThrow(MfaRequiredError);
+
+      expect(setMFAAuthDetailsSpy).toHaveBeenCalledWith(
+        'mfa-token-123',
+        expect.stringContaining('openid profile'),
+        'https://api.example.com',
+        { challenge: [{ type: 'otp' }] }
+      );
+    });
+
+    it('should re-throw non-MFA errors without storing MFA context', async () => {
+      const auth0 = await localSetup();
+
+      const genericError = new Error('invalid_grant');
+      auth0['_requestToken'] = jest.fn().mockRejectedValue(genericError);
+      const setMFAAuthDetailsSpy = jest.spyOn(auth0.mfa, 'setMFAAuthDetails');
+
+      await expect(
+        auth0.loginWithCustomTokenExchange({
+          subject_token: 'external_token_value',
+          subject_token_type: 'urn:acme:legacy-system-token'
+        })
+      ).rejects.toThrow('invalid_grant');
+
+      expect(setMFAAuthDetailsSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('customTokenExchange()', () => {
@@ -936,6 +990,42 @@ describe('Auth0Client', () => {
       });
 
       expect(mockVerify).not.toHaveBeenCalled();
+    });
+
+    it('stores MFA context and re-throws MfaRequiredError', async () => {
+      const auth0 = setup({
+        authorizationParams: {
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        }
+      });
+
+      jest.spyOn(api, 'oauthToken').mockRejectedValue(
+        new MfaRequiredError(
+          'mfa_required',
+          'Multifactor authentication required',
+          'mfa-token-123',
+          { challenge: [{ type: 'otp' }] }
+        )
+      );
+
+      const setMFAAuthDetailsSpy = jest.spyOn(auth0.mfa, 'setMFAAuthDetails');
+
+      await expect(
+        auth0.customTokenExchange({
+          subject_token: 'external_token',
+          subject_token_type: 'urn:acme:legacy-token',
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      ).rejects.toThrow(MfaRequiredError);
+
+      expect(setMFAAuthDetailsSpy).toHaveBeenCalledWith(
+        'mfa-token-123',
+        expect.stringContaining('openid profile'),
+        'https://api.example.com',
+        { challenge: [{ type: 'otp' }] }
+      );
     });
   });
 

--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -50,7 +50,7 @@ import {
   INVALID_REFRESH_TOKEN_ERROR_MESSAGE,
   USER_BLOCKED_ERROR_MESSAGE
 } from '../../src/constants';
-import { GenericError } from '../../src/errors';
+import { GenericError, MfaRequiredError } from '../../src/errors';
 import {
   buildGetTokenSilentlyLockKey,
   buildIframeLockKey
@@ -2593,6 +2593,41 @@ describe('Auth0Client', () => {
       ).rejects.toThrow(USER_BLOCKED_ERROR_MESSAGE);
 
       expect(auth0.logout).toHaveBeenCalledWith({ openUrl: false });
+    });
+
+    it('when using Refresh Tokens and mfa_required is returned, stores MFA context and re-throws MfaRequiredError', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        authorizationParams: {
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        }
+      });
+
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'Multifactor authentication required',
+          mfa_token: 'mfa-token-123',
+          mfa_requirements: { challenge: [{ type: 'otp' }] }
+        })
+      );
+
+      const setMFAAuthDetailsSpy = jest.spyOn(auth0.mfa, 'setMFAAuthDetails');
+
+      await expect(
+        auth0.getTokenSilently({ cacheMode: 'off' })
+      ).rejects.toThrow(MfaRequiredError);
+
+      expect(setMFAAuthDetailsSpy).toHaveBeenCalledWith(
+        'mfa-token-123',
+        'openid profile offline_access',
+        'https://api.example.com',
+        { challenge: [{ type: 'otp' }] }
+      );
     });
 
     it('when using Refresh Tokens and fallback fails, ensure the user is logged out', async () => {

--- a/__tests__/Auth0Client/handleRedirectCallback.test.ts
+++ b/__tests__/Auth0Client/handleRedirectCallback.test.ts
@@ -30,7 +30,7 @@ import {
 } from '../constants';
 
 import { DEFAULT_AUTH0_CLIENT } from '../../src/constants';
-import { Auth0Client, ConnectError, GenericError } from '../../src';
+import { Auth0Client, ConnectError, GenericError, MfaRequiredError } from '../../src';
 import { CompleteResponse } from '../../src/myaccount';
 
 jest.mock('es-cookie');
@@ -321,6 +321,34 @@ describe('Auth0Client', () => {
 
       // should not throw
       await auth0.handleRedirectCallback();
+    });
+
+    it('should re-throw MfaRequiredError without storing MFA context for authorization_code grant', async () => {
+      // MFA for redirect/popup flows is handled by Universal Login during the
+      // authorization phase — mfa_required should never come from the token
+      // endpoint here, but if it does the SDK must not store MFA context.
+      const auth0 = setup();
+      const setMFAAuthDetailsSpy = jest.spyOn(auth0.mfa, 'setMFAAuthDetails');
+
+      await expect(
+        loginWithRedirect(
+          auth0,
+          {},
+          {
+            token: {
+              success: false,
+              response: {
+                error: 'mfa_required',
+                error_description: 'Multifactor authentication required',
+                mfa_token: 'mfa-token-123',
+                mfa_requirements: { challenge: [{ type: 'otp' }] }
+              }
+            }
+          }
+        )
+      ).rejects.toThrow(MfaRequiredError);
+
+      expect(setMFAAuthDetailsSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/Auth0Client/requestTokenForPasskey.test.ts
+++ b/__tests__/Auth0Client/requestTokenForPasskey.test.ts
@@ -2,6 +2,7 @@ import { verify } from '../../src/jwt';
 import { MessageChannel } from 'worker_threads';
 import * as utils from '../../src/utils';
 import * as scope from '../../src/scope';
+import { MfaRequiredError } from '../../src/errors';
 
 import { fetchResponse, setupFn } from './helpers';
 
@@ -280,6 +281,36 @@ describe('Auth0Client', () => {
         error: 'invalid_grant',
         error_description: 'Auth session has expired'
       });
+    });
+
+    it('stores MFA context and re-throws MfaRequiredError', async () => {
+      const auth0 = setup();
+      const setMFAAuthDetailsSpy = jest.spyOn(auth0.mfa, 'setMFAAuthDetails');
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'Multifactor authentication required',
+          mfa_token: 'mfa-token-123',
+          mfa_requirements: { challenge: [{ type: 'otp' }] }
+        })
+      );
+
+      await expect(
+        auth0._requestTokenForPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: TEST_CREDENTIAL as any,
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      ).rejects.toThrow(MfaRequiredError);
+
+      expect(setMFAAuthDetailsSpy).toHaveBeenCalledWith(
+        'mfa-token-123',
+        'openid profile email',
+        'https://api.example.com',
+        { challenge: [{ type: 'otp' }] }
+      );
     });
 
     it('sends JSON body to /oauth/token endpoint (not form-encoded)', async () => {

--- a/__tests__/mfa/MfaApiClient.test.ts
+++ b/__tests__/mfa/MfaApiClient.test.ts
@@ -45,6 +45,7 @@ import {
   MfaChallengeError as Auth0JsMfaChallengeError
 } from '@auth0/auth0-auth-js';
 import type { Authenticator } from '../../src/mfa/types';
+import { MfaRequiredError } from '../../src/errors';
 
 describe('MfaApiClient', () => {
   let mfaClient: MfaApiClient;
@@ -97,31 +98,41 @@ describe('MfaApiClient', () => {
 
       await expect(
         mfaClient.getAuthenticators(mfaToken)
-      ).rejects.toThrow('challengeType is required');
+      ).rejects.toThrow('MFA context not found for this MFA token');
     });
 
-    it('should throw error when context has no mfaRequirements', async () => {
+    it('should return all authenticators when context has no mfaRequirements (global MFA policy)', async () => {
       const mfaToken = 'test-mfa-token';
+      const mockData: Authenticator[] = [
+        { id: 'otp|dev_123', authenticatorType: 'otp', active: true, type: 'otp' },
+        { id: 'email|dev_789', authenticatorType: 'oob', active: true, type: 'email' }
+      ];
 
-      // Set up context without mfaRequirements
+      // Global MFA policy: context exists but mfaRequirements is absent
       mfaClient.setMFAAuthDetails(mfaToken, 'openid profile', 'https://api.example.com');
+      mockAuthJsMfaClient.listAuthenticators.mockResolvedValue(mockData);
 
-      await expect(
-        mfaClient.getAuthenticators(mfaToken)
-      ).rejects.toThrow('challengeType is required');
+      const result = await mfaClient.getAuthenticators(mfaToken);
+
+      expect(result).toEqual(mockData);
     });
 
-    it('should throw error when context has empty challenge array', async () => {
+    it('should return all authenticators when context has empty challenge array (global MFA policy)', async () => {
       const mfaToken = 'test-mfa-token';
+      const mockData: Authenticator[] = [
+        { id: 'otp|dev_123', authenticatorType: 'otp', active: true, type: 'otp' },
+        { id: 'email|dev_789', authenticatorType: 'oob', active: true, type: 'email' }
+      ];
 
-      // Set up context with empty challenge array
+      // Global MFA policy: challenge array is empty, no type constraints
       mfaClient.setMFAAuthDetails(mfaToken, 'openid profile', 'https://api.example.com', {
         challenge: []
       });
+      mockAuthJsMfaClient.listAuthenticators.mockResolvedValue(mockData);
 
-      await expect(
-        mfaClient.getAuthenticators(mfaToken)
-      ).rejects.toThrow('challengeType is required');
+      const result = await mfaClient.getAuthenticators(mfaToken);
+
+      expect(result).toEqual(mockData);
     });
 
     it('should filter authenticators by single challenge type', async () => {
@@ -616,6 +627,32 @@ describe('MfaApiClient', () => {
       await expect(mfaClient.verify(params)).rejects.toThrow(
         'MFA context not found for this MFA token'
       );
+    });
+
+    it('re-throws MfaRequiredError without storing context at the MfaApiClient layer', async () => {
+      // MFA context storage for mfa_required is centralised in Auth0Client._requestToken.
+      // MfaApiClient.verify must not intercept the error — it re-throws so the central
+      // handler (which runs before the error reaches this layer) has already stored context.
+      const mfaToken = 'token123';
+
+      mfaClient.setMFAAuthDetails(mfaToken, 'openid profile', 'https://api.example.com');
+
+      // Spy after context setup so we only track calls triggered by verify() itself.
+      const setMFAAuthDetailsSpy = jest.spyOn(mfaClient, 'setMFAAuthDetails');
+
+      const mfaError = new MfaRequiredError(
+        'mfa_required',
+        'Multifactor authentication required',
+        'new-mfa-token-456',
+        { challenge: [{ type: 'otp' }] }
+      );
+      mockAuth0Client._requestTokenForMfa.mockRejectedValue(mfaError);
+
+      await expect(
+        mfaClient.verify({ mfaToken, otp: '123456' })
+      ).rejects.toThrow(mfaError);
+
+      expect(setMFAAuthDetailsSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -3,6 +3,7 @@ jest.mock('@auth0/auth0-auth-js', () => ({
 }));
 
 import { PasskeyApiClient } from '../../src/passkey/PasskeyApiClient';
+import { MfaRequiredError } from '../../src/errors';
 
 const TEST_AUTH_SESSION = 'auth-session-abc123';
 
@@ -409,6 +410,40 @@ describe('PasskeyApiClient', () => {
       expect(credential.response.clientDataJSON).toMatch(/^[A-Za-z0-9_-]+$/);
       expect(credential.response.attestationObject).toMatch(/^[A-Za-z0-9_-]+$/);
     });
+
+    it('should re-throw MfaRequiredError', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create: jest.fn().mockResolvedValue(createMockPublicKeyCredential('create')) },
+        configurable: true
+      });
+
+      const mfaError = new MfaRequiredError(
+        'mfa_required',
+        'Multifactor authentication required',
+        'mfa-token-123',
+        { challenge: [{ type: 'otp' }] }
+      );
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(mfaError);
+
+      await expect(
+        passkeyClient.signup({
+          email: 'user@example.com',
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      ).rejects.toThrow(mfaError);
+    });
   });
 
   describe('login', () => {
@@ -629,6 +664,37 @@ describe('PasskeyApiClient', () => {
       expect(credential.response.authenticatorData).toMatch(/^[A-Za-z0-9_-]+$/);
       expect(credential.response.signature).toMatch(/^[A-Za-z0-9_-]+$/);
       expect(credential.response.userHandle).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('should re-throw MfaRequiredError', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get: jest.fn().mockResolvedValue(createMockPublicKeyCredential('get')) },
+        configurable: true
+      });
+
+      const mfaError = new MfaRequiredError(
+        'mfa_required',
+        'Multifactor authentication required',
+        'mfa-token-456',
+        { enroll: [{ type: 'otp' }] }
+      );
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(mfaError);
+
+      await expect(
+        passkeyClient.login({
+          scope: 'openid profile',
+          audience: 'https://api.example.com'
+        })
+      ).rejects.toThrow(mfaError);
     });
   });
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1635,6 +1635,8 @@ export class Auth0Client {
     }
   }
 
+  // Central MFA context store — called from _requestToken for all non-authorization_code
+  // grants (including via _requestTokenForMfa) and from customTokenExchange.
   private _storeMfaContext(e: unknown, scope?: string, audience?: string): void {
     if (e instanceof MfaRequiredError) {
       this.mfa.setMFAAuthDetails(e.mfa_token, scope, audience, e.mfa_requirements);

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1548,15 +1548,6 @@ export class Auth0Client {
         }
       }
 
-      if (e instanceof MfaRequiredError) {
-        this.mfa.setMFAAuthDetails(
-          e.mfa_token,
-          options.authorizationParams?.scope,
-          options.authorizationParams?.audience,
-          e.mfa_requirements
-        );
-      }
-
       throw e;
     }
   }
@@ -1644,6 +1635,12 @@ export class Auth0Client {
     }
   }
 
+  private _storeMfaContext(e: unknown, scope?: string, audience?: string): void {
+    if (e instanceof MfaRequiredError) {
+      this.mfa.setMFAAuthDetails(e.mfa_token, scope, audience, e.mfa_requirements);
+    }
+  }
+
   private async _requestToken(
     options:
       | PKCERequestTokenOptions
@@ -1653,57 +1650,66 @@ export class Auth0Client {
     additionalParameters?: RequestTokenAdditionalParameters
   ) {
     const { nonceIn, organization, scopesToRequest } = additionalParameters || {};
-    const authResult = await oauthToken(
-      {
-        baseUrl: this.domainUrl,
-        client_id: this.options.clientId,
-        auth0Client: this.options.auth0Client,
-        useFormData: this.options.useFormData,
-        timeout: this.httpTimeoutMs,
-        useMrrt: this.options.useMrrt,
-        dpop: this.dpop,
-        ...options,
-        scope: scopesToRequest || options.scope,
-      },
-      this.worker
-    );
+    try {
+      const authResult = await oauthToken(
+        {
+          baseUrl: this.domainUrl,
+          client_id: this.options.clientId,
+          auth0Client: this.options.auth0Client,
+          useFormData: this.options.useFormData,
+          timeout: this.httpTimeoutMs,
+          useMrrt: this.options.useMrrt,
+          dpop: this.dpop,
+          ...options,
+          scope: scopesToRequest || options.scope,
+        },
+        this.worker
+      );
 
-    const decodedToken = await this._verifyIdToken(
-      authResult.id_token,
-      nonceIn,
-      organization
-    );
+      const decodedToken = await this._verifyIdToken(
+        authResult.id_token,
+        nonceIn,
+        organization
+      );
 
-    // When logging in with authorization_code, check if a different user is authenticating
-    // If so, clear the cache to prevent tokens from multiple users coexisting
-    if (options.grant_type === 'authorization_code') {
-      const existingIdToken = await this._getIdTokenFromCache();
+      // When logging in with authorization_code, check if a different user is authenticating
+      // If so, clear the cache to prevent tokens from multiple users coexisting
+      if (options.grant_type === 'authorization_code') {
+        const existingIdToken = await this._getIdTokenFromCache();
 
-      if (existingIdToken?.decodedToken?.claims?.sub &&
-        existingIdToken.decodedToken.claims.sub !== decodedToken.claims.sub) {
-        // Different user detected - clear cached tokens
-        await this.cacheManager.clear(this.options.clientId);
-        this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
+        if (existingIdToken?.decodedToken?.claims?.sub &&
+          existingIdToken.decodedToken.claims.sub !== decodedToken.claims.sub) {
+          // Different user detected - clear cached tokens
+          await this.cacheManager.clear(this.options.clientId);
+          this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
+        }
       }
+
+      await this._saveEntryInCache({
+        ...authResult,
+        decodedToken,
+        scope: options.scope,
+        audience: options.audience || DEFAULT_AUDIENCE,
+        ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null),
+        client_id: this.options.clientId
+      });
+
+      this.cookieStorage.save(this.isAuthenticatedCookieName, true, {
+        daysUntilExpire: this.sessionCheckExpiryDays,
+        cookieDomain: this.options.cookieDomain
+      });
+
+      this._processOrgHint(organization || decodedToken.claims.org_id);
+
+      return { ...authResult, decodedToken };
+    } catch (e) {
+      // Exclude authorization_code: MFA is handled by Universal Login during the
+      // authorization phase for redirect/popup flows, not via a token endpoint error.
+      if (options.grant_type !== 'authorization_code') {
+        this._storeMfaContext(e, scopesToRequest || options.scope, options.audience);
+      }
+      throw e;
     }
-
-    await this._saveEntryInCache({
-      ...authResult,
-      decodedToken,
-      scope: options.scope,
-      audience: options.audience || DEFAULT_AUDIENCE,
-      ...(authResult.scope ? { oauthTokenScope: authResult.scope } : null),
-      client_id: this.options.clientId
-    });
-
-    this.cookieStorage.save(this.isAuthenticatedCookieName, true, {
-      daysUntilExpire: this.sessionCheckExpiryDays,
-      cookieDomain: this.options.cookieDomain
-    });
-
-    this._processOrgHint(organization || decodedToken.claims.org_id);
-
-    return { ...authResult, decodedToken };
   }
 
   /*
@@ -1829,25 +1835,31 @@ export class Auth0Client {
   async customTokenExchange(
     options: CustomTokenExchangeOptions
   ): Promise<TokenEndpointResponse> {
-    const result = await oauthToken(
-      {
-        ...this._buildTokenExchangeParams(options),
-        baseUrl: this.domainUrl,
-        client_id: this.options.clientId,
-        auth0Client: this.options.auth0Client,
-        useFormData: this.options.useFormData,
-        timeout: this.httpTimeoutMs,
-        dpop: this.dpop,
-      },
-      this.worker,
-      true // skipTokenStorage — when using a worker, refresh_token is discarded inside it
-    );
+    const params = this._buildTokenExchangeParams(options);
+    try {
+      const result = await oauthToken(
+        {
+          ...params,
+          baseUrl: this.domainUrl,
+          client_id: this.options.clientId,
+          auth0Client: this.options.auth0Client,
+          useFormData: this.options.useFormData,
+          timeout: this.httpTimeoutMs,
+          dpop: this.dpop,
+        },
+        this.worker,
+        true // skipTokenStorage — when using a worker, refresh_token is discarded inside it
+      );
 
-    if (result.id_token) {
-      await this._verifyIdToken(result.id_token, undefined, options.organization);
+      if (result.id_token) {
+        await this._verifyIdToken(result.id_token, undefined, options.organization);
+      }
+
+      return result;
+    } catch (e) {
+      this._storeMfaContext(e, params.scope, params.audience);
+      throw e;
     }
-
-    return result;
   }
 
   /**

--- a/src/mfa/MfaApiClient.ts
+++ b/src/mfa/MfaApiClient.ts
@@ -115,27 +115,30 @@ export class MfaApiClient {
    * ```
    */
   public async getAuthenticators(mfaToken: string): Promise<Authenticator[]> {
-    // Auto-resolve challenge types from stored context
     const context = this.contextManager.get(mfaToken);
 
-    // Single validation check for context and challenge types
-    if (!context?.mfaRequirements?.challenge || context.mfaRequirements.challenge.length === 0) {
+    if (!context) {
       throw new MfaListAuthenticatorsError(
         'invalid_request',
-        'challengeType is required and must contain at least one challenge type, please check mfa_required error payload'
+        'MFA context not found for this MFA token'
       );
     }
 
-    const challengeTypes = context.mfaRequirements.challenge.map(
+    // step-up policy: challenge types are present, filter to only accepted types
+    // global MFA policy: challenge types are absent, all authenticators are valid
+    const challengeTypes = context.mfaRequirements?.challenge?.map(
       c => c.type
-    ) as ChallengeType[];
+    ) as ChallengeType[] | undefined;
 
     try {
       const allAuthenticators = await this.authJsMfaClient.listAuthenticators({
         mfaToken
       });
 
-      // Filter authenticators by challenge types from context
+      if (!challengeTypes || challengeTypes.length === 0) {
+        return allAuthenticators;
+      }
+
       return allAuthenticators.filter(auth => {
         if (!auth.type) return false;
         return challengeTypes.includes(auth.type as ChallengeType);

--- a/src/mfa/MfaApiClient.ts
+++ b/src/mfa/MfaApiClient.ts
@@ -25,7 +25,7 @@ import {
   MfaVerifyError,
   MfaEnrollmentFactorsError
 } from './errors';
-import { MfaRequirements, MfaRequiredError } from '../errors';
+import { MfaRequirements } from '../errors';
 import { MfaContextManager } from './MfaContextManager';
 
 /**
@@ -406,14 +406,7 @@ export class MfaApiClient {
 
       return result;
     } catch (error: unknown) {
-      if (error instanceof MfaRequiredError) {
-        this.setMFAAuthDetails(
-          error.mfa_token,
-          scope,
-          audience,
-          error.mfa_requirements
-        );
-      } else if (error instanceof MfaVerifyError) {
+      if (error instanceof MfaVerifyError) {
         throw new MfaVerifyError(
           error.error,
           error.error_description

--- a/src/mfa/MfaApiClient.ts
+++ b/src/mfa/MfaApiClient.ts
@@ -415,6 +415,7 @@ export class MfaApiClient {
           error.error_description
         );
       }
+      // MfaRequiredError is handled upstream in Auth0Client._requestToken before reaching here.
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- Moves MFA context storage out of individual call sites into `_requestToken` so any grant type that receives `mfa_required` from the token endpoint automatically stores MFA context
- Extracts `_storeMfaContext` private helper to avoid duplicating the logic, used by `_requestToken` and `customTokenExchange`
- Adds MFA context storage to `customTokenExchange` which bypasses `_requestToken` by design (no session side effects) but still needs to store context so `mfa.verify()` works
- Fixes scope stored in MFA context to use `scopesToRequest || options.scope` to ensure correctness in the MRRT case where the token endpoint receives a broader cached scope than what was requested
- Fixes `customTokenExchange` to store the resolved scope and audience from `_buildTokenExchangeParams` in MFA context rather than the raw caller values — without this, a caller that omits `audience` would store `undefined` even though the request used `authorizationParams.audience`
- Removes redundant `MfaRequiredError` handling from `MfaApiClient.verify` which was storing MFA context a second time with the same values, now handled centrally by `_requestToken`
- Guards `authorization_code` grant since MFA is handled by Universal Login during the authorization phase, not via a token endpoint error

## Test plan

- [x] `requestTokenForPasskey.test.ts` - passkey grant stores MFA context and re-throws
- [x] `getTokenSilently.test.ts` - refresh token grant stores MFA context and re-throws
- [x] `handleRedirectCallback.test.ts` - `authorization_code` grant does not store MFA context
- [x] `exchangeToken.test.ts` - `loginWithCustomTokenExchange` stores MFA context end-to-end via real fetch mock (previously only tested re-throw via `_requestToken` mock)
- [x] `exchangeToken.test.ts` - `customTokenExchange` stores MFA context and re-throws
- [x] `PasskeyApiClient.test.ts` - `MfaRequiredError` is re-thrown from signup/login