### PR TITLE
ci: enforce conventional commits format on PR titles 

### DIFF
--- a/.github/actions/lint-pr-title/action.yml
+++ b/.github/actions/lint-pr-title/action.yml
@@ -1,0 +1,8 @@
+name: lint-pr-title
+description: Ensure PR titles match the Conventional Commits Specification (https://www.conventionalcommits.org/).
+runs:
+  using: 'node24'
+  main: 'src/index.js'
+branding:
+  icon: 'shield'
+  color: 'green'

--- a/.github/actions/lint-pr-title/package.json
+++ b/.github/actions/lint-pr-title/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@auth0/lint-pr-title",
+  "version": "1.0.0",
+  "description": "Lint PR titles with commitlint",
+  "main": "src/index.js",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@actions/core": "^3.0.0",
+    "@actions/github": "^9.0.0",
+    "@commitlint/format": "^20.0.0",
+    "@commitlint/lint": "^20.0.0",
+    "@commitlint/load": "^20.1.0"
+  }
+}

--- a/.github/actions/lint-pr-title/src/index.js
+++ b/.github/actions/lint-pr-title/src/index.js
@@ -1,0 +1,63 @@
+import { default as load } from '@commitlint/load';
+import { default as lint } from '@commitlint/lint';
+import { default as format } from '@commitlint/format';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+async function run() {
+  try {
+    // 1. Get the pull request title
+    const prTitle = github.context.payload.pull_request?.title;
+
+    if (!prTitle) {
+      core.setFailed('⛔️ Could not get pull request title. This action should only be run on a pull_request event.');
+      return;
+    }
+
+    core.info(`📝 Validating PR Title: "${prTitle}"`);
+
+    // 2. Load the commitlint configuration from the repository
+    const config = await load();
+    core.info('✅ Loaded commitlint configuration successfully.');
+
+    // 3. Lint the pull request title
+    const result = await lint(prTitle, config.rules, {
+      defaultIgnores: config.defaultIgnores,
+      helpUrl: config.helpUrl,
+    });
+
+    // 4. Report the results
+    if (result.valid) {
+      core.info('✅ PR title is valid.');
+    } else {
+      const errors = format({ results: [result] }, { color: false }).trimEnd();
+      const validTypes = config.rules['type-enum']?.[2]?.join(', ');
+      const sep = '─'.repeat(49);
+      const details = [
+        errors,
+        '',
+        sep,
+        ' Expected format:  <type>(<optional scope>): <subject>',
+        ...(validTypes ? ['', ` Valid types:  ${validTypes}`] : []),
+        '',
+        ' Examples:',
+        '   feat: add login with passkeys',
+        '   fix(cache): correct token expiry edge case',
+        '   ci: add PR title linting',
+        '',
+        ' Learn more: https://www.conventionalcommits.org',
+        sep,
+      ].join('\n');
+      core.info(details);
+      core.setFailed(`PR title "${prTitle}" does not follow the Conventional Commits format.`);
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(`⛔️ Action failed with error: ${error.message}`);
+    } else {
+      core.setFailed('⛔️ An unknown error occurred.');
+    }
+  }
+}
+
+run();

--- a/.github/actions/lint-pr-title/src/index.js
+++ b/.github/actions/lint-pr-title/src/index.js
@@ -17,7 +17,13 @@ async function run() {
     core.info(`📝 Validating PR Title: "${prTitle}"`);
 
     // 2. Load the commitlint configuration from the repository
-    const config = await load();
+    const config = await load({}, { file: 'commitlint.config.mjs', cwd: process.cwd() });
+
+    if (!config.rules || Object.keys(config.rules).length === 0) {
+      core.setFailed('⛔️ No commitlint rules loaded. Is commitlint.config.mjs present at the repo root?');
+      return;
+    }
+
     core.info('✅ Loaded commitlint configuration successfully.');
 
     // 3. Lint the pull request title

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,37 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+permissions:
+  pull-requests: read
+
+env:
+  NODE_VERSION: 24
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  lint-title:
+    name: Lint PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install action dependencies
+        run: npm install
+        working-directory: .github/actions/lint-pr-title
+
+      - name: Lint PR Title
+        uses: ./.github/actions/lint-pr-title

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,7 +7,7 @@ on:
       - edited
 
 permissions:
-  pull-requests: read
+  contents: read
 
 env:
   NODE_VERSION: 24
@@ -30,7 +30,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install action dependencies
-        run: npm install
+        run: npm install --ignore-scripts
         working-directory: .github/actions/lint-pr-title
 
       - name: Lint PR Title

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,24 @@
+export default {
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'chore',
+        'build',
+        'refactor',
+        'test',
+        'ci',
+        'perf',
+        'revert',
+      ],
+    ],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-empty': [2, 'never'],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+  },
+};


### PR DESCRIPTION
## Summary

- Adds a `lint-pr-title` local action to validate PR titles against the Conventional Commits specification using commitlint
- Adds `commitlint.config.mjs` at the repo root with inline rules (no external `extends` dependency)
- Adds `.github/workflows/lint-pr-title.yml` triggered on `pull_request` (works for forks on public repos without needing elevated permissions)
- Action runs on Node 24 with ESM modules

## Test plan

- [x] Open a PR with an invalid title (e.g. `my change`) and verify the check fails
- [x] Open a PR with a valid title (e.g. `fix: correct token expiry edge case`) and verify the check passes
- [ ] Verify the check runs on PRs from forks