### PR TITLE
docs: note that Online Refresh Tokens don't support Ephemeral Sessions yet

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -225,6 +225,9 @@ await auth0.revokeRefreshToken();
 > [!NOTE]
 > Online Access (Online Refresh Tokens) support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
 
+> [!WARNING]
+> Online Refresh Tokens do not currently support resource servers with **Ephemeral Sessions** enabled. If a resource server has both `allow_online_access` and "Allow for Ephemeral Sessions" enabled, the authorization server issues an Online Refresh Token at login that is then rejected with `invalid_grant` (`"Unknown or invalid refresh token"`) on the very next refresh — this is a known backend limitation, not a client-side defect. Until Ephemeral Sessions support is added for Online Refresh Tokens, disable "Allow for Ephemeral Sessions" on any resource server used with `refreshTokenMode: RefreshTokenMode.Online`.
+
 **Online Refresh Tokens (ORTs)** are a refresh token type bound to the lifetime of the user's Auth0 session. See the [Auth0 documentation on Online Refresh Tokens](https://auth0.com/docs/secure/tokens/refresh-tokens/online-refresh-tokens/online-refresh-tokens) for the full conceptual overview. Unlike the rotating [offline refresh tokens](#refresh-tokens) described above, an ORT is:
 
 - **Session-bound** — it is valid only while the underlying Auth0 session is active. When the session ends (logout, idle/absolute session expiry, or an admin revoking the session), the ORT stops working.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ window.addEventListener('load', async () => {
 > [!NOTE]
 > Online Access (Online Refresh Tokens) support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
 
+> [!WARNING]
+> Online Refresh Tokens do not currently support resource servers with **Ephemeral Sessions** enabled. Enabling both `allow_online_access` and "Allow for Ephemeral Sessions" on the same resource server results in the authorization server issuing an Online Refresh Token that is then rejected (`invalid_grant`) on the very next refresh. Until Ephemeral Sessions support is added for Online Refresh Tokens, disable "Allow for Ephemeral Sessions" on any resource server used with `refreshTokenMode: RefreshTokenMode.Online`.
+
 Set `refreshTokenMode` to `RefreshTokenMode.Online` (together with the required `useRefreshTokens: true` and `useDpop: true`) to use **Online Refresh Tokens** — non-rotating refresh tokens bound to the Auth0 session lifetime. The SDK injects the `online_access` scope and routes renewal through the refresh-token grant.
 
 ```js


### PR DESCRIPTION
## Summary

Adds a `[!WARNING]` note to both `README.md` and `EXAMPLES.md` under the "Online Access" sections stating that Online Refresh Tokens (ORTs) do not currently support resource servers with **Ephemeral Sessions** enabled.

## Changes

- `README.md` — added a `[!WARNING]` under `### Online Access`
- `EXAMPLES.md` — added the same `[!WARNING]` under `## Online Access (Online Refresh Tokens)`, right after the existing Early Access note

Both note the workaround: disable "Allow for Ephemeral Sessions" on any resource server used with `refreshTokenMode: RefreshTokenMode.Online` until backend support lands.

Docs-only change, no code or behavior changes.