### PR TITLE
fix: propagate the rotated refresh token to all cache entries on MFA grants

### DIFF
--- a/__tests__/Auth0Client/requestTokenForMfa.test.ts
+++ b/__tests__/Auth0Client/requestTokenForMfa.test.ts
@@ -1,0 +1,215 @@
+import { verify } from '../../src/jwt';
+import { MessageChannel } from 'worker_threads';
+import * as utils from '../../src/utils';
+import * as scope from '../../src/scope';
+import { MfaRequiredError } from '../../src/errors';
+
+import { fetchResponse, loginWithRedirectFn, setupFn } from './helpers';
+
+import {
+  TEST_CODE_CHALLENGE,
+  TEST_ID_TOKEN,
+  TEST_REFRESH_TOKEN
+} from '../constants';
+
+jest.mock('es-cookie');
+jest.mock('../../src/jwt');
+jest.mock('../../src/worker/token.worker');
+
+const mockWindow = <any>global;
+const mockFetch = <jest.Mock>mockWindow.fetch;
+const mockVerify = <jest.Mock>verify;
+
+jest
+  .spyOn(utils, 'bufferToBase64UrlEncoded')
+  .mockReturnValue(TEST_CODE_CHALLENGE);
+
+jest.spyOn(utils, 'runPopup');
+
+const setup = setupFn(mockVerify);
+const loginWithRedirect = loginWithRedirectFn(mockWindow, mockFetch);
+
+const API_AUDIENCE = 'https://api.example.com';
+const MY_ACCOUNT_AUDIENCE = 'https://auth0_domain/me/';
+const MFA_TOKEN = 'mfa-token-abc123';
+
+const requestBody = (body: string): Record<string, string> => {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return Object.fromEntries(new URLSearchParams(body).entries());
+  }
+};
+
+const refreshTokenSentInCall = (callNum: number) =>
+  requestBody(mockFetch.mock.calls[callNum][1].body).refresh_token;
+
+// Echoes the requested scope back: the MRRT path rejects a response that does
+// not cover every scope it asked for.
+const mockTokenResponse = (refresh_token: string) =>
+  mockFetch.mockImplementationOnce((_url: string, init: { body: string }) =>
+    fetchResponse(true, {
+      id_token: TEST_ID_TOKEN,
+      access_token: `access-token-for-${refresh_token}`,
+      refresh_token,
+      token_type: 'Bearer',
+      expires_in: 86400,
+      scope: requestBody(init.body).scope
+    })
+  );
+
+const mockMfaRequired = () =>
+  mockFetch.mockResolvedValueOnce(
+    fetchResponse(false, {
+      error: 'mfa_required',
+      error_description: 'Multifactor authentication required',
+      mfa_token: MFA_TOKEN
+    })
+  );
+
+describe('Auth0Client', () => {
+  const oldWindowLocation = window.location;
+
+  beforeEach(() => {
+    // https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
+    delete window.location;
+    window.location = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        assign: {
+          configurable: true,
+          value: jest.fn()
+        }
+      }
+    ) as Location;
+    // --
+
+    mockWindow.open = jest.fn();
+    mockWindow.addEventListener = jest.fn();
+    mockWindow.removeEventListener = jest.fn();
+    mockWindow.crypto = {
+      subtle: {
+        digest: () => 'foo'
+      },
+      getRandomValues() {
+        return '123';
+      }
+    };
+    mockWindow.MessageChannel = MessageChannel;
+    mockWindow.Worker = {};
+    jest.spyOn(scope, 'getUniqueScopes');
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    jest.clearAllMocks();
+    window.location = oldWindowLocation;
+  });
+
+  describe('_requestTokenForMfa', () => {
+    it('propagates the refresh token rotated by the MFA grant to every MRRT cache entry', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        useMrrt: true,
+        cacheLocation: 'localstorage'
+      });
+
+      // Login: the API entry holds RT1.
+      await loginWithRedirect(auth0, {
+        authorizationParams: { audience: API_AUDIENCE, scope: 'openid profile' }
+      });
+
+      mockFetch.mockReset();
+
+      // MRRT refresh for a second audience: both entries converge on RT2.
+      mockTokenResponse('rt2');
+      await auth0.getTokenSilently({
+        authorizationParams: {
+          audience: MY_ACCOUNT_AUDIENCE,
+          scope: 'openid read:me:authentication_methods'
+        },
+        cacheMode: 'off'
+      });
+
+      // A write scope the tenant challenges: the exchange is refused with an
+      // mfa_token, and the completion grant answers with RT3, rotating RT2 away.
+      mockMfaRequired();
+      await expect(
+        auth0.getTokenSilently({
+          authorizationParams: {
+            audience: MY_ACCOUNT_AUDIENCE,
+            scope: 'openid create:me:authentication_methods'
+          },
+          cacheMode: 'off'
+        })
+      ).rejects.toBeInstanceOf(MfaRequiredError);
+
+      mockTokenResponse('rt3');
+      await auth0.mfa.verify({ mfaToken: MFA_TOKEN, otp: '123456' });
+
+      // The API entry, untouched by the MFA grant, must now refresh with RT3;
+      // presenting RT2 would trip the server's reuse detection.
+      mockTokenResponse('rt4');
+      await auth0.getTokenSilently({
+        authorizationParams: {
+          audience: API_AUDIENCE,
+          scope: 'openid profile'
+        },
+        cacheMode: 'off'
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(refreshTokenSentInCall(0)).toBe(TEST_REFRESH_TOKEN);
+      expect(refreshTokenSentInCall(1)).toBe('rt2');
+      expect(refreshTokenSentInCall(3)).toBe('rt3');
+    });
+
+    it('propagates the rotated refresh token to entries sharing it without MRRT', async () => {
+      const auth0 = setup({
+        useRefreshTokens: true,
+        cacheLocation: 'localstorage'
+      });
+
+      // Login with a broad scope: that entry holds RT1.
+      await loginWithRedirect(auth0, {
+        authorizationParams: {
+          audience: API_AUDIENCE,
+          scope: 'openid profile read:messages'
+        }
+      });
+
+      mockFetch.mockReset();
+
+      // A downscoped request has no entry of its own, so it borrows the broad
+      // entry's RT1, is refused with an mfa_token, and the completion grant
+      // answers with RT2 under the narrower key.
+      mockMfaRequired();
+      await expect(
+        auth0.getTokenSilently({
+          authorizationParams: { audience: API_AUDIENCE, scope: 'openid' },
+          cacheMode: 'off'
+        })
+      ).rejects.toBeInstanceOf(MfaRequiredError);
+
+      mockTokenResponse('rt2');
+      await auth0.mfa.verify({ mfaToken: MFA_TOKEN, otp: '123456' });
+
+      // The broad entry lent RT1 to the refused exchange, so it must move to RT2.
+      mockTokenResponse('rt3');
+      await auth0.getTokenSilently({
+        authorizationParams: {
+          audience: API_AUDIENCE,
+          scope: 'openid profile read:messages'
+        },
+        cacheMode: 'off'
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(refreshTokenSentInCall(0)).toBe(TEST_REFRESH_TOKEN);
+      expect(refreshTokenSentInCall(2)).toBe('rt2');
+    });
+  });
+});

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -2227,7 +2227,37 @@ export class Auth0Client {
   ): Promise<TokenEndpointResponse> {
     // Need to add better typing here
     const { mfaToken, ...restOptions } = options;
-    return this._requestToken({ ...restOptions, mfa_token: mfaToken } as any, additionalParameters);
+
+    // The refresh exchange that was refused with mfa_required consumed the refresh
+    // token some cache entry holds, and the completion grant below rotates it. Read
+    // that entry first so the rotated token can be propagated to every entry
+    // afterwards, as _getTokenUsingRefreshToken does; otherwise the other entries
+    // keep the rotated-away token and their next refresh trips reuse detection.
+    const previous = await this.cacheManager.get(
+      new CacheKey({
+        scope: restOptions.scope,
+        audience: restOptions.audience || DEFAULT_AUDIENCE,
+        clientId: this.options.clientId
+      }),
+      undefined,
+      this.options.useMrrt
+    );
+
+    const result = await this._requestToken(
+      { ...restOptions, mfa_token: mfaToken } as any,
+      additionalParameters
+    );
+
+    if (!this.onlineAccess && result.refresh_token && previous?.refresh_token) {
+      await this.cacheManager.updateEntry(
+        previous.refresh_token,
+        result.refresh_token,
+        this.options.clientId,
+        this.options.useMrrt
+      );
+    }
+
+    return result;
   }
 }
 

