### PR TITLE
fix: run Snyk scan on dependabot PRs

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - if: github.actor == 'dependabot[bot]' || github.event_name == 'merge_group'
-        run: exit 0 # Skip unnecessary test runs for dependabot and merge queues. Artifically flag as successful, as this is a required check for branch protection.
+      - if: github.event_name == 'merge_group'
+        run: exit 0 # Skip unnecessary test runs for merge queues. Artifically flag as successful, as this is a required check for branch protection.
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Changes

Removes the `dependabot[bot]` actor skip condition from the Snyk workflow so vulnerability scanning runs on dependency update PRs. The `merge_group` skip is retained.

## Test plan

- [ ] Verify a dependabot PR triggers the Snyk scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated security-check behavior to short-circuit only for merge-queue events, reducing unnecessary runs.
  * Security checks now run normally for automated dependency update events, instead of being skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->