### PR TITLE
fix(ci): upgrade Node.js to 24 to fix npm Arborist bug in Angular Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  NODE_VERSION: 22
+  NODE_VERSION: 24
   CACHE_KEY: '${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}'
   IMPORT_STATEMENT: |
     import './auth0';


### PR DESCRIPTION
## Summary
- Angular Tests started failing due to a known npm Arborist bug (https://github.com/npm/cli/issues/9787) — `ng new`'s internal `npm install` crashes with `Cannot read properties of null (reading 'edgesOut')` on npm 10.x (shipped with Node 22)
- Fixes by upgrading the test workflow to Node 24 (current LTS), which ships with npm 11.x where the Arborist bug is resolved
- Node 22 is in maintenance mode — this also aligns CI with the current LTS lifecycle

## Test plan
- [x] All jobs pass on this PR with Node 24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and verification environment to use Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->