### PR TITLE
chore: enable conventionalCommits in .shiprc

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,4 +1,5 @@
 {
+    "conventionalCommits": true,
     "files": {
         "src/version.ts": [],
         ".version": [],


### PR DESCRIPTION
## Summary

- Adds `"conventionalCommits": true` to `.shiprc` to adopt the `chore(release): vX.Y.Z` PR title format introduced in `@a0/ship` 0.9.0
- Ensures release PRs pass commitlint CI checks, which enforce Conventional Commits on PR titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled conventional commit handling for project changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->