### PR TITLE
fix: widen getTokenSilently overload return types to include undefined

### DIFF
--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -899,7 +899,7 @@ export class Auth0Client {
    */
   public async getTokenSilently(
     options: GetTokenSilentlyOptions & { detailedResponse: true }
-  ): Promise<GetTokenSilentlyVerboseResponse>;
+  ): Promise<GetTokenSilentlyVerboseResponse | undefined>;
 
   /**
    * Fetches a new access token and returns it.
@@ -908,7 +908,7 @@ export class Auth0Client {
    */
   public async getTokenSilently(
     options?: GetTokenSilentlyOptions
-  ): Promise<string>;
+  ): Promise<string | undefined>;
 
   /**
    * Fetches a new access token, and either returns just the access token (the default) or the response from the /oauth/token endpoint, depending on the `detailedResponse` option.

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,5 +1,5 @@
 import { DPOP_NONCE_HEADER } from './dpop/utils';
-import { UseDpopNonceError } from './errors';
+import { GenericError, UseDpopNonceError } from './errors';
 import { GetTokenSilentlyVerboseResponse } from './global';
 
 export type ResponseHeaders =
@@ -21,7 +21,7 @@ export type AuthParams = {
   audience?: string;
 };
 
-type AccessTokenFactory = (authParams?: AuthParams) => Promise<string | GetTokenSilentlyVerboseResponse>;
+type AccessTokenFactory = (authParams?: AuthParams) => Promise<string | GetTokenSilentlyVerboseResponse | undefined>;
 
 enum TokenType {
   Bearer = 'Bearer',
@@ -94,7 +94,7 @@ export class Fetcher<TOutput extends CustomFetchMinimalOutput> {
     throw new TypeError('`url` must be absolute or `baseUrl` non-empty.');
   }
 
-  protected getAccessToken(authParams?: AuthParams): Promise<string | GetTokenSilentlyVerboseResponse> {
+  protected getAccessToken(authParams?: AuthParams): Promise<string | GetTokenSilentlyVerboseResponse | undefined> {
     return this.config.getAccessToken
       ? this.config.getAccessToken(authParams)
       : this.hooks.getAccessToken(authParams);
@@ -170,6 +170,10 @@ export class Fetcher<TOutput extends CustomFetchMinimalOutput> {
 
   protected async prepareRequest(request: Request, authParams?: AuthParams) {
     const accessTokenResponse = await this.getAccessToken(authParams);
+
+    if (accessTokenResponse === undefined) {
+      throw new GenericError('missing_access_token', 'No access token was returned by getTokenSilently.');
+    }
 
     let tokenType: string;
     let accessToken: string;


### PR DESCRIPTION
The public overloads for `getTokenSilently` declare `Promise<string>` and `Promise<GetTokenSilentlyVerboseResponse>`, but the implementation can return `undefined` in two cases:

- **`cacheMode: 'cache-only'` with no matching cache entry** — pre-existing behaviour; the overloads were already incorrect before IPSIE.
- **IPSIE `session_expiry` ceiling reached** — introduced when the session expiry ceiling feature was added.

The implementation signature already reflects this (`Promise<undefined | string | GetTokenSilentlyVerboseResponse>`), but overload signatures are what callers see — the implementation signature is invisible externally.

This aligns the overloads with the implementation so consumers can write correct null checks without fighting the type system.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token handling when a session is unavailable or no token can be issued.
  * Requests now fail with a clearer error if an access token is missing instead of proceeding with incomplete authorization.
  * Updated token-related responses to indicate they may be unavailable, helping prevent unexpected runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->