--- a/src/Auth0Client.ts
+++ b/src/Auth0Client.ts
@@ -1500,20 +1500,10 @@ export class Auth0Client {
         }
       );
 
-      // Propagate a rotated RT to all MRRT entries. Skipped for online mode,
-      // where ORTs are non-rotating.
-      if (
-        !this.onlineAccess &&
-        tokenResult.refresh_token &&
-        cache?.refresh_token
-      ) {
-        await this.cacheManager.updateEntry(
-          cache.refresh_token,
-          tokenResult.refresh_token,
-          this.options.clientId,
-          this.options.useMrrt
-        );
-      }
+      await this._propagateRotatedRefreshToken(
+        cache?.refresh_token,
+        tokenResult.refresh_token
+      );
 
       // Some scopes requested to the server might not be inside the refresh policies
       // In order to return a token with all requested scopes when using MRRT we should
@@ -1583,6 +1573,27 @@ export class Auth0Client {
 
       throw e;
     }
+  }
+
+  /**
+   * Propagates a rotated refresh token to every cache entry that still holds
+   * the previous one (all MRRT entries when MRRT is on). Skipped for online
+   * mode, where ORTs are non-rotating.
+   */
+  private async _propagateRotatedRefreshToken(
+    previousRefreshToken: string | undefined,
+    newRefreshToken: string | undefined
+  ): Promise<void> {
+    if (this.onlineAccess || !newRefreshToken || !previousRefreshToken) {
+      return;
+    }
+
+    await this.cacheManager.updateEntry(
+      previousRefreshToken,
+      newRefreshToken,
+      this.options.clientId,
+      this.options.useMrrt
+    );
   }
 
   private async _saveEntryInCache(
@@ -2248,14 +2259,10 @@ export class Auth0Client {
       additionalParameters
     );
 
-    if (!this.onlineAccess && result.refresh_token && previous?.refresh_token) {
-      await this.cacheManager.updateEntry(
-        previous.refresh_token,
-        result.refresh_token,
-        this.options.clientId,
-        this.options.useMrrt
-      );
-    }
+    await this._propagateRotatedRefreshToken(
+      previous?.refresh_token,
+      result.refresh_token
+    );
 
     return result;
   }


