### PR TITLE
fix: rename nonRotating to preserveRefreshToken and fix revokeRefreshToken in online mode

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -154,15 +154,22 @@ The `revokeRefreshToken()` method explicitly revokes a refresh token via the `/o
 
 This method only has an effect when `useRefreshTokens` is `true`. If refresh tokens are disabled it returns immediately without doing anything.
 
-> [!NOTE]
-> In [online access](#online-access-online-refresh-tokens) mode (`refreshTokenMode: RefreshTokenMode.Online`), `revokeRefreshToken()` only clears the cached refresh token locally — it does **not** revoke the Online Refresh Token at the authorization server. Online Refresh Tokens are non-rotating and session-bound, and the server does not support token-only revocation for them. To end an online session, call `logout()` instead, which terminates the session and thereby invalidates the ORT.
+> [!WARNING]
+> In [online access](#online-access-online-refresh-tokens) mode (`refreshTokenMode: RefreshTokenMode.Online`), `revokeRefreshToken()` behaves differently from offline mode:
+> - The ORT **is** revoked at the authorization server via `/oauth/revoke`.
+> - Because the ORT is session-bound, the Auth0 **session is terminated server-side** as part of revocation.
+> - The entire local cache is cleared immediately — the access token, ID token, and user profile are wiped. `isAuthenticated()` returns `false` and `getUser()` returns `undefined` right away.
+>
+> After calling `revokeRefreshToken()` in online mode, redirect the user to login — `getTokenSilently()` will fail because the session is gone. For a redirect-based sign-out, `logout()` achieves the same result.
 
 ```js
 // Revoke the refresh token for the default audience
 await auth0.revokeRefreshToken();
 ```
 
-**How it affects the cache:** The access token is preserved in the cache — only the refresh token entry is cleared. Once the access token expires, `getTokenSilently()` will attempt silent auth (via iframe, if `useRefreshTokensFallback` is enabled and the Auth0 session is still active) before requiring a new interactive login.
+**How it affects the cache:**
+- **Offline mode:** only the refresh token entry is cleared — the access token remains in cache until it expires. Once it expires, `getTokenSilently()` will attempt silent auth (via iframe, if `useRefreshTokensFallback` is enabled and the Auth0 session is still active) before requiring a new interactive login.
+- **Online mode:** the entire local cache is cleared (access token, ID token, user profile). `isAuthenticated()` returns `false` immediately. The user must log in again.
 
 **Difference from `logout()`:** `revokeRefreshToken()` invalidates the refresh token on the Auth0 server and removes it from the local cache, but it does **not** clear the user's Auth0 session or the rest of the local cache. If you want to fully terminate the session, use `logout()` instead.
 
@@ -320,8 +327,8 @@ await auth0.logout({ logoutParams: { returnTo: window.location.origin } });
 
 After logout, the ORT is no longer valid; a subsequent `getTokenSilently()` falls through to the [iframe fallback](#refresh-token-fallback) (if `useRefreshTokensFallback` is enabled) and ultimately to an interactive login.
 
-> [!NOTE]
-> In online mode, [`revokeRefreshToken()`](#revoking-refresh-tokens) only clears the cached token locally — it does **not** revoke the ORT at the authorization server. The server has no token-only revocation for non-rotating ORTs, so `logout()` is the only way to invalidate an ORT.
+> [!WARNING]
+> In online mode, [`revokeRefreshToken()`](#revoking-refresh-tokens) revokes the ORT at the authorization server **and terminates the Auth0 session**. The entire local cache (access token, ID token, user profile) is cleared immediately — `isAuthenticated()` returns `false` right away. Redirect the user to login after calling this. Use `logout()` instead if you want a redirect-based sign-out.
 
 ### Using with Multi-Resource Refresh Tokens (MRRT)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -171,7 +171,11 @@ await auth0.revokeRefreshToken();
 - **Offline mode:** only the refresh token entry is cleared — the access token remains in cache until it expires. Once it expires, `getTokenSilently()` will attempt silent auth (via iframe, if `useRefreshTokensFallback` is enabled and the Auth0 session is still active) before requiring a new interactive login.
 - **Online mode:** the entire local cache is cleared (access token, ID token, user profile). `isAuthenticated()` returns `false` immediately. The user must log in again.
 
-**Difference from `logout()`:** `revokeRefreshToken()` invalidates the refresh token on the Auth0 server and removes it from the local cache, but it does **not** clear the user's Auth0 session or the rest of the local cache. If you want to fully terminate the session, use `logout()` instead.
+**Difference from `logout()`:**
+- In **offline mode**, `revokeRefreshToken()` invalidates the rotating refresh token at the server and strips it from the cache, but does **not** terminate the Auth0 session or clear the rest of the local cache (access token, ID token, user profile remain until they expire).
+- In **online mode**, `revokeRefreshToken()` terminates the Auth0 session server-side and clears the entire local cache immediately — equivalent to a silent `logout()` without a redirect.
+
+In both modes, if you want a **redirect-based** sign-out, use `logout()` instead.
 
 #### Error Handling
 

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -599,6 +599,47 @@ describe('Auth0Client', () => {
       expect(rt).toBe(TEST_REFRESH_TOKEN);
     });
 
+    it('carries the ORT forward via MRRT when MFA is required on a brand-new audience with no existing cache entry', async () => {
+      // Regression test: the carry-forward lookup at _requestToken must pass useMrrt
+      // through to cacheManager.get(), otherwise a first-ever request for a new
+      // audience/scope combo (no exact key, no scope-superset match) can't find the
+      // ORT stashed under the login audience's cache entry.
+      const auth0 = setup({
+        ...onlineConfig,
+        useMrrt: true
+      } as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      const NEW_AUDIENCE = 'https://brand-new-resource/';
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'MFA required',
+          mfa_token: 'test-mfa-mrrt-token'
+        })
+      );
+      try {
+        await auth0.getTokenSilently({
+          authorizationParams: { audience: NEW_AUDIENCE, scope: 'read:foo' },
+          cacheMode: 'off'
+        });
+      } catch (_) {}
+
+      mockMfaVerifyResponse(); // no refresh_token — non-rotating ORT behaviour
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-mrrt-token', otp: '123456' });
+
+      // Must check the NEW_AUDIENCE entry specifically — the untouched login entry
+      // (default audience) always still has the ORT, so find(Boolean) over all
+      // entries would pass even if the carry-forward for this entry failed.
+      const newAudienceEntry = getCacheEntries().find(
+        e => e?.body?.audience === NEW_AUDIENCE
+      );
+      expect(newAudienceEntry?.body?.refresh_token).toBe(TEST_REFRESH_TOKEN);
+    });
+
     it('uses the server-returned ORT when the server does issue one on the MFA grant', async () => {
       const auth0 = setup(onlineConfig as any);
       await loginWithRedirect(auth0);

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -594,6 +594,33 @@ describe('Auth0Client', () => {
       expect(rt).toBe(NEW_ORT);
     });
 
+    it('uses options.refresh_token directly for refresh_token grant without hitting the cache', async () => {
+      // The refactored ?? path: options.refresh_token is set on the refresh_token grant,
+      // so the cache lookup branch must NOT run — the token on options is used as-is.
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      // Force-refresh: server returns no refresh_token (non-rotating ORT behaviour)
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: 'new-access-token',
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: 'openid profile email online_access',
+          // no refresh_token — server does not echo ORT back
+        })
+      );
+
+      await auth0.getTokenSilently({ cacheMode: 'off' });
+
+      // ORT from the original login (TEST_REFRESH_TOKEN) must survive in cache —
+      // it was on options.refresh_token and ?? short-circuits before the cache lookup.
+      const rt = getCacheEntries().map(e => e?.body?.refresh_token).find(Boolean);
+      expect(rt).toBe(TEST_REFRESH_TOKEN);
+    });
+
     it('does NOT carry the ORT forward on MFA grants in offline mode', async () => {
       const auth0 = setup({
         useRefreshTokens: true,

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -75,6 +75,7 @@ describe('Auth0Client', () => {
         } as any)
     );
     sessionStorage.clear();
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -382,6 +383,105 @@ describe('Auth0Client', () => {
           }
         )
       ).rejects.toThrow(/write:foo/);
+    });
+  });
+
+  describe('online access — revokeRefreshToken clears local session', () => {
+    const onlineConfig = {
+      refreshTokenMode: 'online' as const,
+      useRefreshTokens: true,
+      useDpop: true,
+      cacheLocation: 'localstorage' as const
+    };
+
+    const mockSuccessfulRevoke = () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('')
+      });
+    };
+
+    it('clears the entire local cache after successful revocation', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+      mockSuccessfulRevoke();
+
+      const clearSpy = jest.spyOn((auth0 as any).cacheManager, 'clear');
+
+      await auth0.revokeRefreshToken();
+
+      expect(clearSpy).toHaveBeenCalled();
+    });
+
+    it('isAuthenticated() returns false immediately after revokeRefreshToken', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+      mockSuccessfulRevoke();
+
+      expect(await auth0.isAuthenticated()).toBe(true);
+
+      await auth0.revokeRefreshToken();
+
+      expect(await auth0.isAuthenticated()).toBe(false);
+    });
+
+    it('getUser() returns undefined immediately after revokeRefreshToken', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+      mockSuccessfulRevoke();
+
+      expect(await auth0.getUser()).toBeDefined();
+
+      await auth0.revokeRefreshToken();
+
+      expect(await auth0.getUser()).toBeUndefined();
+    });
+
+    it('does NOT clear the local cache if the revoke request fails', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({ error_description: 'The token has been revoked' })
+          )
+      });
+
+      const clearSpy = jest.spyOn((auth0 as any).cacheManager, 'clear');
+
+      await expect(auth0.revokeRefreshToken()).rejects.toThrow();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      // User should still appear authenticated since server revoke failed
+      expect(await auth0.isAuthenticated()).toBe(true);
+    });
+
+    it('does NOT clear the local cache after revokeRefreshToken in offline mode', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'localstorage' as const
+      });
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+      mockSuccessfulRevoke();
+
+      const clearSpy = jest.spyOn((auth0 as any).cacheManager, 'clear');
+
+      await auth0.revokeRefreshToken();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      // Access token and user profile remain after offline revocation
+      expect(await auth0.isAuthenticated()).toBe(true);
+      expect(await auth0.getUser()).toBeDefined();
     });
   });
 });

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -13,10 +13,13 @@ import {
 
 import {
   TEST_CODE_CHALLENGE,
-  TEST_REFRESH_TOKEN
+  TEST_REFRESH_TOKEN,
+  TEST_ACCESS_TOKEN,
+  TEST_ID_TOKEN
 } from '../constants';
 import { DEFAULT_AUDIENCE } from '../../src/constants';
-import { InvalidConfigurationError } from '../../src/errors';
+import { InvalidConfigurationError, MfaRequiredError } from '../../src/errors';
+import { fetchResponse } from './helpers';
 
 jest.mock('es-cookie');
 jest.mock('../../src/jwt');
@@ -482,6 +485,225 @@ describe('Auth0Client', () => {
       // Access token and user profile remain after offline revocation
       expect(await auth0.isAuthenticated()).toBe(true);
       expect(await auth0.getUser()).toBeDefined();
+    });
+  });
+
+  describe('online access — MFA grant carries ORT forward when server returns none', () => {
+    // Parity with refresh_token grant: the server does not echo the ORT back in the MFA
+    // verify response. The SDK must read the ORT from the cache and re-save it so subsequent
+    // getTokenSilently calls can still use it.
+
+    const onlineConfig = {
+      refreshTokenMode: 'online' as const,
+      useRefreshTokens: true,
+      useDpop: true,
+      cacheLocation: 'localstorage' as const
+    };
+
+    const getCacheEntries = () =>
+      Object.keys(localStorage)
+        .filter(k => k.startsWith('@@auth0spajs@@'))
+        .map(k => JSON.parse(localStorage.getItem(k)));
+
+    const mockMfaRequired = () => {
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'MFA required',
+          mfa_token: 'test-mfa-token'
+        })
+      );
+    };
+
+    const mockMfaVerifyResponse = (overrides: Record<string, unknown> = {}) => {
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: 'openid profile email online_access',
+          // no refresh_token by default — non-rotating ORT behaviour
+          ...overrides
+        })
+      );
+    };
+
+    it('carries the cached ORT forward when server returns no refresh_token on mfa-otp grant', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockMfaRequired();
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      mockMfaVerifyResponse(); // no refresh_token in response
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-token', otp: '123456' });
+
+      const rt = getCacheEntries().map(e => e?.body?.refresh_token).find(Boolean);
+      expect(rt).toBe(TEST_REFRESH_TOKEN);
+    });
+
+    it('carries the cached ORT forward on mfa-oob grant', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockMfaRequired();
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      mockMfaVerifyResponse();
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-token', oobCode: 'oob-code', bindingCode: '123456' });
+
+      const rt = getCacheEntries().map(e => e?.body?.refresh_token).find(Boolean);
+      expect(rt).toBe(TEST_REFRESH_TOKEN);
+    });
+
+    it('carries the cached ORT forward on mfa-recovery-code grant', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockMfaRequired();
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      mockMfaVerifyResponse();
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-token', recoveryCode: 'XXXX-XXXX' });
+
+      const rt = getCacheEntries().map(e => e?.body?.refresh_token).find(Boolean);
+      expect(rt).toBe(TEST_REFRESH_TOKEN);
+    });
+
+    it('uses the server-returned ORT when the server does issue one on the MFA grant', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockMfaRequired();
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      const NEW_ORT = 'fresh-ort-from-mfa-verify';
+      mockMfaVerifyResponse({ refresh_token: NEW_ORT });
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-token', otp: '123456' });
+
+      const rt = getCacheEntries().map(e => e?.body?.refresh_token).find(Boolean);
+      expect(rt).toBe(NEW_ORT);
+    });
+
+    it('does NOT carry the ORT forward on MFA grants in offline mode', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'localstorage' as const
+      });
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      // In offline mode getTokenSilently uses the refresh_token grant, which also throws
+      // mfa_required. Simulate that to populate the MFA context.
+      mockMfaRequired();
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      // Offline MFA verify: server returns no refresh_token
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: 'openid profile email offline_access'
+          // no refresh_token
+        })
+      );
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-token', otp: '123456' });
+
+      // The original rotating RT must NOT be carried forward — it's single-use
+      const mfaEntry = getCacheEntries()
+        .find(e => e?.body?.access_token === TEST_ACCESS_TOKEN);
+      expect(mfaEntry?.body?.refresh_token).toBeUndefined();
+    });
+  });
+
+  describe('online access — MFA grant scope carries online_access (ORT vs offline RT)', () => {
+    // When mfa.verify() is called after a getTokenSilently mfa_required, the scope stored in
+    // MFA context came from the failing refresh request — which includes online_access.
+    // The MFA grant must therefore request online_access, and the result is keyed under it.
+
+    const onlineConfig = {
+      refreshTokenMode: 'online' as const,
+      useRefreshTokens: true,
+      useDpop: true,
+      cacheLocation: 'localstorage' as const
+    };
+
+    it('passes online_access scope to the MFA grant (scope captured from failing refresh)', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'MFA required',
+          mfa_token: 'test-mfa-scope-check'
+        })
+      );
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      const requestMfaSpy = jest.spyOn(auth0 as any, '_requestTokenForMfa');
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: 'openid profile email online_access',
+          refresh_token: 'ort-after-mfa'
+        })
+      );
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-scope-check', otp: '123456' });
+
+      const calledScope: string = (requestMfaSpy.mock.calls[0][0] as any).scope;
+      expect(calledScope).toContain('online_access');
+      expect(calledScope).not.toContain('offline_access');
+    });
+
+    it('result cache entry is keyed under online_access (not offline_access)', async () => {
+      const auth0 = setup(onlineConfig as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(false, {
+          error: 'mfa_required',
+          error_description: 'MFA required',
+          mfa_token: 'test-mfa-cache-key'
+        })
+      );
+      try { await auth0.getTokenSilently({ cacheMode: 'off' }); } catch (_) {}
+
+      mockFetch.mockResolvedValueOnce(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
+          access_token: TEST_ACCESS_TOKEN,
+          token_type: 'Bearer',
+          expires_in: 86400,
+          scope: 'openid profile email online_access',
+          refresh_token: 'ort-after-mfa'
+        })
+      );
+
+      await auth0.mfa.verify({ mfaToken: 'test-mfa-cache-key', otp: '123456' });
+
+      const keys = Object.keys(localStorage).filter(k => k.startsWith('@@auth0spajs@@'));
+      expect(keys.find(k => k.includes('online_access'))).toBeDefined();
+      expect(keys.find(k => k.includes('offline_access'))).toBeUndefined();
     });
   });
 });

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -18,7 +18,7 @@ import {
   TEST_ID_TOKEN
 } from '../constants';
 import { DEFAULT_AUDIENCE } from '../../src/constants';
-import { InvalidConfigurationError, MfaRequiredError } from '../../src/errors';
+import { InvalidConfigurationError } from '../../src/errors';
 import { fetchResponse } from './helpers';
 
 jest.mock('es-cookie');
@@ -596,12 +596,18 @@ describe('Auth0Client', () => {
 
     it('uses options.refresh_token directly for refresh_token grant without hitting the cache', async () => {
       // The refactored ?? path: options.refresh_token is set on the refresh_token grant,
-      // so the cache lookup branch must NOT run — the token on options is used as-is.
+      // so the cache lookup inside _requestToken must NOT fire — options.refresh_token
+      // short-circuits the ?? before the cache is read.
+      //
+      // Verifiable because _getTokenUsingRefreshToken calls cacheManager.get exactly once
+      // (to retrieve the cached RT before the exchange). A second call would mean the
+      // ?? fallback ran — which must NOT happen when options.refresh_token is present.
       const auth0 = setup(onlineConfig as any);
       await loginWithRedirect(auth0);
       mockFetch.mockReset();
 
-      // Force-refresh: server returns no refresh_token (non-rotating ORT behaviour)
+      const cacheGetSpy = jest.spyOn((auth0 as any).cacheManager, 'get');
+
       mockFetch.mockResolvedValueOnce(
         fetchResponse(true, {
           id_token: TEST_ID_TOKEN,
@@ -615,8 +621,12 @@ describe('Auth0Client', () => {
 
       await auth0.getTokenSilently({ cacheMode: 'off' });
 
-      // ORT from the original login (TEST_REFRESH_TOKEN) must survive in cache —
-      // it was on options.refresh_token and ?? short-circuits before the cache lookup.
+      // _getTokenUsingRefreshToken calls get() once. The ORT carry-forward in
+      // _requestToken must NOT add a second call — options.refresh_token is set
+      // so ?? resolves without reaching the cache.
+      expect(cacheGetSpy).toHaveBeenCalledTimes(1);
+
+      // And the ORT must still be in the cache after the refresh.
       const rt = getCacheEntries().map(e => e?.body?.refresh_token).find(Boolean);
       expect(rt).toBe(TEST_REFRESH_TOKEN);
     });

--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -486,6 +486,28 @@ describe('Auth0Client', () => {
       expect(await auth0.isAuthenticated()).toBe(true);
       expect(await auth0.getUser()).toBeDefined();
     });
+
+    it('clears state via worker path (in-memory cache) after successful revocation in online mode', async () => {
+      // Default cacheLocation is memory, which activates the worker path.
+      // _clearLocalSession() sends { type: 'clear' } to the worker; verify
+      // that isAuthenticated() returns false immediately after revocation.
+      const auth0 = setup({
+        refreshTokenMode: 'online' as const,
+        useRefreshTokens: true,
+        useDpop: true
+        // no cacheLocation — defaults to memory (worker path)
+      } as any);
+      await loginWithRedirect(auth0);
+      mockFetch.mockReset();
+      mockSuccessfulRevoke();
+
+      expect(await auth0.isAuthenticated()).toBe(true);
+
+      await auth0.revokeRefreshToken();
+
+      expect(await auth0.isAuthenticated()).toBe(false);
+      expect(await auth0.getUser()).toBeUndefined();
+    });
   });
 
   describe('online access — MFA grant carries ORT forward when server returns none', () => {

--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -210,7 +210,7 @@ describe('token worker', () => {
         method: 'POST',
         body: JSON.stringify({ grant_type: 'refresh_token' })
       },
-      nonRotating: true
+      preserveRefreshToken: true
     });
 
     // Second refresh: the stored ORT must still be injected (not evicted).
@@ -227,7 +227,7 @@ describe('token worker', () => {
         method: 'POST',
         body: JSON.stringify({ grant_type: 'refresh_token' })
       },
-      nonRotating: true
+      preserveRefreshToken: true
     });
 
     expect(response.json.error).toBeUndefined();

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1223,10 +1223,12 @@ export class Auth0Client {
    * If `useRefreshTokens` is disabled, this method does nothing.
    *
    * **Online mode:** when `refreshTokenMode` is `'online'`, revoking the ORT via
-   * `/oauth/revoke` **also terminates the Auth0 session**. Because Online Refresh Tokens
-   * are session-bound, the authorization server ties the token directly to the session —
-   * revoking the ORT invalidates the session server-side. This means the user will be
-   * required to log in again even if their session cookie has not yet expired.
+   * `/oauth/revoke` **also terminates the Auth0 session** and **clears the entire local
+   * cache** (access token, ID token, user profile). Because Online Refresh Tokens are
+   * session-bound, the authorization server ties the token directly to the session —
+   * revoking the ORT invalidates the session server-side. The local cache is cleared
+   * immediately so that `isAuthenticated()` returns `false` and `getUser()` returns
+   * `undefined` right away, without waiting for the access token to expire.
    * Use this when you need to force a sign-out without a redirect (e.g. background
    * revocation). For a redirect-based sign-out, prefer `logout()`.
    *
@@ -1283,6 +1285,14 @@ export class Auth0Client {
       },
       this.worker
     );
+
+    // In online mode the ORT is session-bound: revoking it terminates the Auth0 session
+    // server-side. Clear the entire local cache so that isAuthenticated() returns false
+    // and getUser() returns undefined immediately — the stale access token and ID token
+    // must not remain visible to the application after the session is gone.
+    if (this.onlineAccess) {
+      await this._clearLocalSession();
+    }
   }
 
   /**

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1819,7 +1819,9 @@ export class Auth0Client {
             scope: scopesToRequest || options.scope,
             audience: options.audience || DEFAULT_AUDIENCE,
             clientId: this.options.clientId,
-          })
+          }),
+          undefined,
+          this.options.useMrrt
         ))?.refresh_token;
       }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1811,10 +1811,10 @@ export class Auth0Client {
       // carry the ORT forward to avoid evicting it on save.
       // Online-only: in offline mode a refresh token is single-use and reusing it would
       // trip reuse detection.
-      let refresh_token = authResult.refresh_token;
-      if (!refresh_token && this.onlineAccess) {
-        const optionsRefreshToken = (options as RefreshTokenRequestTokenOptions).refresh_token;
-        refresh_token = optionsRefreshToken ?? (await this.cacheManager.get(
+      // Mutate authResult so ...authResult in _saveEntryInCache picks up the ORT directly.
+      // Safe: GetTokenSilentlyVerboseResponse omits refresh_token, so it never reaches app code.
+      if (!authResult.refresh_token && this.onlineAccess) {
+        authResult.refresh_token = (options as RefreshTokenRequestTokenOptions).refresh_token ?? (await this.cacheManager.get(
           new CacheKey({
             scope: scopesToRequest || options.scope,
             audience: options.audience || DEFAULT_AUDIENCE,
@@ -1825,7 +1825,6 @@ export class Auth0Client {
 
       await this._saveEntryInCache({
         ...authResult,
-        ...(refresh_token ? { refresh_token } : null),
         decodedToken,
         scope: options.scope,
         audience: options.audience || DEFAULT_AUDIENCE,

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1809,34 +1809,18 @@ export class Auth0Client {
       }
       // Online refresh tokens are non-rotating: the server returns no refresh_token, so
       // carry the ORT forward to avoid evicting it on save.
-      //
-      // refresh_token grant: the ORT being exchanged is on options.refresh_token.
-      //
-      // MFA grants (mfa-otp, mfa-oob, mfa-recovery-code): options carries no refresh_token
-      // field. The ORT was stored in the cache at login / last refresh; read it from there
-      // so the same token survives the step-up verify.
-      //
       // Online-only: in offline mode a refresh token is single-use and reusing it would
       // trip reuse detection.
       let refresh_token = authResult.refresh_token;
       if (!refresh_token && this.onlineAccess) {
-        const MFA_GRANTS = new Set([
-          'http://auth0.com/oauth/grant-type/mfa-otp',
-          'http://auth0.com/oauth/grant-type/mfa-oob',
-          'http://auth0.com/oauth/grant-type/mfa-recovery-code',
-        ]);
-        if (options.grant_type === 'refresh_token') {
-          refresh_token = options.refresh_token;
-        } else if (MFA_GRANTS.has(options.grant_type)) {
-          const cachedEntry = await this.cacheManager.get(
-            new CacheKey({
-              scope: scopesToRequest || options.scope,
-              audience: options.audience || DEFAULT_AUDIENCE,
-              clientId: this.options.clientId,
-            })
-          );
-          refresh_token = cachedEntry?.refresh_token;
-        }
+        const optionsRefreshToken = (options as RefreshTokenRequestTokenOptions).refresh_token;
+        refresh_token = optionsRefreshToken ?? (await this.cacheManager.get(
+          new CacheKey({
+            scope: scopesToRequest || options.scope,
+            audience: options.audience || DEFAULT_AUDIENCE,
+            clientId: this.options.clientId,
+          })
+        ))?.refresh_token;
       }
 
       await this._saveEntryInCache({

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1222,16 +1222,18 @@ export class Auth0Client {
    *
    * If `useRefreshTokens` is disabled, this method does nothing.
    *
-   * **Online mode:** when `refreshTokenMode` is `'online'` this method only clears the
-   * cached refresh token locally — it does **not** revoke the Online Refresh Token at the
-   * authorization server. Online Refresh Tokens are non-rotating and session-bound, and the
-   * server does not support token-only revocation for them. To end an online session, use
-   * `logout()` instead, which terminates the session and thereby invalidates the ORT.
+   * **Online mode:** when `refreshTokenMode` is `'online'`, revoking the ORT via
+   * `/oauth/revoke` **also terminates the Auth0 session**. Because Online Refresh Tokens
+   * are session-bound, the authorization server ties the token directly to the session —
+   * revoking the ORT invalidates the session server-side. This means the user will be
+   * required to log in again even if their session cookie has not yet expired.
+   * Use this when you need to force a sign-out without a redirect (e.g. background
+   * revocation). For a redirect-based sign-out, prefer `logout()`.
    *
    * **Important:** This method revokes the refresh token for a single audience. If your
    * application requests tokens for multiple audiences, each audience may have its own
    * refresh token. To fully revoke all refresh tokens, call this method once per audience.
-   * If you want to terminate the user's session entirely, use `logout()` instead.
+   * If you want to terminate the user's session with a redirect, use `logout()` instead.
    *
    * When using Multi-Resource Refresh Tokens (MRRT), a single refresh token may cover
    * multiple audiences. In that case, revoking it will affect all cache entries that
@@ -1758,7 +1760,7 @@ export class Auth0Client {
           timeout: this.httpTimeoutMs,
           useMrrt: this.options.useMrrt,
           dpop: this.dpop,
-          nonRotating: this.onlineAccess,
+          preserveRefreshToken: this.onlineAccess,
           ...options,
           scope: scopesToRequest || options.scope,
         },

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -197,7 +197,6 @@ export class Auth0Client {
 
   /** Validates online-access config and returns whether online mode is enabled. */
   private resolveOnlineAccess(options: Auth0ClientOptions): boolean {
-
     if (options.refreshTokenMode !== 'online') {
       return false;
     }
@@ -1809,13 +1808,36 @@ export class Auth0Client {
         }
       }
       // Online refresh tokens are non-rotating: the server returns no refresh_token, so
-      // carry the ORT forward to avoid evicting it on save. Online-only: in offline mode
-      // a refresh token is single-use and reusing it would trip reuse detection.
-      const refresh_token =
-        authResult.refresh_token ||
-        (this.onlineAccess && options.grant_type === 'refresh_token'
-          ? options.refresh_token
-          : undefined);
+      // carry the ORT forward to avoid evicting it on save.
+      //
+      // refresh_token grant: the ORT being exchanged is on options.refresh_token.
+      //
+      // MFA grants (mfa-otp, mfa-oob, mfa-recovery-code): options carries no refresh_token
+      // field. The ORT was stored in the cache at login / last refresh; read it from there
+      // so the same token survives the step-up verify.
+      //
+      // Online-only: in offline mode a refresh token is single-use and reusing it would
+      // trip reuse detection.
+      let refresh_token = authResult.refresh_token;
+      if (!refresh_token && this.onlineAccess) {
+        const MFA_GRANTS = new Set([
+          'http://auth0.com/oauth/grant-type/mfa-otp',
+          'http://auth0.com/oauth/grant-type/mfa-oob',
+          'http://auth0.com/oauth/grant-type/mfa-recovery-code',
+        ]);
+        if (options.grant_type === 'refresh_token') {
+          refresh_token = options.refresh_token;
+        } else if (MFA_GRANTS.has(options.grant_type)) {
+          const cachedEntry = await this.cacheManager.get(
+            new CacheKey({
+              scope: scopesToRequest || options.scope,
+              audience: options.audience || DEFAULT_AUDIENCE,
+              clientId: this.options.clientId,
+            })
+          );
+          refresh_token = cachedEntry?.refresh_token;
+        }
+      }
 
       await this._saveEntryInCache({
         ...authResult,

--- a/src/api.ts
+++ b/src/api.ts
@@ -38,7 +38,7 @@ export async function oauthToken(
     useFormData,
     useMrrt,
     dpop,
-    nonRotating,
+    preserveRefreshToken,
     ...options
   }: TokenEndpointOptions,
   worker?: Worker,
@@ -92,7 +92,7 @@ export async function oauthToken(
     isDpopSupported ? dpop : undefined,
     undefined,
     skipTokenStorage,
-    nonRotating
+    preserveRefreshToken
   );
 }
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -74,7 +74,7 @@ const fetchWithWorker = async (
   useFormData?: boolean,
   useMrrt?: boolean,
   skipTokenStorage?: boolean,
-  nonRotating?: boolean
+  preserveRefreshToken?: boolean
 ) => {
   return sendMessage(
     {
@@ -89,7 +89,7 @@ const fetchWithWorker = async (
       useFormData,
       useMrrt,
       skipTokenStorage,
-      nonRotating
+      preserveRefreshToken
     },
     worker
   );
@@ -105,7 +105,7 @@ export const switchFetch = async (
   timeout = DEFAULT_FETCH_TIMEOUT_MS,
   useMrrt?: boolean,
   skipTokenStorage?: boolean,
-  nonRotating?: boolean
+  preserveRefreshToken?: boolean
 ): Promise<any> => {
   if (worker) {
     return fetchWithWorker(
@@ -118,7 +118,7 @@ export const switchFetch = async (
       useFormData,
       useMrrt,
       skipTokenStorage,
-      nonRotating
+      preserveRefreshToken
     );
   } else {
     return fetchWithoutWorker(fetchUrl, fetchOptions, timeout);
@@ -137,7 +137,7 @@ export async function getJSON<T>(
   dpop?: Pick<Dpop, 'generateProof' | 'getNonce' | 'setNonce'>,
   isDpopRetry?: boolean,
   skipTokenStorage?: boolean,
-  nonRotating?: boolean
+  preserveRefreshToken?: boolean
 ): Promise<T> {
   if (dpop) {
     const dpopProof = await dpop.generateProof({
@@ -164,7 +164,7 @@ export async function getJSON<T>(
         timeout,
         useMrrt,
         skipTokenStorage,
-        nonRotating
+        preserveRefreshToken
       );
       fetchError = null;
       break;
@@ -239,7 +239,7 @@ export async function getJSON<T>(
         dpop,
         true, // !
         skipTokenStorage,
-        nonRotating
+        preserveRefreshToken
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,11 @@ export {
   PopupOpenError,
   MfaRequiredError,
   MissingRefreshTokenError,
+  MissingScopesError,
   UseDpopNonceError
 } from './errors';
+
+export type { MfaRequirements } from './errors';
 
 export {
   MfaError,

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -189,6 +189,9 @@ const messageHandler = async ({
       setRefreshToken(json.refresh_token, audience, scope);
       delete json.refresh_token;
     } else if (!preserveRefreshToken) {
+      // Offline rotating tokens: evict the stored RT so it can't be reused.
+      // Online (preserveRefreshToken=true) skips this — the ORT is non-rotating
+      // and the server never returns a replacement.
       deleteRefreshToken(audience, scope);
     }
 

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -82,7 +82,7 @@ const checkDownscoping = (scope: string, audience: string): boolean => {
 }
 
 const messageHandler = async ({
-  data: { timeout, auth, fetchUrl, fetchOptions, useFormData, useMrrt, skipTokenStorage, nonRotating },
+  data: { timeout, auth, fetchUrl, fetchOptions, useFormData, useMrrt, skipTokenStorage, preserveRefreshToken },
   ports: [port]
 }: MessageEvent<WorkerRefreshTokenMessage>) => {
   let headers: FetchResponse['headers'] = {};
@@ -188,9 +188,7 @@ const messageHandler = async ({
 
       setRefreshToken(json.refresh_token, audience, scope);
       delete json.refresh_token;
-    } else if (!nonRotating) {
-      // Non-rotating (online) refresh tokens come back without a replacement;
-      // keep the stored ORT instead of evicting it.
+    } else if (!preserveRefreshToken) {
       deleteRefreshToken(audience, scope);
     }
 

--- a/src/worker/worker.types.ts
+++ b/src/worker/worker.types.ts
@@ -21,10 +21,10 @@ export type WorkerRefreshTokenMessage = WorkerTokenMessage & {
   useMrrt?: boolean;
   skipTokenStorage?: boolean;
   /**
-   * Non-rotating refresh token (Online Refresh Token). When set, the worker keeps
-   * the stored token if the response carries no replacement, instead of deleting it.
+   * When true the worker keeps the stored token if the response carries no replacement
+   * (Online Refresh Tokens are non-rotating and never come back with a new token).
    */
-  nonRotating?: boolean;
+  preserveRefreshToken?: boolean;
 };
 
 export type WorkerRevokeTokenMessage = Omit<WorkerTokenMessage, 'auth'> & {

--- a/static/online-access.html
+++ b/static/online-access.html
@@ -390,12 +390,16 @@
       await refreshDiagnostics(client);
     }
 
-    // Calls revokeRefreshToken and reports the raw outcome. Online: clears the local cache only,
-    // the ORT is NOT revoked server-side. Offline: revokes the rotating RT at the server.
+    // Calls revokeRefreshToken.
+    // Online (memory/worker mode): the ORT lives in the worker's in-memory store.
+    //   revokeToken sends a 'revoke' message to the worker → worker calls /oauth/revoke
+    //   with the ORT → deletes it from its store. Server-side revocation works.
+    // Offline: rotating RT read from ICache → revoked at server.
     async function revoke(client) {
       var before = readRefreshTokenFromCache();
       tokenOutEl.textContent = 'Revoking refresh token…';
 
+      var t0 = performance.now();
       var error;
       try {
         // The RT is cached under the login audience; pass it so the lookup finds the token.
@@ -404,6 +408,7 @@
       } catch (err) {
         error = err instanceof Error ? err.message : String(err);
       }
+      var ms = Math.round(performance.now() - t0);
 
       var after = readRefreshTokenFromCache();
 
@@ -412,13 +417,14 @@
           {
             mode: mode,
             note: mode === 'online'
-              ? 'Online: local cache cleared only; ORT NOT revoked server-side. Use logout() to end the session.'
+              ? 'Online (worker mode): ORT revoked at /oauth/revoke via worker. getTokenSilently should now fail.'
               : 'Offline: rotating refresh token revoked at the server.',
+            durationMs: ms,
             refreshTokenBefore: mask(before),
             refreshTokenAfter: mask(after),
-            changed: before !== after
+            cacheChanged: before !== after
           },
-          error ? { error: error } : null
+          error ? { error: error } : { success: true }
         ),
         null, 2
       );


### PR DESCRIPTION
## Summary

Four fixes for online mode (`refreshTokenMode: 'online'`) and related ORT handling:

1. **Local cache not cleared after `revokeRefreshToken()` in online mode** — after a successful revoke, the access token, ID token, and user profile remained in the local cache. `isAuthenticated()` returned `true` and `getUser()` returned the stale profile until the access token expired. Fixed by calling `_clearLocalSession()` after a successful revoke in online mode, so client state is consistent with server state immediately.

2. **ORT not preserved after MFA step-up** — in online mode the server never returns a new refresh token (ORTs are non-rotating). The previous carry-forward logic only covered the `refresh_token` grant type explicitly, so the ORT was silently evicted after an MFA step-up (which uses a different grant type). Refactored to mutate `authResult.refresh_token` directly using `options.refresh_token ?? cacheManager.get(...)?.refresh_token` so the ORT is preserved for any grant type when no new RT is returned by the server.

3. **Incorrect JSDoc / docs** — the previous documentation incorrectly stated that `revokeRefreshToken()` in online mode only clears the local cache and does _not_ revoke the ORT at the server. In reality the `/oauth/revoke` endpoint accepts ORTs, and because an ORT is session-bound, revoking it also terminates the Auth0 session server-side. All documentation updated to reflect actual behavior.

4. **`nonRotating` renamed to `preserveRefreshToken`** — the old name created a confusing double-negative at the use site (`!nonRotating`) in security-critical token-handling code inside the web worker. Renamed across `worker.types.ts`, `token.worker.ts`, `http.ts`, and `api.ts`. No behavior change.

Additionally: exported `MissingScopesError` and `MfaRequirements` from `src/index.ts` (were already defined internally but not re-exported).

## Details

### Bug: stale client state after `revokeRefreshToken()` in online mode

`revokeRefreshToken()` called `stripRefreshToken()` on success, which removes only the `refresh_token` field from each cache entry — leaving the access token, ID token, and user profile intact. After the call:

- Server: ORT revoked, Auth0 session terminated
- Client: `isAuthenticated()` → `true`, `getUser()` → stale user object, `getTokenSilently()` → returns the still-cached (but server-invalidated) access token until it expires

Fix: call `_clearLocalSession()` in online mode after `revokeToken` resolves. This wipes the full cache (access token, ID token, user profile), cookies, and the worker's in-memory RT store — matching what `logout()` does for the local side. `isAuthenticated()` returns `false` immediately.

### Bug: ORT evicted after MFA step-up in online mode

When `mfa_required` is thrown during `getTokenSilently()` and the user completes MFA, the SDK calls `_getTokenUsingMfaCode()` with the `http://auth0.com/oauth/grant-type/mfa-otp` grant type. The previous carry-forward logic:

