### PR TITLE
feat: enforce IPSIE session_expiry ceiling on local session lifetime

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -14,6 +14,7 @@
 - [Multi-Factor Authentication (MFA)](#multi-factor-authentication-mfa)
 - [Step-Up Authentication](#step-up-authentication)
 - [MyAccount API](#myaccount-api)
+- [Session Expiry from Upstream IdP (IPSIE)](#session-expiry-from-upstream-idp-ipsie)
 
 ## Logging Out
 
@@ -1871,3 +1872,71 @@ try {
 
 > [!IMPORTANT]
 > `interactiveErrorHandler` only affects `getTokenSilently()`. Other methods like `loginWithPopup()` and `loginWithRedirect()` are not affected.
+
+## Session Expiry from Upstream IdP (IPSIE)
+
+### Overview
+
+When using Okta or OIDC enterprise connections configured with `id_token_session_expiry_supported: true`, Auth0 includes a `session_expiry` claim in the ID token. This represents the latest moment the upstream identity provider considers the session valid — an absolute Unix timestamp in seconds.
+
+You can also emit this claim via a Post-Login Action:
+
+```js
+exports.onExecutePostLogin = async (event, api) => {
+  // IMPORTANT: value must be Unix seconds, not milliseconds.
+  // Wrong:  Date.now() + 7200000          — milliseconds, throws invalid_token at login
+  // Correct: Math.floor(Date.now() / 1000) + 7200  — 2-hour ceiling
+  api.idToken.setCustomClaim('session_expiry', Math.floor(Date.now() / 1000) + 7200);
+};
+```
+
+### Prerequisites
+
+- Okta or OIDC enterprise connection with `id_token_session_expiry_supported: true`, **or**
+- A Post-Login Action that sets `session_expiry` as a Unix timestamp in seconds
+
+### Behavior
+
+Once the ceiling is reached (with a 30-second clock-skew tolerance), the SDK tears down the local session. No network call is made past the ceiling.
+
+```ts
+// Before ceiling is reached
+const user = await auth0.getUser();            // returns the user object
+const token = await auth0.getTokenSilently();  // returns the access token
+
+// After ceiling is reached
+const user = await auth0.getUser();            // returns undefined
+const token = await auth0.getTokenSilently();  // returns undefined — no network call made
+const claims = await auth0.getIdTokenClaims(); // returns undefined
+const isAuth = await auth0.isAuthenticated();  // returns false
+```
+
+The ceiling is pinned to the value set at initial login. Silent token refreshes cannot extend it.
+
+### Upgrading Existing Apps
+
+If your app assumes `getUser()` or `getTokenSilently()` always return a value for a logged-in user, add null checks to handle the breach gracefully:
+
+```ts
+const token = await auth0.getTokenSilently();
+
+if (!token) {
+  await auth0.loginWithRedirect();
+  return;
+}
+
+fetch('/api/data', {
+  headers: { Authorization: `Bearer ${token}` }
+});
+```
+
+```ts
+const user = await auth0.getUser();
+
+if (!user) {
+  await auth0.loginWithRedirect();
+  return;
+}
+
+console.log(`Hello, ${user.name}`);
+```

--- a/__tests__/Auth0Client/session-expiry.test.ts
+++ b/__tests__/Auth0Client/session-expiry.test.ts
@@ -1,0 +1,507 @@
+import { verify } from '../../src/jwt';
+import { MessageChannel } from 'worker_threads';
+import * as utils from '../../src/utils';
+import * as scope from '../../src/scope';
+import { expect } from '@jest/globals';
+
+import * as esCookie from 'es-cookie';
+// @ts-ignore — resolved to the test mock via jest.mock() below
+import TokenWorker from '../../src/worker/token.worker';
+
+import { GenericError } from '../../src/errors';
+import {
+  fetchResponse,
+  loginWithPopupFn,
+  loginWithRedirectFn,
+  setupFn
+} from './helpers';
+import {
+  TEST_ACCESS_TOKEN,
+  TEST_CLIENT_ID,
+  TEST_CODE_CHALLENGE,
+  TEST_ID_TOKEN,
+  TEST_REFRESH_TOKEN,
+  TEST_TOKEN_TYPE,
+  nowSeconds
+} from '../constants';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue(TEST_CODE_CHALLENGE);
+
+const setup = setupFn(mockVerify);
+const loginWithRedirect = loginWithRedirectFn(mockWindow, mockFetch);
+const loginWithPopup = loginWithPopupFn(mockWindow, mockFetch);
+
+describe('Auth0Client', () => {
+  const oldWindowLocation = window.location;
+
+  beforeEach(() => {
+    delete window.location;
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: {
+          configurable: true,
+          value: jest.fn()
+        }
+      }
+    ) as Location;
+
+    mockWindow.open = jest.fn();
+    mockWindow.addEventListener = jest.fn();
+    mockWindow.removeEventListener = jest.fn();
+
+    mockWindow.crypto = {
+      subtle: { digest: () => 'foo' },
+      getRandomValues() {
+        return '123';
+      }
+    };
+
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+
+    jest.spyOn(scope, 'getUniqueScopes');
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+    window.location = oldWindowLocation;
+  });
+
+  describe('session_expiry', () => {
+    describe('login-time validation', () => {
+      it('throws if session_expiry equals iat', async () => {
+        const iat = nowSeconds();
+        const auth0 = setup({}, { iat, session_expiry: iat });
+
+        const error = await loginWithRedirect(auth0).catch(e => e);
+        expect(error).toBeInstanceOf(GenericError);
+        expect(error.error).toBe('invalid_token');
+        expect(error.message).toBe(
+          'Invalid session_expiry: session ceiling is before or at the token issue time.'
+        );
+      });
+
+      it('throws if session_expiry is before iat', async () => {
+        const iat = nowSeconds();
+        const auth0 = setup({}, { iat, session_expiry: iat - 1 });
+
+        const error = await loginWithRedirect(auth0).catch(e => e);
+        expect(error).toBeInstanceOf(GenericError);
+        expect(error.error).toBe('invalid_token');
+        expect(error.message).toBe(
+          'Invalid session_expiry: session ceiling is before or at the token issue time.'
+        );
+      });
+
+      it('succeeds if session_expiry is after iat', async () => {
+        const iat = nowSeconds();
+        const auth0 = setup({}, { iat, session_expiry: iat + 3600 });
+
+        await expect(loginWithRedirect(auth0)).resolves.not.toThrow();
+      });
+
+      it('succeeds when session_expiry is absent', async () => {
+        const auth0 = setup();
+
+        await expect(loginWithRedirect(auth0)).resolves.not.toThrow();
+      });
+    });
+
+    describe('getTokenSilently ceiling enforcement', () => {
+      it('returns a token when no session_expiry claim is present', async () => {
+        const auth0 = setup();
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+
+        expect(token).toBeTruthy();
+      });
+
+      it('returns a token when the ceiling has not been reached', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry - 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+
+        expect(token).toBeTruthy();
+      });
+
+      it('returns undefined when the ceiling has been breached', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+
+        expect(token).toBeUndefined();
+      });
+
+      it('returns undefined when within the 30s leeway window', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        // nowSeconds = sessionExpiry - 15, which is >= sessionExpiry - 30
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry - 15) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+
+        expect(token).toBeUndefined();
+      });
+
+      it('returns a token when just outside the 30s leeway window', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        // nowSeconds = sessionExpiry - 31, which is < sessionExpiry - 30
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry - 31) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+
+        expect(token).toBeTruthy();
+      });
+
+      it('does not reach the network on breach', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        await auth0.getTokenSilently();
+
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('getUser returns undefined after breach', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        await auth0.getTokenSilently();
+        const user = await auth0.getUser();
+
+        expect(user).toBeUndefined();
+      });
+
+      it('ceiling is enforced after a silent refresh that omits the claim', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        let currentTime = (iat + 100) * 1000;
+
+        const auth0 = setup(
+          { useRefreshTokens: true, nowProvider: () => currentTime },
+          { iat, session_expiry: sessionExpiry }
+        );
+
+        // Initial login — ID token carries session_expiry
+        await loginWithRedirect(auth0);
+
+        // Silent refresh via /oauth/token — response ID token omits session_expiry
+        mockVerify.mockReturnValueOnce({
+          claims: { sub: 'me', exp: Date.now() / 1000 + 86400, iat },
+          user: { sub: 'me' }
+        });
+        mockFetch.mockResolvedValueOnce(
+          fetchResponse(true, {
+            id_token: TEST_ID_TOKEN,
+            refresh_token: TEST_REFRESH_TOKEN,
+            access_token: TEST_ACCESS_TOKEN,
+            token_type: TEST_TOKEN_TYPE,
+            expires_in: 86400
+          })
+        );
+        await auth0.getTokenSilently({ cacheMode: 'off' });
+
+        // Advance clock past the original ceiling
+        currentTime = (sessionExpiry + 100) * 1000;
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+        expect(token).toBeUndefined();
+      });
+
+      it('original ceiling wins when a silent refresh re-emits a later session_expiry', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        let currentTime = (iat + 100) * 1000;
+
+        const auth0 = setup(
+          { useRefreshTokens: true, nowProvider: () => currentTime },
+          { iat, session_expiry: sessionExpiry }
+        );
+
+        // Initial login — ceiling at iat + 3600
+        await loginWithRedirect(auth0);
+
+        // Silent refresh re-emits a later session_expiry (iat + 7200) — must be ignored
+        mockVerify.mockReturnValueOnce({
+          claims: {
+            sub: 'me',
+            exp: Date.now() / 1000 + 86400,
+            iat,
+            session_expiry: iat + 7200
+          },
+          user: { sub: 'me' }
+        });
+        mockFetch.mockResolvedValueOnce(
+          fetchResponse(true, {
+            id_token: TEST_ID_TOKEN,
+            refresh_token: TEST_REFRESH_TOKEN,
+            access_token: TEST_ACCESS_TOKEN,
+            token_type: TEST_TOKEN_TYPE,
+            expires_in: 86400
+          })
+        );
+        await auth0.getTokenSilently({ cacheMode: 'off' });
+
+        // Advance clock past the original ceiling but before the extended one
+        currentTime = (sessionExpiry + 100) * 1000;
+        mockFetch.mockReset();
+
+        // Original ceiling must still be enforced
+        const token = await auth0.getTokenSilently();
+        expect(token).toBeUndefined();
+      });
+
+      it('does not invent a ceiling when session_expiry was never present', async () => {
+        // Two logins, neither carries session_expiry
+        const auth0 = setup();
+        await loginWithRedirect(auth0);
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+        expect(token).toBeTruthy();
+      });
+
+      it('fresh re-login via loginWithRedirect does not inherit the old ceiling', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        let currentTime = (iat + 100) * 1000;
+
+        const auth0 = setup(
+          { nowProvider: () => currentTime },
+          { iat, session_expiry: sessionExpiry }
+        );
+
+        // First login — token carries session_expiry ceiling
+        await loginWithRedirect(auth0);
+
+        // Re-login without logout — new token has no session_expiry
+        mockVerify.mockReturnValueOnce({
+          claims: { sub: 'me', exp: Date.now() / 1000 + 86400, iat },
+          user: { sub: 'me' }
+        });
+        await loginWithRedirect(auth0);
+
+        // Advance clock past the original ceiling
+        currentTime = (sessionExpiry + 100) * 1000;
+        mockFetch.mockReset();
+
+        // Old ceiling must not have been inherited — token should still be served
+        const token = await auth0.getTokenSilently();
+        expect(token).toBeTruthy();
+      });
+
+      it('getUser returns undefined on breach without a prior getTokenSilently call', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        // call getUser directly — no getTokenSilently first
+        const user = await auth0.getUser();
+        expect(user).toBeUndefined();
+      });
+
+      it('isAuthenticated returns false on breach without a prior getTokenSilently call', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        // call isAuthenticated directly — no getTokenSilently first
+        const authenticated = await auth0.isAuthenticated();
+        expect(authenticated).toBe(false);
+      });
+
+      it('getIdTokenClaims returns undefined on breach without a prior getTokenSilently call', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        // call getIdTokenClaims directly — no getTokenSilently first
+        const claims = await auth0.getIdTokenClaims();
+        expect(claims).toBeUndefined();
+      });
+
+      it('isAuthenticated returns false after breach', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        mockFetch.mockReset();
+
+        await auth0.getTokenSilently();
+        const authenticated = await auth0.isAuthenticated();
+
+        expect(authenticated).toBe(false);
+      });
+    });
+
+    describe('_clearLocalSession on breach', () => {
+      it('removes the isAuthenticated cookie on breach', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+
+        await auth0.getUser();
+
+        expect(esCookie.remove).toHaveBeenCalledWith(
+          `auth0.${TEST_CLIENT_ID}.is.authenticated`,
+          {}
+        );
+      });
+
+      it('clears DPoP keys on breach', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        // Login without DPoP to avoid IndexedDB in JSDOM, then inject a mock
+        // DPoP handler so we can assert it gets cleared on breach.
+        const auth0 = setup(
+          { nowProvider: () => (sessionExpiry + 100) * 1000 },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+
+        const mockDpop = { clear: jest.fn().mockResolvedValue(undefined) };
+        Object.defineProperty(auth0, 'dpop', { value: mockDpop, writable: true });
+
+        await auth0.getUser();
+
+        expect(mockDpop.clear).toHaveBeenCalled();
+      });
+
+      it("sends a 'clear' message to the worker on breach", async () => {
+        const postMessageSpy = jest.spyOn(
+          TokenWorker.prototype as any,
+          'postMessage'
+        );
+
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        const auth0 = setup(
+          {
+            nowProvider: () => (sessionExpiry + 100) * 1000,
+            useRefreshTokens: true,
+            cacheLocation: 'memory'
+          },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithRedirect(auth0);
+        postMessageSpy.mockClear();
+
+        await auth0.getUser();
+
+        const clearCalls = postMessageSpy.mock.calls.filter(
+          ([msg]) => msg && (msg as any).type === 'clear'
+        );
+        expect(clearCalls.length).toBe(1);
+      });
+    });
+
+    describe('loginWithPopup', () => {
+      it('throws if session_expiry equals iat via popup', async () => {
+        const iat = nowSeconds();
+        const auth0 = setup({}, { iat, session_expiry: iat });
+
+        const error = await loginWithPopup(auth0).catch(e => e);
+        expect(error).toBeInstanceOf(GenericError);
+        expect(error.error).toBe('invalid_token');
+        expect(error.message).toBe(
+          'Invalid session_expiry: session ceiling is before or at the token issue time.'
+        );
+      });
+
+      it('enforces the ceiling set via loginWithPopup', async () => {
+        const iat = nowSeconds();
+        const sessionExpiry = iat + 3600;
+        let currentTime = (iat + 100) * 1000;
+
+        const auth0 = setup(
+          { nowProvider: () => currentTime },
+          { iat, session_expiry: sessionExpiry }
+        );
+        await loginWithPopup(auth0);
+
+        currentTime = (sessionExpiry + 100) * 1000;
+        mockFetch.mockReset();
+
+        const token = await auth0.getTokenSilently();
+        expect(token).toBeUndefined();
+      });
+    });
+  });
+});

