### PR TITLE
fix: converge MRRT cache to single RT on concurrent refresh

### DIFF
--- a/__tests__/Auth0Client/onlineAccess.test.ts
+++ b/__tests__/Auth0Client/onlineAccess.test.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   TEST_CODE_CHALLENGE,
+  TEST_CLIENT_ID,
   TEST_REFRESH_TOKEN,
   TEST_ACCESS_TOKEN,
   TEST_ID_TOKEN
@@ -317,7 +318,9 @@ describe('Auth0Client', () => {
 
       expect(updateEntrySpy).toHaveBeenCalledWith(
         TEST_REFRESH_TOKEN,
-        'new_refresh_token'
+        'new_refresh_token',
+        TEST_CLIENT_ID,
+        undefined
       );
     });
   });

--- a/__tests__/cache/cache-manager.test.ts
+++ b/__tests__/cache/cache-manager.test.ts
@@ -915,7 +915,7 @@ cacheFactories.forEach(cacheFactory => {
         }
 
         // Act
-        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN);
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID);
 
         // Assert: All entries have new refresh token
         for (const entry of entries) {
@@ -948,7 +948,7 @@ cacheFactories.forEach(cacheFactory => {
         global.Date.now = jest.fn(() => laterTime);
 
         // Act: Update refresh token 22 hours later
-        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN);
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID);
 
         // Assert: Get raw cache entry to check expiresAt
         const cacheKey = CacheKey.fromCacheEntry(entry).toKey();
@@ -973,7 +973,7 @@ cacheFactories.forEach(cacheFactory => {
 
         await manager.set(entry);
 
-        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN);
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID);
 
         const result = await manager.get(CacheKey.fromCacheEntry(entry));
         expect(result?.access_token).toBe(TEST_ACCESS_TOKEN);
@@ -996,7 +996,7 @@ cacheFactories.forEach(cacheFactory => {
         await manager.set(entryA);
         await manager.set(entryB);
 
-        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN);
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID);
 
         const resultA = await manager.get(CacheKey.fromCacheEntry(entryA));
         const resultB = await manager.get(CacheKey.fromCacheEntry(entryB));
@@ -1005,9 +1005,72 @@ cacheFactories.forEach(cacheFactory => {
         expect(resultB?.refresh_token).toBe('different_refresh_token');
       });
 
+      it('should update all entries unconditionally when useMrrt is true', async () => {
+        const entryA = {
+          ...defaultData,
+          audience: 'https://api-a.com',
+          refresh_token: OLD_REFRESH_TOKEN
+        };
+
+        const entryB = {
+          ...defaultData,
+          audience: 'https://api-b.com',
+          refresh_token: 'forked_refresh_token'
+        };
+
+        await manager.set(entryA);
+        await manager.set(entryB);
+
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID, true);
+
+        const resultA = await manager.get(CacheKey.fromCacheEntry(entryA));
+        const resultB = await manager.get(CacheKey.fromCacheEntry(entryB));
+
+        expect(resultA?.refresh_token).toBe(NEW_REFRESH_TOKEN);
+        expect(resultB?.refresh_token).toBe(NEW_REFRESH_TOKEN);
+      });
+
+      it('should not update entries for other clients when useMrrt is true', async () => {
+        const OTHER_CLIENT_ID = 'other_client_id';
+
+        const entryThisClient = {
+          ...defaultData,
+          audience: 'https://api-a.com',
+          refresh_token: OLD_REFRESH_TOKEN
+        };
+
+        const entryOtherClient = {
+          ...defaultData,
+          client_id: OTHER_CLIENT_ID,
+          audience: 'https://api-a.com',
+          refresh_token: OLD_REFRESH_TOKEN
+        };
+
+        await manager.set(entryThisClient);
+        await manager.set(entryOtherClient);
+
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID, true);
+
+        const resultThisClient = await manager.get(CacheKey.fromCacheEntry(entryThisClient));
+        const resultOtherClient = await manager.get(CacheKey.fromCacheEntry(entryOtherClient));
+
+        expect(resultThisClient?.refresh_token).toBe(NEW_REFRESH_TOKEN);
+        expect(resultOtherClient?.refresh_token).toBe(OLD_REFRESH_TOKEN);
+      });
+
+      it('should skip entries that have been evicted from the cache', async () => {
+        jest.spyOn(manager as any, 'getCacheKeys').mockResolvedValueOnce([
+          new CacheKey({ clientId: TEST_CLIENT_ID, audience: TEST_AUDIENCE, scope: TEST_SCOPES }).toKey()
+        ]);
+
+        await expect(
+          manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID)
+        ).resolves.not.toThrow();
+      });
+
       it('should handle empty cache gracefully', async () => {
         await expect(
-          manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN)
+          manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID)
         ).resolves.not.toThrow();
       });
 
@@ -1020,7 +1083,7 @@ cacheFactories.forEach(cacheFactory => {
         await manager.set(entry);
 
         await expect(
-          manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN)
+          manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID)
         ).resolves.not.toThrow();
 
         const result = await manager.get(CacheKey.fromCacheEntry(entry));