```typescript
const refresh_token =
  authResult.refresh_token ||
  (this.onlineAccess && options.grant_type === 'refresh_token'
    ? options.refresh_token
    : undefined);
```

only preserved the ORT when `grant_type === 'refresh_token'`. For MFA grants, `options.grant_type` is `'http://auth0.com/oauth/grant-type/mfa-otp'`, so the condition was `false` and `refresh_token` was `undefined` — causing the ORT to be evicted from the cache.

Refactored to mutate `authResult` directly:

```typescript
// Mutate authResult so ...authResult in _saveEntryInCache picks up the ORT directly.
// Safe: GetTokenSilentlyVerboseResponse omits refresh_token, so it never reaches app code.
if (!authResult.refresh_token && this.onlineAccess) {
  authResult.refresh_token = (options as RefreshTokenRequestTokenOptions).refresh_token ?? (await this.cacheManager.get(
    new CacheKey({
      scope: scopesToRequest || options.scope,
      audience: options.audience || DEFAULT_AUDIENCE,
      clientId: this.options.clientId,
    })
  ))?.refresh_token;
}
```

This preserves the ORT for any grant type. If `options.refresh_token` is set (refresh_token grant), it uses that directly without a cache lookup. For MFA grants where `options.refresh_token` is absent, it falls back to the cache to recover the stored ORT. The mutation is safe because `GetTokenSilentlyVerboseResponse` explicitly `Omit`s `refresh_token`, so the ORT never reaches app code.