### PR DESCRIPTION
## Problem

With refresh token rotation and `useMrrt: true`, every cache entry shares one refresh token family. When a refresh exchange is refused with `mfa_required` and the app completes it through `mfa.verify(...)`, the completion grant rotates the refresh token like any refresh exchange does, but `_requestTokenForMfa` → `_requestToken` → `_saveEntryInCache` writes the new token only into the entry it just minted. Every other entry keeps the rotated-away token. The next refresh from one of them makes the server log `ferrt` "reused refresh token detected" (`tokenCounter: N, latestCounter: N+1`) and revoke the whole family; the SDK then survives on the iframe fallback, and when the entry being renewed needs a scope the tenant MFA-gates, the iframe fails with "Multifactor authentication required" and the SDK logs the user out.

Reproduction and tenant-log signature: #1742.

**Root cause:** `_getTokenUsingRefreshToken` has converged the cache after a refresh via `cacheManager.updateEntry(...)` since #1503 / #1702. `_requestTokenForMfa` never got the same step.

## Fix

`_requestTokenForMfa` reads the entry the refused exchange borrowed its refresh token from, using the same MRRT-aware `cacheManager.get(...)` lookup `_getTokenUsingRefreshToken` uses, then after `_requestToken` calls `updateEntry(previous.refresh_token, result.refresh_token, clientId, useMrrt)` under the same `!this.onlineAccess` guard. Under MRRT that converges every entry; without MRRT it updates only the entries that held the consumed token.

Notes for review:
- Touches the token cache (the "ask first" area in `CLAUDE.md`), but only repeats the propagation step the refresh path already performs, with the same guards.
- No public API or option changes, so no README / `examples/` update.
- `_requestTokenForPasskey` is left alone: a passkey login starts a new family rather than rotating one an existing entry holds. Happy to extend if you'd rather have it there too.

## Test plan

- [x] `npx jest __tests__/Auth0Client/requestTokenForMfa.test.ts` — two new tests drive the real client through `loginWithRedirect` → MRRT refresh → `mfa_required` refusal → `mfa.verify` → refresh of the untouched entry, and assert which refresh token went out on the wire. Both fail on `main` (the rotated-away token is sent) and pass with the change; the second covers the non-MRRT downscoping shape from #1503.
- [x] `npx jest __tests__/Auth0Client/onlineAccess.test.ts __tests__/mfa` — existing MFA and online-access suites green.
- [x] `npm test` — full unit suite green (51 suites, 1094 tests).
- [x] `npm run build` including `test:es-check`.

Fixes #1742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-factor authentication token exchanges when refresh-token rotation is enabled.
  - Updated related cached sessions with the newly issued refresh token, helping prevent authentication failures during subsequent token refreshes.
  - Ensured sessions sharing refresh-token credentials continue using the latest valid token after MFA completion.
  - Improved consistency across repeated MFA-related token exchanges when sessions share refresh-token credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->