@@ -1058,7 +1121,7 @@ cacheFactories.forEach(cacheFactory => {
         global.Date.now = jest.fn(() => laterTime);
 
         // Act: Simulate refresh token rotation
-        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN);
+        await manager.updateEntry(OLD_REFRESH_TOKEN, NEW_REFRESH_TOKEN, TEST_CLIENT_ID);
 
         // Assert: All entries still expire at original time
         for (const audience of audiences) {

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1509,7 +1509,9 @@ export class Auth0Client {
       ) {
         await this.cacheManager.updateEntry(
           cache.refresh_token,
-          tokenResult.refresh_token
+          tokenResult.refresh_token,
+          this.options.clientId,
+          this.options.useMrrt
         );
       }
 

--- a/src/cache/cache-manager.ts
+++ b/src/cache/cache-manager.ts
@@ -346,27 +346,41 @@ export class CacheManager {
   }
 
   /**
-   * Updates the refresh token in all cache entries that contain the old refresh token.
+   * Updates the refresh token in cache entries after a rotation.
    *
    * When a refresh token is rotated, multiple cache entries (for different audiences/scopes)
    * may share the same refresh token. This method propagates the new refresh token to all
    * matching entries.
    *
+   * With MRRT enabled, concurrent `getTokenSilently()` calls for different audiences all
+   * read the same RT and exchange it in parallel. Each exchange returns a different rotated
+   * RT, which would leave the client with a diverged set of forked tokens per audience.
+   * Passing `useMrrt = true` unconditionally overwrites every entry that has *any*
+   * refresh token, so the last concurrent call to complete always wins and the client
+   * converges to a single shared RT.
+   *
    * @param oldRefreshToken The refresh token that was used and is now invalid
    * @param newRefreshToken The new refresh token received from the server
+   * @param clientId The client ID whose entries should be updated
+   * @param useMrrt When true, update all entries regardless of their current RT value
    */
   async updateEntry(
     oldRefreshToken: string,
     newRefreshToken: string,
+    clientId: string,
+    useMrrt = false
   ): Promise<void> {
     const allKeys = await this.getCacheKeys();
-
     if (!allKeys) return;
 
     for (const key of allKeys) {
-      const entry = await this.cache.get<WrappedCacheEntry>(key);
+      if (CacheKey.fromKey(key).clientId !== clientId) continue;
 
-      if (entry?.body?.refresh_token === oldRefreshToken) {
+      const entry = await this.cache.get<WrappedCacheEntry>(key);
+      if (!entry?.body) continue;
+
+      const rt = entry.body.refresh_token;
+      if (rt && (useMrrt || rt === oldRefreshToken)) {
         entry.body.refresh_token = newRefreshToken;
         await this.cache.set(key, entry);
       }


### PR DESCRIPTION
## Problem

When MRRT (multi-resource refresh tokens) is enabled, concurrent `getTokenSilently()` calls for different audiences can leave the cache in a diverged state.

**Steps to reproduce:**
1. Configure `Auth0Client` with `useRefreshTokens: true` and multiple resource audiences.
2. Fire two concurrent `getTokenSilently()` calls for different audiences (e.g. `api-1` and `api-2`) before either resolves.
3. Both calls read the same RT (RT0) from cache and exchange it in parallel at `/oauth/token`.
4. The server issues a different rotated RT to each call (RT1-a to Call 1, RT1-b to Call 2).
5. Call 1 completes first:
   - `updateEntry(RT0, RT1-a)` propagates RT1-a to all MRRT entries, including api-2.
   - `cacheManager.set` writes api-1's own entry with RT1-a.
6. Call 2 completes:
   - `updateEntry(RT0, RT1-b)` finds no entry with RT0 (already rotated to RT1-a), so it is a no-op. RT1-b is never propagated to api-1.
   - `cacheManager.set` writes api-2's own entry with RT1-b.
7. Final state: api-1 has RT1-a, api-2 has RT1-b. The cache is diverged.

**Root cause:** Each call does two writes — `updateEntry` propagates the new RT to other MRRT entries, and `cacheManager.set` writes the caller's own entry. With concurrent calls, whichever call finishes second has its `updateEntry` silently no-op (the old RT is already gone), so the new RT never propagates to the other audience entries. Both calls end up writing different RTs to their own entries leaving the cache in a diverged state.

## Fix

- Added a `useMrrt` parameter to `CacheManager.updateEntry`. When `true`, instead of matching `oldRefreshToken`, it unconditionally overwrites every entry that holds a RT. This way the last concurrent call to complete always wins and the client converges to a single shared RT.
- Added a `clientId` parameter to `CacheManager.updateEntry`. Without this, the unconditional overwrite would also update RT-bearing entries for other `Auth0Client` instances sharing the same storage (e.g. `localStorage`). The loop now skips any key whose parsed `clientId` does not match the caller's.
- Passes `this.options.clientId` and `this.options.useMrrt` at the call site in `Auth0Client`.

## Test plan

- [x] `npx jest __tests__/cache/cache-manager.test.ts` - new tests verify (1) `useMrrt=true` overwrites a forked RT unconditionally, (2) entries belonging to a different `clientId` are left untouched, and (3) entries evicted between key listing and fetching are skipped gracefully
- [x] `npx jest __tests__/Auth0Client/onlineAccess.test.ts` - existing spy assertion updated to reflect the new arguments
- [x] `npm test` - full unit suite green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh-token rotation across cached entries when using multi-resource refresh tokens.
  * Prevented updates from affecting entries belonging to other client applications.
  * Ensured token updates continue safely when cached entries have been removed.
  * Improved consistency for concurrent token exchanges across multiple audiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->