### `revokeRefreshToken()` vs `logout()` in online mode

Both terminate the session. The difference is mechanics:

| | `revokeRefreshToken()` | `logout()` |
|---|---|---|
| Mechanism | POST to `/oauth/revoke` | Redirect to `/v2/logout` |
| Session terminated server-side | Yes | Yes |
| Local cache cleared | Yes (after this fix) | Yes |
| Redirect | No | Yes |
| Use when | Background / silent sign-out | Redirect to post-logout page |

After calling `revokeRefreshToken()` in online mode, the user must log in again — `getTokenSilently()` will fail because the session is gone.

### `preserveRefreshToken` rename

Threaded through four files with no behavior change:

- `src/worker/worker.types.ts` — type definition
- `src/worker/token.worker.ts` — destructuring + use site
- `src/http.ts` — `fetchWithWorker`, `switchFetch`, `getJSON` (×2 for DPoP retry)
- `src/api.ts` — `oauthToken` destructuring + pass-through

## Test plan

- [x] `revokeRefreshToken()` in online mode (localStorage path): after the call, `isAuthenticated()` returns `false` and `getUser()` returns `undefined`
- [x] `revokeRefreshToken()` in online mode (worker/memory path): `isAuthenticated()` returns `false` and `getUser()` returns `undefined` immediately
- [x] `revokeRefreshToken()` in online mode: `getTokenSilently()` fails (session gone) — not the cached token
- [x] `revokeRefreshToken()` failure: cache NOT cleared, user remains authenticated
- [x] `revokeRefreshToken()` in offline mode: access token remains cached; `isAuthenticated()` still returns `true` until the AT expires
- [x] ORT is preserved (not deleted) from the worker store after a successful token refresh in online mode
- [x] ORT is preserved after MFA step-up (mfa-otp, mfa-oob, mfa-recovery-code grants) in online mode
- [x] Server-returned ORT on MFA grant is used in preference to the cached one
- [x] When `options.refresh_token` is set (refresh_token grant), cache is not hit for the carry-forward (verified via spy)
- [x] ORT NOT carried forward on MFA grants in offline mode (single-use RT must not be reused)
- [x] Existing worker tests pass with the `preserveRefreshToken` rename