### PR TITLE
chore: group @typescript-eslint deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Group `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` into a single Dependabot PR since they are always versioned together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an anonymous session demonstration page with session creation, refresh, login, logout, and local-state clearing.
  * Added visibility into configuration, session status, token claims, and API request/response details.
  * Added support for handling authentication redirect callbacks and displaying errors.

* **Chores**
  * Grouped related TypeScript ESLint dependencies for streamlined updates.
  * Enabled conventional commit support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->