### PR TITLE
feat: Add granular passkey APIs (getSignupChallenge, getLoginChallenge, getTokenWithPasskey)

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1087,6 +1087,7 @@ Passkeys provide password-less authentication using platform biometrics (Face ID
 - [Important: Use Refresh Tokens with Passkeys](#important-use-refresh-tokens-with-passkeys)
 - [Signup with Passkey](#signup-with-passkey)
 - [Login with Passkey](#login-with-passkey)
+- [Granular Passkey APIs](#granular-passkey-apis)
 - [Complete Passkey Flow Example](#complete-passkey-flow-example)
 - [Error Handling](#passkey-error-handling)
 
@@ -1233,6 +1234,113 @@ const tokens = await auth0.passkey.login({
   organization: 'org_abc123'
 });
 ```
+
+### Granular Passkey APIs
+
+For advanced use cases where you need fine-grained control, you can use the individual API methods to handle each step of the passkey flow separately.
+
+#### Get Signup Challenge
+
+Request a passkey signup challenge to start the granular signup flow:
+
+```js
+const challenge = await auth0.passkey.getSignupChallenge({
+  email: 'user@example.com',
+  name: 'Jane Doe' // optional display name
+});
+
+// challenge.authSession — save this to complete signup later
+// challenge.publicKey — pass to navigator.credentials.create()
+```
+
+#### Get Login Challenge
+
+Request a passkey login challenge to start the granular login flow:
+
+```js
+const challenge = await auth0.passkey.getLoginChallenge({
+  realm: 'Username-Password-Authentication' // optional
+});
+
+// challenge.authSession — save this to complete login later
+// challenge.publicKey — pass to navigator.credentials.get()
+```
+
+#### Get Token with Passkey
+
+Exchange a signed credential for tokens. This is the final step after running the WebAuthn ceremony:
+
+```js
+// After navigator.credentials.create() or navigator.credentials.get()
+const credential = await navigator.credentials.create({
+  publicKey: challenge.publicKey
+});
+
+const tokens = await auth0.passkey.getTokenWithPasskey({
+  authSession: challenge.authSession,
+  credential: credential, // the raw PublicKeyCredential
+  scope: 'openid profile email',
+  audience: 'https://api.example.com'
+});
+```
+
+#### Complete Granular Signup Example
+
+```js
+async function granularSignup(email, displayName) {
+  // Step 1: Get challenge
+  const challenge = await auth0.passkey.getSignupChallenge({
+    email,
+    name: displayName
+  });
+
+  // Step 2: Create credential
+  const credential = await navigator.credentials.create({
+    publicKey: challenge.publicKey
+  });
+
+  if (!credential) {
+    throw new Error('Credential creation cancelled');
+  }
+
+  // Step 3: Exchange for tokens
+  const tokens = await auth0.passkey.getTokenWithPasskey({
+    authSession: challenge.authSession,
+    credential
+  });
+
+  return tokens;
+}
+```
+
+#### Complete Granular Login Example
+
+```js
+async function granularLogin() {
+  // Step 1: Get challenge
+  const challenge = await auth0.passkey.getLoginChallenge();
+
+  // Step 2: Get credential
+  const credential = await navigator.credentials.get({
+    publicKey: challenge.publicKey
+  });
+
+  if (!credential) {
+    throw new Error('Credential assertion cancelled');
+  }
+
+  // Step 3: Exchange for tokens
+  const tokens = await auth0.passkey.getTokenWithPasskey({
+    authSession: challenge.authSession,
+    credential
+  });
+
+  return tokens;
+}
+```
+
+> [!NOTE]
+> The granular APIs (`getSignupChallenge`, `getLoginChallenge`, `getTokenWithPasskey`) provide the same automatic token caching and session establishment as the simplified `signup()` and `login()` methods. After successful completion, `isAuthenticated()`, `getUser()`, and `getTokenSilently()` work as expected.
 
 ### Complete Passkey Flow Example
 

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -4,8 +4,77 @@ jest.mock('@auth0/auth0-auth-js', () => ({
 
 import { PasskeyApiClient } from '../../src/passkey/PasskeyApiClient';
 import { MfaRequiredError } from '../../src/errors';
+import { PasskeyError } from '../../src/passkey/errors';
 
 const TEST_AUTH_SESSION = 'auth-session-abc123';
+
+// jsdom does not implement the WebAuthn response classes, but
+// `getTokenWithPasskey` branches on `instanceof AuthenticatorAttestationResponse`
+// / `AuthenticatorAssertionResponse`. 
+class MockAuthenticatorAttestationResponse {
+  clientDataJSON: ArrayBuffer;
+  attestationObject: ArrayBuffer;
+  constructor(clientDataJSON: ArrayBuffer, attestationObject: ArrayBuffer) {
+    this.clientDataJSON = clientDataJSON;
+    this.attestationObject = attestationObject;
+  }
+}
+
+class MockAuthenticatorAssertionResponse {
+  clientDataJSON: ArrayBuffer;
+  authenticatorData: ArrayBuffer;
+  signature: ArrayBuffer;
+  userHandle: ArrayBuffer | null;
+  constructor(
+    clientDataJSON: ArrayBuffer,
+    authenticatorData: ArrayBuffer,
+    signature: ArrayBuffer,
+    userHandle: ArrayBuffer | null
+  ) {
+    this.clientDataJSON = clientDataJSON;
+    this.authenticatorData = authenticatorData;
+    this.signature = signature;
+    this.userHandle = userHandle;
+  }
+}
+
+(global as any).AuthenticatorAttestationResponse = MockAuthenticatorAttestationResponse;
+(global as any).AuthenticatorAssertionResponse = MockAuthenticatorAssertionResponse;
+
+// Builds a credential whose `response` is a real instance of one of the mock
+// WebAuthn response classes above, so `getTokenWithPasskey`'s `instanceof`
+// detection resolves correctly under jsdom.
+function createTypedPublicKeyCredential(type: 'create' | 'get') {
+  const clientDataJSON = new Uint8Array([1, 2, 3]).buffer;
+
+  if (type === 'create') {
+    return {
+      id: 'credential-id-123',
+      rawId: new Uint8Array([10, 20, 30]).buffer,
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: new MockAuthenticatorAttestationResponse(
+        clientDataJSON,
+        new Uint8Array([40, 50, 60]).buffer
+      ),
+      getClientExtensionResults: () => ({})
+    } as unknown as PublicKeyCredential;
+  }
+
+  return {
+    id: 'credential-id-456',
+    rawId: new Uint8Array([10, 20, 30]).buffer,
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: new MockAuthenticatorAssertionResponse(
+      clientDataJSON,
+      new Uint8Array([70, 80, 90]).buffer,
+      new Uint8Array([100, 110, 120]).buffer,
+      new Uint8Array([130, 140, 150]).buffer
+    ),
+    getClientExtensionResults: () => ({})
+  } as unknown as PublicKeyCredential;
+}
 
 function createMockPublicKeyCredential(type: 'create' | 'get') {
   const clientDataJSON = new Uint8Array([1, 2, 3]).buffer;
@@ -693,6 +762,390 @@ describe('PasskeyApiClient', () => {
         passkeyClient.login({
           scope: 'openid profile',
           audience: 'https://api.example.com'
+        })
+      ).rejects.toThrow(mfaError);
+    });
+  });
+
+  describe('getSignupChallenge', () => {
+    it('should return authSession and a decoded creation publicKey', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+          timeout: 60000
+        }
+      };
+      mockPasskeyClient.register.mockResolvedValue(challengeResponse);
+
+      const result = await passkeyClient.getSignupChallenge({
+        email: 'user@example.com'
+      });
+
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com'
+      });
+      expect(result.authSession).toBe(TEST_AUTH_SESSION);
+      expect(result.publicKey.challenge).toBeInstanceOf(ArrayBuffer);
+      expect(result.publicKey.user.id).toBeInstanceOf(ArrayBuffer);
+      expect(result.publicKey.rp).toEqual({
+        id: 'example.auth0.com',
+        name: 'Example'
+      });
+    });
+
+    it('should forward all supported signup properties to register', async () => {
+      mockPasskeyClient.register.mockResolvedValue({
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      });
+
+      await passkeyClient.getSignupChallenge({
+        email: 'user@example.com',
+        phoneNumber: '+1234567890',
+        username: 'janedoe',
+        name: 'Jane Doe',
+        givenName: 'Jane',
+        familyName: 'Doe',
+        nickname: 'janie',
+        picture: 'https://example.com/avatar.png',
+        userMetadata: { plan: 'pro' },
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123'
+      });
+
+      // Every supported property is passed straight through to the challenge
+      // request. Unlike signup(), there is no scope/audience here — those apply
+      // only at the getTokenWithPasskey() step.
+      expect(mockPasskeyClient.register).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        phoneNumber: '+1234567890',
+        username: 'janedoe',
+        name: 'Jane Doe',
+        givenName: 'Jane',
+        familyName: 'Doe',
+        nickname: 'janie',
+        picture: 'https://example.com/avatar.png',
+        userMetadata: { plan: 'pro' },
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123'
+      });
+    });
+
+    it('should not trigger the WebAuthn ceremony or token exchange', async () => {
+      mockPasskeyClient.register.mockResolvedValue({
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rp: { id: 'example.auth0.com', name: 'Example' },
+          user: { id: 'dXNlci0x', name: 'user@example.com', displayName: 'User' },
+          pubKeyCredParams: [{ type: 'public-key', alg: -7 }]
+        }
+      });
+      const create = jest.fn();
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { create },
+        configurable: true
+      });
+
+      await passkeyClient.getSignupChallenge({ email: 'user@example.com' });
+
+      expect(create).not.toHaveBeenCalled();
+      expect(mockAuth0Client._requestTokenForPasskey).not.toHaveBeenCalled();
+    });
+
+    it('should throw if WebAuthn is not supported', async () => {
+      Object.defineProperty(window, 'PublicKeyCredential', {
+        value: undefined,
+        writable: true,
+        configurable: true
+      });
+
+      await expect(
+        passkeyClient.getSignupChallenge({ email: 'user@example.com' })
+      ).rejects.toThrow('WebAuthn is not supported in this browser.');
+    });
+
+    it('should propagate errors from PasskeyClient.register', async () => {
+      mockPasskeyClient.register.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        passkeyClient.getSignupChallenge({ email: 'user@example.com' })
+      ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('getLoginChallenge', () => {
+    it('should return authSession and a decoded request publicKey', async () => {
+      const challengeResponse = {
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com',
+          timeout: 60000,
+          userVerification: 'preferred'
+        }
+      };
+      mockPasskeyClient.challenge.mockResolvedValue(challengeResponse);
+
+      const result = await passkeyClient.getLoginChallenge();
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith(undefined);
+      expect(result.authSession).toBe(TEST_AUTH_SESSION);
+      expect(result.publicKey.challenge).toBeInstanceOf(ArrayBuffer);
+      expect(result.publicKey.rpId).toBe('example.auth0.com');
+    });
+
+    it('should call challenge with provided options', async () => {
+      mockPasskeyClient.challenge.mockResolvedValue({
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      });
+
+      await passkeyClient.getLoginChallenge({});
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith({});
+    });
+
+    it('should forward challenge options when provided', async () => {
+      mockPasskeyClient.challenge.mockResolvedValue({
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      });
+
+      await passkeyClient.getLoginChallenge({
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123'
+      });
+
+      expect(mockPasskeyClient.challenge).toHaveBeenCalledWith({
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123'
+      });
+    });
+
+    it('should not trigger the WebAuthn ceremony or token exchange', async () => {
+      mockPasskeyClient.challenge.mockResolvedValue({
+        authSession: TEST_AUTH_SESSION,
+        authnParamsPublicKey: {
+          challenge: 'Y2hhbGxlbmdl',
+          rpId: 'example.auth0.com'
+        }
+      });
+      const get = jest.fn();
+      Object.defineProperty(global.navigator, 'credentials', {
+        value: { get },
+        configurable: true
+      });
+
+      await passkeyClient.getLoginChallenge();
+
+      expect(get).not.toHaveBeenCalled();
+      expect(mockAuth0Client._requestTokenForPasskey).not.toHaveBeenCalled();
+    });
+
+    it('should throw if WebAuthn is not supported', async () => {
+      Object.defineProperty(window, 'PublicKeyCredential', {
+        value: undefined,
+        writable: true,
+        configurable: true
+      });
+
+      await expect(passkeyClient.getLoginChallenge()).rejects.toThrow(
+        'WebAuthn is not supported in this browser.'
+      );
+    });
+
+    it('should propagate errors from PasskeyClient.challenge', async () => {
+      mockPasskeyClient.challenge.mockRejectedValue(
+        new Error('Service unavailable')
+      );
+
+      await expect(passkeyClient.getLoginChallenge()).rejects.toThrow(
+        'Service unavailable'
+      );
+    });
+  });
+
+  describe('getTokenWithPasskey', () => {
+    it('should serialize an attestation credential and exchange it for tokens', async () => {
+      const mockTokenResponse = {
+        id_token: 'eyJ...',
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.getTokenWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: createTypedPublicKeyCredential('create')
+      });
+
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential: expect.objectContaining({
+          id: 'credential-id-123',
+          rawId: expect.any(String),
+          type: 'public-key',
+          response: expect.objectContaining({
+            clientDataJSON: expect.any(String),
+            attestationObject: expect.any(String)
+          })
+        }),
+        realm: undefined,
+        organization: undefined,
+        scope: undefined,
+        audience: undefined
+      });
+      expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should serialize an assertion credential and exchange it for tokens', async () => {
+      const mockTokenResponse = {
+        access_token: 'at_456',
+        token_type: 'Bearer',
+        expires_in: 86400
+      };
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue(mockTokenResponse);
+
+      const result = await passkeyClient.getTokenWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: createTypedPublicKeyCredential('get')
+      });
+
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith({
+        authSession: TEST_AUTH_SESSION,
+        credential: expect.objectContaining({
+          id: 'credential-id-456',
+          rawId: expect.any(String),
+          type: 'public-key',
+          response: expect.objectContaining({
+            clientDataJSON: expect.any(String),
+            authenticatorData: expect.any(String),
+            signature: expect.any(String),
+            userHandle: expect.any(String)
+          })
+        }),
+        realm: undefined,
+        organization: undefined,
+        scope: undefined,
+        audience: undefined
+      });
+      expect(result).toEqual(mockTokenResponse);
+    });
+
+    it('should forward realm, organization, scope, and audience', async () => {
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.getTokenWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: createTypedPublicKeyCredential('create'),
+        realm: 'Username-Password-Authentication',
+        organization: 'org_abc123',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com'
+      });
+
+      expect(mockAuth0Client._requestTokenForPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authSession: TEST_AUTH_SESSION,
+          realm: 'Username-Password-Authentication',
+          organization: 'org_abc123',
+          scope: 'openid profile email',
+          audience: 'https://api.example.com'
+        })
+      );
+    });
+
+    it('should throw a PasskeyError if the credential is neither attestation nor assertion', async () => {
+      const invalidCredential = {
+        id: 'credential-id-789',
+        rawId: new Uint8Array([1, 2, 3]).buffer,
+        type: 'public-key',
+        response: { somethingElse: true },
+        getClientExtensionResults: () => ({})
+      } as unknown as PublicKeyCredential;
+
+      await expect(
+        passkeyClient.getTokenWithPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: invalidCredential
+        })
+      ).rejects.toThrow(
+        new PasskeyError(
+          'passkey_invalid_credential',
+          'The provided credential is not a valid attestation or assertion response.'
+        )
+      );
+
+      expect(mockAuth0Client._requestTokenForPasskey).not.toHaveBeenCalled();
+    });
+
+    it('should serialize credential fields with base64url encoding', async () => {
+      mockAuth0Client._requestTokenForPasskey.mockResolvedValue({
+        access_token: 'at_123',
+        token_type: 'Bearer',
+        expires_in: 86400
+      });
+
+      await passkeyClient.getTokenWithPasskey({
+        authSession: TEST_AUTH_SESSION,
+        credential: createTypedPublicKeyCredential('get')
+      });
+
+      const credential =
+        mockAuth0Client._requestTokenForPasskey.mock.calls[0][0].credential;
+      expect(credential.rawId).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.clientDataJSON).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.authenticatorData).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(credential.response.signature).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('should propagate errors from the token exchange', async () => {
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(
+        new Error('Token exchange failed')
+      );
+
+      await expect(
+        passkeyClient.getTokenWithPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: createTypedPublicKeyCredential('create')
+        })
+      ).rejects.toThrow('Token exchange failed');
+    });
+
+    it('should re-throw MfaRequiredError', async () => {
+      const mfaError = new MfaRequiredError(
+        'mfa_required',
+        'Multifactor authentication required',
+        'mfa-token-789',
+        { challenge: [{ type: 'otp' }] }
+      );
+      mockAuth0Client._requestTokenForPasskey.mockRejectedValue(mfaError);
+
+      await expect(
+        passkeyClient.getTokenWithPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: createTypedPublicKeyCredential('get')
         })
       ).rejects.toThrow(mfaError);
     });

--- a/__tests__/passkey/PasskeyApiClient.test.ts
+++ b/__tests__/passkey/PasskeyApiClient.test.ts
@@ -982,6 +982,23 @@ describe('PasskeyApiClient', () => {
   });
 
   describe('getTokenWithPasskey', () => {
+    it('should throw if WebAuthn is not supported', async () => {
+      Object.defineProperty(window, 'PublicKeyCredential', {
+        value: undefined,
+        writable: true,
+        configurable: true
+      });
+
+      await expect(
+        passkeyClient.getTokenWithPasskey({
+          authSession: TEST_AUTH_SESSION,
+          credential: createTypedPublicKeyCredential('create')
+        })
+      ).rejects.toThrow(
+        'WebAuthn is not supported in this browser.'
+      );
+    });
+
     it('should serialize an attestation credential and exchange it for tokens', async () => {
       const mockTokenResponse = {
         id_token: 'eyJ...',

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,10 @@ export type {
   PasskeyCreationOptions,
   PasskeyRequestOptions,
   PasskeySignupOptions,
-  PasskeyLoginOptions
+  PasskeyLoginOptions,
+  PasskeySignupChallenge,
+  PasskeyLoginChallenge,
+  PasskeyGetTokenOptions
 } from './passkey';
 
 export type { CustomTokenExchangeOptions } from './TokenExchange';

--- a/src/passkey/PasskeyApiClient.ts
+++ b/src/passkey/PasskeyApiClient.ts
@@ -5,7 +5,12 @@ import type {
   PasskeyLoginOptions,
   PasskeyCredentialResponse,
   PasskeyCreationOptions,
-  PasskeyRequestOptions
+  PasskeyRequestOptions,
+  PasskeySignupChallengeOptions,
+  PasskeyLoginChallengeOptions,
+  PasskeySignupChallenge,
+  PasskeyLoginChallenge,
+  PasskeyGetTokenOptions
 } from './types';
 import type { PasskeyClient } from '@auth0/auth0-auth-js';
 import { PasskeyError } from './errors';
@@ -138,6 +143,108 @@ export class PasskeyApiClient {
       credential: serialized,
       realm: challengeOptions.realm,
       organization: challengeOptions.organization,
+      scope,
+      audience
+    });
+  }
+
+  /**
+   * Request a passkey signup challenge.
+   *
+   * Step 1 of the granular signup flow. Returns the auth session and a
+   * decoded `PublicKeyCredentialCreationOptions`. Run the WebAuthn credential
+   * creation ceremony with `publicKey`, then hand the resulting credential and `authSession` to
+   * `getTokenWithPasskey()`.
+   *
+   * @param options - Signup challenge options (user identifier, optional realm/organization/metadata)
+   * @returns A promise resolving to `{ authSession, publicKey }`
+   * @throws {PasskeyError} If WebAuthn is not supported in the browser
+   * @throws {PasskeyRegisterError} If the challenge request fails
+   */
+  async getSignupChallenge(
+    options: PasskeySignupChallengeOptions
+  ): Promise<PasskeySignupChallenge> {
+    if (!window.PublicKeyCredential) {
+      throw new PasskeyError('passkey_not_supported', 'WebAuthn is not supported in this browser.');
+    }
+
+    const challenge = await this.#passkeyClient.register(options);
+    return {
+      authSession: challenge.authSession,
+      publicKey: prepareCreationOptions(challenge.authnParamsPublicKey)
+    };
+  }
+
+  /**
+   * Request a passkey login challenge.
+   *
+   * Step 1 of the granular login flow. Returns the auth session and a
+   * decoded `PublicKeyCredentialRequestOptions`. Run the WebAuthn assertion
+   * ceremony with `publicKey`, then hand the resulting credential and `authSession` to
+   * `getTokenWithPasskey()`.
+   *
+   * @param options - Optional login challenge options (realm/organization)
+   * @returns A promise resolving to `{ authSession, publicKey }`
+   * @throws {PasskeyError} If WebAuthn is not supported in the browser
+   * @throws {PasskeyChallengeError} If the challenge request fails
+   */
+  async getLoginChallenge(
+    options?: PasskeyLoginChallengeOptions
+  ): Promise<PasskeyLoginChallenge> {
+    if (!window.PublicKeyCredential) {
+      throw new PasskeyError('passkey_not_supported', 'WebAuthn is not supported in this browser.');
+    }
+
+    const challenge = await this.#passkeyClient.challenge(options);
+
+    return {
+      authSession: challenge.authSession,
+      publicKey: prepareRequestOptions(challenge.authnParamsPublicKey)
+    };
+  }
+
+  /**
+   * Exchange a signed passkey credential for tokens.
+   *
+   * Step 2 of the granular flow. Serializes the raw `PublicKeyCredential`
+   * produced by the WebAuthn ceremony — either a creation (signup) or an
+   * assertion (login) credential — and exchanges it for tokens. The credential
+   * type (attestation vs assertion) is detected automatically.
+   *
+   * @param options - The auth session, raw credential, and optional realm/organization/scope/audience
+   * @returns A promise resolving to the token endpoint response
+   * @throws {PasskeyError} If WebAuthn is not supported in the browser
+   * @throws {PasskeyError} If the credential is not a valid attestation or assertion response
+   * @throws {GenericError} If the token exchange fails
+   */
+  async getTokenWithPasskey(
+    options: PasskeyGetTokenOptions
+  ): Promise<TokenEndpointResponse> {
+    if (!window.PublicKeyCredential) {
+      throw new PasskeyError('passkey_not_supported', 'WebAuthn is not supported in this browser.');
+    }
+
+    const { authSession, credential, realm, organization, scope, audience } = options;
+    const response = credential.response;
+
+    let serialized: PasskeyCredentialResponse;
+
+    if (response instanceof AuthenticatorAttestationResponse) {
+      serialized = serializeCreationCredential(credential);
+    } else if (response instanceof AuthenticatorAssertionResponse) {
+      serialized = serializeAssertionCredential(credential);
+    } else {
+      throw new PasskeyError(
+        'passkey_invalid_credential',
+        'The provided credential is not a valid attestation or assertion response.'
+      );
+    }
+
+    return this.#auth0Client._requestTokenForPasskey({
+      authSession,
+      credential: serialized,
+      realm,
+      organization,
       scope,
       audience
     });

--- a/src/passkey/index.ts
+++ b/src/passkey/index.ts
@@ -15,5 +15,8 @@ export type {
   PasskeyCreationOptions,
   PasskeyRequestOptions,
   PasskeySignupOptions,
-  PasskeyLoginOptions
+  PasskeyLoginOptions,
+  PasskeySignupChallenge,
+  PasskeyLoginChallenge,
+  PasskeyGetTokenOptions
 } from './types';

--- a/src/passkey/types.ts
+++ b/src/passkey/types.ts
@@ -33,3 +33,42 @@ export type PasskeyLoginOptions = PasskeyLoginChallengeOptions & {
   scope?: string;
   audience?: string;
 };
+
+/**
+ * A passkey signup challenge ready for the WebAuthn ceremony.
+ *
+ * `publicKey` is decoded (base64url → ArrayBuffer) and can be fed directly into
+ * a WebAuthn credential creation ceremony. `authSession` must be retained and passed to `getTokenWithPasskey()`.
+ */
+export type PasskeySignupChallenge = {
+  authSession: string;
+  publicKey: PublicKeyCredentialCreationOptions;
+};
+
+/**
+ * A passkey login challenge ready for the WebAuthn ceremony.
+ *
+ * `publicKey` is decoded (base64url → ArrayBuffer) and can be fed directly into
+ * a WebAuthn assertion ceremony . `authSession` must be retained and passed to `getTokenWithPasskey()`.
+ */
+export type PasskeyLoginChallenge = {
+  authSession: string;
+  publicKey: PublicKeyCredentialRequestOptions;
+};
+
+/**
+ * Options for exchanging a signed passkey credential for tokens.
+ *
+ * `credential` is the raw `PublicKeyCredential` produced by the WebAuthn
+ * ceremony — a creation credential (signup) or an assertion credential
+ * (login). The credential type (attestation vs assertion) is detected
+ * automatically during serialization.
+ */
+export type PasskeyGetTokenOptions = {
+  authSession: string;
+  credential: PublicKeyCredential;
+  realm?: string;
+  organization?: string;
+  scope?: string;
+  audience?: string;
+};


### PR DESCRIPTION
## Description

Exposes three new granular public methods on `PasskeyApiClient`, giving customers control over each stage of the passkey flow instead of only the all-in-one `signup()` / `login()` methods:

- **`getSignupChallenge(options)`** — requests a signup challenge and returns `{ authSession, publicKey }` with a decoded `PublicKeyCredentialCreationOptions`.
- **`getLoginChallenge(options?)`** — requests a login challenge and returns `{ authSession, publicKey }` with a decoded `PublicKeyCredentialRequestOptions`.
- **`getTokenWithPasskey(options)`** — serializes the signed `PublicKeyCredential` (auto-detecting attestation vs assertion) and exchanges it for tokens.

The customer runs the WebAuthn ceremony themselves (any library/framework) between the challenge and token-exchange steps.

## Motivation

The existing `signup()` / `login()` bundle challenge → WebAuthn ceremony → token exchange into a single call. Customers who need to run the ceremony with their own tooling, or interleave custom logic, had no entry point. These methods expose the individual stages while leaving the all-in-one methods unchanged.

## Notes

- **Fully backwards compatible** — `signup()` and `login()` are untouched; this only adds new methods and types.
- New types exported: `PasskeySignupChallenge`, `PasskeyLoginChallenge`, `PasskeyGetTokenOptions`.
- `getTokenWithPasskey` throws `PasskeyError('passkey_invalid_credential', ...)` if the credential is neither an attestation nor an assertion response.
- `scope` / `audience` live only on `getTokenWithPasskey` (the token-exchange step), not on the challenge methods.

## Testing

- Added 22 unit tests across the three new methods (challenge decoding, option forwarding, WebAuthn-unsupported guard, credential-type detection, the invalid-credential guard, base64url serialization, error propagation, and `MfaRequiredError` re-throw).
- Full suite green; `npm run build` passes.
- Manually validated end-to-end against a live tenant.


https://github.com/user-attachments/assets/536d1bc4-b154-4a47-8c09-e716978fc173



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added granular Passkey APIs to request signup and login challenges (`getSignupChallenge`, `getLoginChallenge`).
  * Added token exchange for signed WebAuthn credentials (`getTokenWithPasskey`), including optional realm/organization/scope/audience.
  * Exposed new TypeScript types for granular challenge responses and token exchange options.
* **Documentation**
  * Added a new “Granular Passkey APIs” section with step-by-step signup/login and token exchange examples, plus caching/session notes.
* **Tests**
  * Expanded coverage for granular challenge handling and token exchange validation/errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->