### PR TITLE
test: fix flaky concurrency test for cacheMode off

### DIFF
--- a/__tests__/Auth0Client/getTokenSilently.test.ts
+++ b/__tests__/Auth0Client/getTokenSilently.test.ts
@@ -1076,16 +1076,36 @@ describe('Auth0Client', () => {
       it('should make its own network request when cacheMode is off and a cacheMode on call is in flight', async () => {
         const client = setup();
 
-        jest.spyOn(<any>utils, 'runIframe').mockResolvedValue({
+        const runIframeResponse = {
           access_token: TEST_ACCESS_TOKEN,
           state: TEST_STATE,
           code: TEST_CODE
+        };
+
+        // Block the first (cacheMode:'on') call at runIframe so it is
+        // definitively in-flight — and hasn't stored anything to cache yet —
+        // when the second (cacheMode:'off') call starts.
+        let unfreezeFirstCall: (() => void) | undefined;
+        const firstCallAtIframe = new Promise<void>(resolve => {
+          jest.spyOn(<any>utils, 'runIframe')
+            .mockImplementationOnce(
+              () => new Promise(res => {
+                resolve(); // signal: first call is now blocked at runIframe
+                unfreezeFirstCall = () => res(runIframeResponse);
+              })
+            )
+            .mockResolvedValue(runIframeResponse);
         });
 
-        await Promise.all([
-          getTokenSilently(client),
-          getTokenSilently(client, { cacheMode: 'off' })
-        ]);
+        const onCallPromise = getTokenSilently(client);
+
+        // Wait until cacheMode:'on' is blocked at runIframe before launching
+        // cacheMode:'off', guaranteeing it is in-flight with no cached result yet.
+        await firstCallAtIframe;
+        const offCallPromise = getTokenSilently(client, { cacheMode: 'off' });
+
+        unfreezeFirstCall?.();
+        await Promise.all([onCallPromise, offCallPromise]);
 
         expect(utils.runIframe).toHaveBeenCalledTimes(2);
       });


### PR DESCRIPTION
## Problem

The test `should make its own network request when cacheMode is off and a cacheMode on call is in flight` (added in #1693) is flaky. It passes in isolation but fails when the 3 preceding concurrency tests run first.

**Root cause:** The test used `Promise.all` to fire both calls simultaneously and assumed `cacheMode: 'on'` would always acquire the lock first. In practice, `cacheMode: 'off'` reaches the lock faster because it skips the pre-lock cache check (one fewer async hop). After JIT warm-up from the preceding tests, `cacheMode: 'off'` consistently wins the race — it fetches, stores to cache, and completes before `cacheMode: 'on'` does its inner cache check. `cacheMode: 'on'` then correctly returns the cached result without calling `runIframe`, leaving only 1 call instead of the expected 2.

## Fix

Replace the non-deterministic `Promise.all` with a deferred promise that:
1. Blocks the `cacheMode: 'on'` call at `runIframe` so it is definitively in-flight with nothing stored to cache yet
2. Waits for confirmation before launching the `cacheMode: 'off'` call
3. Releases the first call — both complete and `runIframe` is called twice

The test now deterministically verifies the intended scenario regardless of JIT state or test ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved coverage for concurrent silent token requests with different cache settings.
  - Added a deterministic in-flight race scenario to verify that overlapping requests trigger separate iframe invocations rather than reusing cached results.
  - No user-facing functionality or public API changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->