### PR TITLE
fix(ci): upgrade Node.js to 24 to fix npm Arborist bug in Angular Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,8 +193,9 @@ jobs:
         with:
           node: ${{ env.NODE_VERSION }}
           cache: ${{ env.CACHE_KEY }}
+          ignore-scripts: false
           install: |
-            npx -p @angular/cli@22.1.6 ng new my-app --defaults=true < /dev/null
+            npx -p @angular/cli ng new my-app --defaults=true < /dev/null
           content: |
             echo -e "${{ env.AUTH0_CONTENT }}" > src/auth0.js;
           import: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,9 +193,9 @@ jobs:
         with:
           node: ${{ env.NODE_VERSION }}
           cache: ${{ env.CACHE_KEY }}
-          ignore-scripts: false
           install: |
-            npx -p @angular/cli ng new my-app --defaults=true < /dev/null
+            npx -p @angular/cli ng new my-app --defaults=true --skip-install < /dev/null
+            npm install --prefix my-app
           content: |
             echo -e "${{ env.AUTH0_CONTENT }}" > src/auth0.js;
           import: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,7 @@ jobs:
           cache: ${{ env.CACHE_KEY }}
           install: |
             npx -p @angular/cli ng new my-app --defaults=true --skip-install < /dev/null
-            npm install --prefix my-app
+            npm install --prefix my-app --legacy-peer-deps
           content: |
             echo -e "${{ env.AUTH0_CONTENT }}" > src/auth0.js;
           import: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,7 @@ jobs:
           node: ${{ env.NODE_VERSION }}
           cache: ${{ env.CACHE_KEY }}
           install: |
-            npx -p @angular/cli ng new my-app --defaults=true < /dev/null
+            npx -p @angular/cli@22.1.6 ng new my-app --defaults=true < /dev/null
           content: |
             echo -e "${{ env.AUTH0_CONTENT }}" > src/auth0.js;
           import: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: 24
   CACHE_KEY: '${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}'
   IMPORT_STATEMENT: |
     import './auth0';
@@ -194,8 +194,7 @@ jobs:
           node: ${{ env.NODE_VERSION }}
           cache: ${{ env.CACHE_KEY }}
           install: |
-            npx -p @angular/cli ng new my-app --defaults=true --skip-install < /dev/null
-            npm install --prefix my-app --legacy-peer-deps
+            npx -p @angular/cli ng new my-app --defaults=true < /dev/null
           content: |
             echo -e "${{ env.AUTH0_CONTENT }}" > src/auth0.js;
           import: |


### PR DESCRIPTION
## Summary
- Angular Tests started failing due to a known npm Arborist bug (https://github.com/npm/cli/issues/9787) — `ng new`'s internal `npm install` crashes with `Cannot read properties of null (reading 'edgesOut')` on npm 10.x (shipped with Node 22)
- Fixes by upgrading the test workflow to Node 24 (current LTS), which ships with npm 11.x where the Arborist bug is resolved
- Node 22 is in maintenance mode — this also aligns CI with the current LTS lifecycle

## Test plan
- [x] All jobs pass on this PR with Node 24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated testing environment to use Node.js 24.
  * Simplified Angular app setup by restoring dependency installation during project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->