### PR TITLE
fix: widen getTokenSilently overload return types to include undefined

### DIFF
--- a/__tests__/fetcher.test.ts
+++ b/__tests__/fetcher.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { beforeEach, describe, expect } from '@jest/globals';
-import { UseDpopNonceError } from '../src/errors';
+import { GenericError, UseDpopNonceError } from '../src/errors';
 import { GetTokenSilentlyVerboseResponse } from '../src/global';
 import {
   Fetcher,
@@ -332,6 +332,30 @@ describe('Fetcher', () => {
         request,
         TEST_ACCESS_TOKEN
       ));
+  });
+
+  describe('prepareRequest() with undefined token', () => {
+    const fetcher = newTestFetcher({});
+    const request = new Request('https://example.com');
+
+    beforeEach(() => {
+      fetcher['getAccessToken'] = () => Promise.resolve(undefined);
+      fetcher['setAuthorizationHeader'] = jest.fn();
+      fetcher['setDpopProofHeader'] = jest.fn();
+    });
+
+    it('rejects with GenericError missing_access_token', () =>
+      expect(fetcher['prepareRequest'](request)).rejects.toThrow(GenericError));
+
+    it('does not set authorization header', async () => {
+      await fetcher['prepareRequest'](request).catch(() => {});
+      expect(fetcher['setAuthorizationHeader']).not.toHaveBeenCalled();
+    });
+
+    it('does not set DPoP header', async () => {
+      await fetcher['prepareRequest'](request).catch(() => {});
+      expect(fetcher['setDpopProofHeader']).not.toHaveBeenCalled();
+    });
   });
 
   describe('getHeader()', () => {

--- a/__tests__/fetcher.test.ts
+++ b/__tests__/fetcher.test.ts
@@ -336,7 +336,6 @@ describe('Fetcher', () => {
 
   describe('prepareRequest() with undefined token', () => {
     const fetcher = newTestFetcher({});
-    const request = new Request('https://example.com');
 
     beforeEach(() => {
       fetcher['getAccessToken'] = () => Promise.resolve(undefined);
@@ -344,16 +343,22 @@ describe('Fetcher', () => {
       fetcher['setDpopProofHeader'] = jest.fn();
     });
 
-    it('rejects with GenericError missing_access_token', () =>
-      expect(fetcher['prepareRequest'](request)).rejects.toThrow(GenericError));
+    it('rejects with GenericError missing_access_token', async () => {
+      const promise = fetcher['prepareRequest'](new Request('https://example.com'));
+      await expect(promise).rejects.toBeInstanceOf(GenericError);
+      await expect(promise).rejects.toMatchObject({
+        error: 'missing_access_token',
+        error_description: 'No access token available'
+      });
+    });
 
-    it('does not set authorization header', async () => {
-      await fetcher['prepareRequest'](request).catch(() => {});
+    it('does not call setAuthorizationHeader', async () => {
+      await fetcher['prepareRequest'](new Request('https://example.com')).catch(() => {});
       expect(fetcher['setAuthorizationHeader']).not.toHaveBeenCalled();
     });
 
-    it('does not set DPoP header', async () => {
-      await fetcher['prepareRequest'](request).catch(() => {});
+    it('does not call setDpopProofHeader', async () => {
+      await fetcher['prepareRequest'](new Request('https://example.com')).catch(() => {});
       expect(fetcher['setDpopProofHeader']).not.toHaveBeenCalled();
     });
   });

--- a/examples/calling-an-api.md
+++ b/examples/calling-an-api.md
@@ -10,6 +10,13 @@ Retrieve an access token to pass along in the `Authorization` header using the `
 //with async/await
 document.getElementById('call-api').addEventListener('click', async () => {
   const accessToken = await auth0.getTokenSilently();
+
+  if (!accessToken) {
+    // getTokenSilently returns undefined when cacheMode is 'cache-only' and
+    // there is no cached token, or when a session ceiling has been reached.
+    return;
+  }
+
   const result = await fetch('https://myapi.com', {
     method: 'GET',
     headers: {

--- a/examples/myaccount-api.md
+++ b/examples/myaccount-api.md
@@ -181,15 +181,20 @@ await auth0.myAccount.enrollmentVerify({
 
 ### Error Handling
 
-All MyAccount API errors throw `MyAccountApiError` with RFC 7807 fields.
+Every MyAccount API call can throw one of two errors — wrap them all the same way:
+
+- **`GenericError` (`error === 'missing_access_token'`)** — thrown before the request is made when no access token is available (e.g. `cacheMode: 'cache-only'` cache miss or session ceiling reached). Redirect the user to log in.
+- **`MyAccountApiError`** — thrown when the API responds with an error. Contains RFC 7807 fields (`status`, `title`, `detail`, and optionally `validation_errors`).
 
 ```js
-import { MyAccountApiError } from '@auth0/auth0-spa-js';
+import { GenericError, MyAccountApiError } from '@auth0/auth0-spa-js';
 
 try {
   await auth0.myAccount.enrollmentChallenge({ type: 'passkey' });
 } catch (err) {
-  if (err instanceof MyAccountApiError) {
+  if (err instanceof GenericError && err.error === 'missing_access_token') {
+    // No token available — redirect the user to log in.
+  } else if (err instanceof MyAccountApiError) {
     console.error(err.status, err.title, err.detail);
     if (err.validation_errors) {
       err.validation_errors.forEach(e => console.error(e.field, e.detail));

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -898,7 +898,7 @@ export class Auth0Client {
    */
   public async getTokenSilently(
     options: GetTokenSilentlyOptions & { detailedResponse: true }
-  ): Promise<GetTokenSilentlyVerboseResponse>;
+  ): Promise<GetTokenSilentlyVerboseResponse | undefined>;
 
   /**
    * Fetches a new access token and returns it.
@@ -907,7 +907,7 @@ export class Auth0Client {
    */
   public async getTokenSilently(
     options?: GetTokenSilentlyOptions
-  ): Promise<string>;
+  ): Promise<string | undefined>;
 
   /**
    * Fetches a new access token, and either returns just the access token (the default) or the response from the /oauth/token endpoint, depending on the `detailedResponse` option.

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,5 +1,5 @@
 import { DPOP_NONCE_HEADER } from './dpop/utils';
-import { UseDpopNonceError } from './errors';
+import { GenericError, UseDpopNonceError } from './errors';
 import { GetTokenSilentlyVerboseResponse } from './global';
 
 export type ResponseHeaders =
@@ -21,7 +21,7 @@ export type AuthParams = {
   audience?: string;
 };
 
-type AccessTokenFactory = (authParams?: AuthParams) => Promise<string | GetTokenSilentlyVerboseResponse>;
+type AccessTokenFactory = (authParams?: AuthParams) => Promise<string | GetTokenSilentlyVerboseResponse | undefined>;
 
 enum TokenType {
   Bearer = 'Bearer',
@@ -94,7 +94,7 @@ export class Fetcher<TOutput extends CustomFetchMinimalOutput> {
     throw new TypeError('`url` must be absolute or `baseUrl` non-empty.');
   }
 
-  protected getAccessToken(authParams?: AuthParams): Promise<string | GetTokenSilentlyVerboseResponse> {
+  protected getAccessToken(authParams?: AuthParams): Promise<string | GetTokenSilentlyVerboseResponse | undefined> {
     return this.config.getAccessToken
       ? this.config.getAccessToken(authParams)
       : this.hooks.getAccessToken(authParams);
@@ -170,6 +170,13 @@ export class Fetcher<TOutput extends CustomFetchMinimalOutput> {
 
   protected async prepareRequest(request: Request, authParams?: AuthParams) {
     const accessTokenResponse = await this.getAccessToken(authParams);
+
+    if (accessTokenResponse === undefined) {
+      throw new GenericError(
+        'missing_access_token',
+        'No access token available'
+      );
+    }
 
     let tokenType: string;
     let accessToken: string;


### PR DESCRIPTION
## Summary

The public overloads for `getTokenSilently` declare `Promise<string>` and `Promise<GetTokenSilentlyVerboseResponse>`, but the implementation can return `undefined` in two cases:

- **`cacheMode: 'cache-only'` with no matching cache entry** — pre-existing behaviour; the overloads were already incorrect before IPSIE.
- **IPSIE `session_expiry` ceiling reached** — introduced when the session expiry ceiling feature was added.

The implementation signature already reflects this (`Promise<undefined | string | GetTokenSilentlyVerboseResponse>`), but overload signatures are what callers see — the implementation signature is invisible externally.

This aligns the overloads with the implementation so consumers can write correct null checks without fighting the type system. Additionally, `Fetcher.prepareRequest` now throws `GenericError('missing_access_token')` instead of a `TypeError` when the token factory resolves to `undefined`, giving callers a structured error they can handle.

## Test plan

- [x] Existing unit tests pass (`npm test`)
- [x] TypeScript consumers can correctly narrow `string | undefined` from `getTokenSilently`
- [x] `prepareRequest` rejects with `GenericError` (error: `missing_access_token`) when the token factory returns `undefined`

> Reopened from #1646 after rebasing onto latest `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when silent token retrieval cannot provide an access token.
  * Requests now return a clear `missing_access_token` error instead of proceeding without authorization.

* **Documentation**
  * Updated API examples to safely handle unavailable access tokens and skip requests when necessary.
  * Clarified error handling for cache-only misses and session limits.
  * Public token retrieval results now indicate when no token is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->