### PR TITLE
fix: remove singlePromise from getTokenSilently to respect cacheMode: 'off'

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -4,7 +4,6 @@ import { MessageChannel } from 'worker_threads';
 import * as api from '../../src/api';
 import * as http from '../../src/http';
 import { verify } from '../../src/jwt';
-import * as promiseUtils from '../../src/promise-utils';
 import * as scope from '../../src/scope';
 import * as utils from '../../src/utils';
 
@@ -1031,7 +1030,7 @@ describe('Auth0Client', () => {
         expect(client['_getTokenSilently']).toHaveBeenCalledTimes(2);
       });
 
-      it('should not call _getTokenSilently if a call is already in flight', async () => {
+      it('should call _getTokenSilently for each concurrent caller but only make one network request', async () => {
         const client = setup();
 
         jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
@@ -1047,11 +1046,11 @@ describe('Auth0Client', () => {
           getTokenSilently(client)
         ]);
 
-        expect(client['_getTokenSilently']).toHaveBeenCalledTimes(1);
+        expect(client['_getTokenSilently']).toHaveBeenCalledTimes(2);
         expect(tokens[0]).toEqual(tokens[1]);
       });
 
-      it('should not call _getTokenSilently if a call is already in flight (cross instance)', async () => {
+      it('should call _getTokenSilently on each instance but only make one network request across instances', async () => {
         const client1 = setup();
         const client2 = setup();
 
@@ -1070,8 +1069,25 @@ describe('Auth0Client', () => {
         ]);
 
         expect(client1['_getTokenSilently']).toHaveBeenCalledTimes(1);
-        expect(client2['_getTokenSilently']).not.toHaveBeenCalled();
+        expect(client2['_getTokenSilently']).toHaveBeenCalledTimes(1);
         expect(tokens[0]).toEqual(tokens[1]);
+      });
+
+      it('should make its own network request when cacheMode is off and a cacheMode on call is in flight', async () => {
+        const client = setup();
+
+        jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+          access_token: TEST_ACCESS_TOKEN,
+          state: TEST_STATE,
+          code: TEST_CODE
+        });
+
+        await Promise.all([
+          getTokenSilently(client),
+          getTokenSilently(client, { cacheMode: 'off' })
+        ]);
+
+        expect(utils.runIframe).toHaveBeenCalledTimes(2);
       });
     });
 
@@ -1357,39 +1373,31 @@ describe('Auth0Client', () => {
     });
 
     it('uses the cache for subsequent requests that occur before the response', async () => {
-      let singlePromiseSpy = jest
-        .spyOn(promiseUtils, 'singlePromise')
-        .mockImplementation(cb => cb());
+      const auth0 = setup();
+      await loginWithRedirect(auth0);
+      await (auth0 as any).cacheManager.clear();
 
-      try {
-        const auth0 = setup();
-        await loginWithRedirect(auth0);
-        await (auth0 as any).cacheManager.clear();
+      jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        access_token: TEST_ACCESS_TOKEN,
+        state: TEST_STATE
+      });
 
-        jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+      mockFetch.mockResolvedValue(
+        fetchResponse(true, {
+          id_token: TEST_ID_TOKEN,
           access_token: TEST_ACCESS_TOKEN,
-          state: TEST_STATE
-        });
+          expires_in: 86400
+        })
+      );
 
-        mockFetch.mockResolvedValue(
-          fetchResponse(true, {
-            id_token: TEST_ID_TOKEN,
-            access_token: TEST_ACCESS_TOKEN,
-            expires_in: 86400
-          })
-        );
+      const [access_token] = await Promise.all([
+        auth0.getTokenSilently(),
+        auth0.getTokenSilently(),
+        auth0.getTokenSilently()
+      ]);
 
-        const [access_token] = await Promise.all([
-          auth0.getTokenSilently(),
-          auth0.getTokenSilently(),
-          auth0.getTokenSilently()
-        ]);
-
-        expect(access_token).toEqual(TEST_ACCESS_TOKEN);
-        expect(utils.runIframe).toHaveBeenCalledTimes(1);
-      } finally {
-        singlePromiseSpy.mockRestore();
-      }
+      expect(access_token).toEqual(TEST_ACCESS_TOKEN);
+      expect(utils.runIframe).toHaveBeenCalledTimes(1);
     });
 
     it('uses the correct response type for subsequent requests that occur before the response', async () => {
@@ -1927,13 +1935,13 @@ describe('Auth0Client', () => {
           })
         ]);
 
-        // Both should return the same token due to locking
-        expect(token1).toEqual(token2);
+        // cacheMode: 'off' calls each make their own request, so they get different tokens
+        expect(token1).not.toEqual(token2);
         expect(token1).toMatch(/^access_token_\d+$/);
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(utils.runIframe).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(utils.runIframe).toHaveBeenCalledTimes(2);
 
