### PR TITLE
docs: mark Online Access as Early Access and drop the feature-flag mention

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -222,6 +222,9 @@ await auth0.revokeRefreshToken();
 
 ## Online Access (Online Refresh Tokens)
 
+> [!NOTE]
+> Online Access (Online Refresh Tokens) support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
+
 **Online Refresh Tokens (ORTs)** are a refresh token type bound to the lifetime of the user's Auth0 session. See the [Auth0 documentation on Online Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens/online-refresh-tokens/online-refresh-tokens) for the full conceptual overview. Unlike the rotating [offline refresh tokens](#refresh-tokens) described above, an ORT is:
 
 - **Session-bound** — it is valid only while the underlying Auth0 session is active. When the session ends (logout, idle/absolute session expiry, or an admin revoking the session), the ORT stops working.
@@ -261,9 +264,6 @@ Enabling this option causes the SDK to:
 
 > [!NOTE]
 > Online access is **opt-in**. When `refreshTokenMode` is unset or `RefreshTokenMode.Offline`, the SDK behaves exactly as before.
-
-> [!NOTE]
-> This feature requires the `online_refresh_tokens` flag to be enabled for your tenant and `allow_online_access` to be enabled on the resource server (on by default).
 
 ### `RefreshTokenMode.Offline` vs. `RefreshTokenMode.Online`
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ window.addEventListener('load', async () => {
 
 ### Online Access
 
+> [!NOTE]
+> Online Access (Online Refresh Tokens) support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
+
 Set `refreshTokenMode` to `RefreshTokenMode.Online` (together with the required `useRefreshTokens: true` and `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
 
 ```js


### PR DESCRIPTION
## Summary

- Adds an Early Access notice to the "Online Access" section in both `README.md` and `EXAMPLES.md`, matching the existing MFA Early Access notice style/placement.
- Removes the note claiming Online Access requires enabling the `online_refresh_tokens` flag on the tenant — this feature is currently gated via Auth0 account team enablement, not a self-service tenant setting, so the flag-based wording was inaccurate.

## Changes

- `README.md` — added Early Access `[!NOTE]` under `### Online Access`
- `EXAMPLES.md` — added Early Access `[!NOTE]` under `## Online Access (Online Refresh Tokens)`; removed the `online_refresh_tokens` flag / `allow_online_access` note

Docs-only change, no code or behavior changes.

This is a draft PR pending final review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Online Access (Online Refresh Tokens)” documentation to add an Early Access note and guidance to request access via an Auth0 representative.
  * Removed the previously documented tenant/resource-server prerequisite regarding enabling specific flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->