--- a/__tests__/Auth0Client/session-expiry.test.ts
+++ b/__tests__/Auth0Client/session-expiry.test.ts
@@ -119,6 +119,30 @@ describe('Auth0Client', () => {
 
         await expect(loginWithRedirect(auth0)).resolves.not.toThrow();
       });
+
+      it('throws if session_expiry is a millisecond-magnitude value', async () => {
+        const iat = nowSeconds();
+        const auth0 = setup({}, { iat, session_expiry: iat * 1000 });
+
+        const error = await loginWithRedirect(auth0).catch(e => e);
+        expect(error).toBeInstanceOf(GenericError);
+        expect(error.error).toBe('invalid_token');
+        expect(error.message).toBe(
+          'Invalid session_expiry: value appears to be in milliseconds; expected a Unix timestamp in seconds.'
+        );
+      });
+
+      it('throws if session_expiry is a non-numeric string', async () => {
+        const iat = nowSeconds();
+        const auth0 = setup({}, { iat, session_expiry: 'not-a-number' as any });
+
+        const error = await loginWithRedirect(auth0).catch(e => e);
+        expect(error).toBeInstanceOf(GenericError);
+        expect(error.error).toBe('invalid_token');
+        expect(error.message).toBe(
+          'Invalid session_expiry: value must be a number.'
+        );
+      });
     });
 
     describe('getTokenSilently ceiling enforcement', () => {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1541,11 +1541,25 @@ export class Auth0Client {
     entry: CacheEntry & { id_token: string; decodedToken: DecodedToken }
   ) {
     const { session_expiry, iat } = entry.decodedToken.claims;
-    if (session_expiry !== undefined && (iat === undefined || session_expiry <= iat)) {
-      throw new GenericError(
-        'invalid_token',
-        'Invalid session_expiry: session ceiling is before or at the token issue time.'
-      );
+    if (session_expiry !== undefined) {
+      if (typeof session_expiry !== 'number') {
+        throw new GenericError(
+          'invalid_token',
+          'Invalid session_expiry: value must be a number.'
+        );
+      }
+      if (session_expiry >= 10_000_000_000) {
+        throw new GenericError(
+          'invalid_token',
+          'Invalid session_expiry: value appears to be in milliseconds; expected a Unix timestamp in seconds.'
+        );
+      }
+      if (iat === undefined || session_expiry <= iat) {
+        throw new GenericError(
+          'invalid_token',
+          'Invalid session_expiry: session ceiling is before or at the token issue time.'
+        );
+      }
     }
 
     const { id_token, decodedToken, ...entryWithoutIdToken } = entry;

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -65,7 +65,8 @@ import {
   USER_BLOCKED_ERROR_MESSAGE,
   DEFAULT_NOW_PROVIDER,
   DEFAULT_FETCH_TIMEOUT_MS,
-  DEFAULT_AUDIENCE
+  DEFAULT_AUDIENCE,
+  SESSION_EXPIRY_LEEWAY_SECONDS
 } from './constants';
 
 import {
@@ -592,6 +593,10 @@ export class Auth0Client {
    * @typeparam TUser The type to return, has to extend {@link User}.
    */
   public async getUser<TUser extends User>(): Promise<TUser | undefined> {
+    if (await this._isSessionCeilingReached()) {
+      return undefined;
+    }
+
     const cache = await this._getIdTokenFromCache();
 
     return cache?.decodedToken?.user as TUser;
@@ -605,6 +610,10 @@ export class Auth0Client {
    * Returns all claims from the id_token if available.
    */
   public async getIdTokenClaims(): Promise<IdToken | undefined> {
+    if (await this._isSessionCeilingReached()) {
+      return undefined;
+    }
+
     const cache = await this._getIdTokenFromCache();
 
     return cache?.decodedToken?.claims;
@@ -939,6 +948,10 @@ export class Auth0Client {
   ): Promise<undefined | GetTokenSilentlyVerboseResponse> {
     const { cacheMode, ...getTokenOptions } = options;
 
+    if (await this._isSessionCeilingReached()) {
+      return undefined;
+    }
+
     // Check the cache before acquiring the lock to avoid the latency of
     // `lock.acquireLock` when the cache is populated.
     if (cacheMode !== 'off') {
@@ -1247,35 +1260,7 @@ export class Auth0Client {
   public async logout(options: LogoutOptions = {}): Promise<void> {
     const { openUrl, ...logoutOptions } = patchOpenUrlWithOnRedirect(options);
 
-    if (options.clientId === null) {
-      await this.cacheManager.clear();
-    } else {
-      await this.cacheManager.clear(options.clientId || this.options.clientId);
-    }
-
-    this.cookieStorage.remove(this.orgHintCookieName, {
-      cookieDomain: this.options.cookieDomain
-    });
-    this.cookieStorage.remove(this.isAuthenticatedCookieName, {
-      cookieDomain: this.options.cookieDomain
-    });
-    this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
-
-    try {
-      await this.dpop?.clear();
-    } catch {
-      // DPoP storage cleanup is best-effort. Logout should still redirect if
-      // IndexedDB or another storage backend fails while clearing local keys.
-    }
-
-    if (this.worker) {
-      try {
-        await sendMessage({ type: 'clear' }, this.worker);
-      } catch {
-        // Worker is an internal, best-effort cleanup channel. If the ACK round-trip
-        // fails we still proceed with logout so the user is not left in a half-state.
-      }
-    }
+    await this._clearLocalSession(options.clientId);
 
     const url = this._buildLogoutUrl(logoutOptions);
 
@@ -1555,6 +1540,14 @@ export class Auth0Client {
   private async _saveEntryInCache(
     entry: CacheEntry & { id_token: string; decodedToken: DecodedToken }
   ) {
+    const { session_expiry, iat } = entry.decodedToken.claims;
+    if (session_expiry !== undefined && (iat === undefined || session_expiry <= iat)) {
+      throw new GenericError(
+        'invalid_token',
+        'Invalid session_expiry: session ceiling is before or at the token issue time.'
+      );
+    }
+
     const { id_token, decodedToken, ...entryWithoutIdToken } = entry;
 
     this.userCache.set(CACHE_KEY_ID_TOKEN_SUFFIX, {
@@ -1569,6 +1562,56 @@ export class Auth0Client {
     );
 
     await this.cacheManager.set(entryWithoutIdToken);
+  }
+
+  private async _clearLocalSession(clientId: string | null | undefined = this.options.clientId) {
+    if (clientId === null) {
+      await this.cacheManager.clear();
+    } else {
+      await this.cacheManager.clear(clientId);
+    }
+    this.cookieStorage.remove(this.orgHintCookieName, {
+      cookieDomain: this.options.cookieDomain
+    });
+    this.cookieStorage.remove(this.isAuthenticatedCookieName, {
+      cookieDomain: this.options.cookieDomain
+    });
+    this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
+
+    try {
+      await this.dpop?.clear();
+    } catch {
+      // DPoP storage cleanup is best-effort.
+    }
+
+    if (this.worker) {
+      try {
+        await sendMessage({ type: 'clear' }, this.worker);
+      } catch {
+        // Worker cleanup is best-effort.
+      }
+    }
+  }
+
+  private async _isSessionCeilingReached(): Promise<boolean> {
+    const inMemory = this.userCache.get<IdTokenEntry>(
+      CACHE_KEY_ID_TOKEN_SUFFIX
+    ) as IdTokenEntry;
+    const idTokenEntry =
+      inMemory ??
+      await this.cacheManager.getIdToken(
+        new CacheKey({ clientId: this.options.clientId })
+      );
+    const sessionExpiresAt = idTokenEntry?.decodedToken?.claims?.session_expiry;
+    if (sessionExpiresAt === undefined) return false;
+
+    const now = await this.nowProvider();
+    const nowSeconds = Math.floor(now / 1000);
+    if (nowSeconds >= sessionExpiresAt - SESSION_EXPIRY_LEEWAY_SECONDS) {
+      await this._clearLocalSession();
+      return true;
+    }
+    return false;
   }
 
   private async _getIdTokenFromCache() {
@@ -1668,7 +1711,7 @@ export class Auth0Client {
         this.worker
       );
 
-      const decodedToken = await this._verifyIdToken(
+      let decodedToken = await this._verifyIdToken(
         authResult.id_token,
         nonceIn,
         organization
@@ -1684,6 +1727,19 @@ export class Auth0Client {
           // Different user detected - clear cached tokens
           await this.cacheManager.clear(this.options.clientId);
           this.userCache.remove(CACHE_KEY_ID_TOKEN_SUFFIX);
+        }
+      }
+
+      // Silent refresh — pin the session_expiry ceiling from the initial login.
+      // Prevents the server from extending the ceiling via a refresh token response.
+      if (options.grant_type !== 'authorization_code') {
+        const existingIdToken = await this._getIdTokenFromCache();
+        const existingCeiling = existingIdToken?.decodedToken?.claims?.session_expiry;
+        if (existingCeiling !== undefined) {
+          decodedToken = {
+            ...decodedToken,
+            claims: { ...decodedToken.claims, session_expiry: existingCeiling }
+          };
         }
       }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,4 +73,7 @@ export const DEFAULT_AUTH0_CLIENT = {
 
 export const DEFAULT_NOW_PROVIDER = () => Date.now();
 
+/** @ignore */
+export const SESSION_EXPIRY_LEEWAY_SECONDS = 30;
+
 export const DEFAULT_AUDIENCE = 'default';

--- a/src/global.ts
+++ b/src/global.ts
@@ -866,6 +866,11 @@ export interface IdToken {
   org_id?: string;
   org_name?: string;
   /**
+   * IPSIE session expiry ceiling (Unix timestamp in seconds).
+   * When present, the SDK will not return tokens after this point in time.
+   */
+  session_expiry?: number;
+  /**
    * The actor claim, present in ID tokens returned via token exchange responses.
    * Identifies the acting party that has been delegated authority to act on behalf
    * of the subject. Set via Auth0 Actions using the `setActor` command.


### PR DESCRIPTION
## Summary

Implements IPSIE SL1 `session_expiry` enforcement. When an ID token carries a `session_expiry` Unix-timestamp claim, the SDK treats it as a hard ceiling on the local session. No token is served and no refresh is attempted once the ceiling has passed.

## Behaviour

| Scenario | Behaviour |
|---|---|
| `session_expiry` absent | No change, fully backward compatible |
| Ceiling not yet reached | Tokens served normally |
| Within 30s leeway window | Treated as expired (clock-skew guard) |
| Ceiling passed | `getUser` / `getIdTokenClaims` / `getTokenSilently` return `undefined`; local session fully torn down |
| `session_expiry <= iat` at login | Rejected immediately with `GenericError('invalid_token')`, session not persisted |
| Token refresh | `/oauth/token` not called past ceiling; ceiling pinned to login-time value |
| Re-login without logout (authorization_code) | Fresh login token claims are authoritative; old ceiling is not inherited |

## Tests

24 new unit tests in `__tests__/Auth0Client/session-expiry.test.ts` covering:
- Login-time validation via `loginWithRedirect` and `loginWithPopup`
- Ceiling enforcement across `getTokenSilently`, `getUser`, `isAuthenticated`, `getIdTokenClaims`
- Leeway boundary, no network call on breach
- Ceiling pinning through silent refresh (refresh token grant) only — fresh `authorization_code` logins do not inherit a prior ceiling
- Full local teardown on breach (cache, cookies, DPoP keys, worker)

## Testing

Deploy the following Post-Login Action on your tenant (Dashboard → Actions → Triggers → post-login):

```js
exports.onExecutePostLogin = async (event, api) => {
  api.idToken.setCustomClaim('session_expiry', Math.floor(Date.now() / 1000) + 120);
};
```

Verified: tokens served normally before ceiling, all session-read methods return `undefined` after breach, no `/oauth/token` call on breach, ceiling not extended by forced refresh.