-        // Make subsequent simultaneous calls - should get a different token since lock was released
+        // Make subsequent simultaneous calls - lock is released so new requests go through
         const [token3, token4] = await Promise.all([
           auth0.getTokenSilently({
             authorizationParams: { audience: 'api1' },
@@ -1945,12 +1953,11 @@ describe('Auth0Client', () => {
           })
         ]);
 
-        // Both should return the same token (but different from first pair)
-        expect(token3).toEqual(token4);
-        expect(token3).not.toEqual(token1);
+        // Each call still makes its own request
+        expect(token3).not.toEqual(token4);
         expect(token3).toMatch(/^access_token_\d+$/);
-        expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect(utils.runIframe).toHaveBeenCalledTimes(2);
+        expect(mockFetch).toHaveBeenCalledTimes(4);
+        expect(utils.runIframe).toHaveBeenCalledTimes(4);
       });
     });
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -100,7 +100,7 @@ import {
 // @ts-ignore
 import TokenWorker from './worker/token.worker.ts';
 import { sendMessage } from './worker/worker.utils';
-import { singlePromise, retryPromise } from './promise-utils';
+import { retryPromise } from './promise-utils';
 import { CacheKeyManifest } from './cache/key-manifest';
 import {
   buildIsAuthenticatedCookieName,
@@ -965,10 +965,7 @@ export class Auth0Client {
       }
     };
 
-    const result = await singlePromise(
-      () => this._getTokenSilently(localOptions),
-      `${this.options.clientId}::${localOptions.authorizationParams.audience}::${localOptions.authorizationParams.scope}`
-    );
+    const result = await this._getTokenSilently(localOptions);
 
     return options.detailedResponse ? result : result?.access_token;
   }

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -100,7 +100,6 @@ import {
 // @ts-ignore
 import TokenWorker from './worker/token.worker.ts';
 import { sendMessage } from './worker/worker.utils';
-import { retryPromise } from './promise-utils';
 import { CacheKeyManifest } from './cache/key-manifest';
 import {
   buildIsAuthenticatedCookieName,

--- a/src/global.ts
+++ b/src/global.ts
@@ -545,7 +545,7 @@ export interface PopupConfigOptions {
 export interface GetTokenSilentlyOptions {
   /**
    * When `off`, ignores the cache and always sends a
-   * request to Auth0.
+   * request to Auth0. Concurrent `off` calls are not deduplicated — each makes its own request.
    * When `cache-only`, only reads from the cache and never sends a request to Auth0.
    * Defaults to `on`, where it both reads from the cache and sends a request to Auth0 as needed.
    */


### PR DESCRIPTION
## Problem

`getTokenSilently({ cacheMode: 'off' })` was silently receiving the cached result from an in-flight `getTokenSilently()` (default `cacheMode: 'on'`) call for the same audience and scope, instead of making its own `/oauth/token` request.

Root cause: `singlePromise` deduplicated calls using a key of `clientId::audience::scope`. `cacheMode` was not part of the key, so a `cacheMode: 'off'` call arriving while a `cacheMode: 'on'` call was in-flight was folded into the existing promise — `_getTokenSilently` was never invoked for the second caller.

Fixes #1691

## Solution

Remove `singlePromise` from `getTokenSilently` entirely and rely on the existing `lockManager.runWithLock` mechanism to handle concurrency. The lock already serialises concurrent token requests correctly via a double-checked cache pattern:

- First caller acquires the lock, fetches a fresh token, stores it in cache, releases the lock
- Subsequent `cacheMode: 'on'` callers acquire the lock, find the token in cache, return it — no extra network request
- `cacheMode: 'off'` callers acquire the lock, skip the cache read, and fetch their own fresh token — as intended

`singlePromise` remains in `promise-utils.ts` as it may be useful elsewhere.

## Test changes

- Added a regression test for the exact bug scenario: a `cacheMode: 'off'` call concurrent with an in-flight `cacheMode: 'on'` call now correctly triggers two separate network requests
- `_getTokenSilently` is now called once per concurrent caller (not once total) — the lock handles deduplication at the network level
- Cross-instance concurrent calls now each invoke `_getTokenSilently` independently — the shared lock still prevents duplicate network requests
- Two concurrent `cacheMode: 'off'` calls now each correctly make their own request and receive independent fresh tokens
- Renamed two concurrency test descriptions that were reflecting the old `singlePromise` behaviour


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved silent token retrieval behavior for concurrent calls, including more accurate expectations around per-caller work while still reusing compatible in-flight activity.
  * Ensured `cacheMode: 'off'` concurrent calls are not deduplicated and each performs its own token retrieval when required.
  * Updated scenarios involving cache hits and lock-release to reflect correct token and network activity counts.
* **Documentation**
  * Clarified `cacheMode: 'off'` behavior for concurrent `getTokenSilently` calls in option documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->