### PR TITLE
fix: skip PR title lint for release branches

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -20,6 +20,7 @@ jobs:
   lint-title:
     name: Lint PR Title
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Skips the PR title lint check for PRs opened from `release/*` branches, as release PR titles don't follow conventional commit format.