### PR TITLE
fix: propagate rotated RT across MRRT entries after MFA completion in worker

### DIFF
--- a/__tests__/token.worker.test.ts
+++ b/__tests__/token.worker.test.ts
@@ -1527,6 +1527,83 @@ describe('token worker', () => {
         refresh_token: 'foo'
       });
     });
+
+    it('propagates the rotated RT to all MRRT entries after MFA completion', async () => {
+      const { messageRouter } = require('../src/worker/token.worker');
+
+      const sendAs = (audience: string, scope: string, opts: any) =>
+        new Promise(resolve =>
+          messageRouter({
+            data: { ...opts, useMrrt: true, auth: { audience, scope } },
+            ports: [{ postMessage: resolve }]
+          })
+        );
+
+      // Login: audience1 entry seeded with RT1.
+      mockFetch.mockReturnValueOnce(Promise.resolve({
+        ok: true,
+        json: () => ({ refresh_token: 'rt1' }),
+        headers: new Headers()
+      }));
+      await sendAs('audience1', 'scope1', {
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: { method: 'POST', body: JSON.stringify({ grant_type: 'authorization_code' }) }
+      });
+
+      // MRRT refresh for audience2: both entries converge on RT2.
+      mockFetch.mockReturnValueOnce(Promise.resolve({
+        ok: true,
+        json: () => ({ refresh_token: 'rt2' }),
+        headers: new Headers()
+      }));
+      await sendAs('audience2', 'scope2', {
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: { method: 'POST', body: JSON.stringify({ grant_type: 'refresh_token' }) }
+      });
+
+      // audience1 refresh is refused with mfa_required: RT2 consumed, audience1 entry evicted.
+      mockFetch.mockReturnValueOnce(Promise.resolve({
+        ok: false,
+        json: () => ({ error: 'mfa_required', mfa_token: 'mfa-token' }),
+        headers: new Headers()
+      }));
+      await sendAs('audience1', 'scope1', {
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: { method: 'POST', body: JSON.stringify({ grant_type: 'refresh_token' }) }
+      });
+
+      // MFA completion grant: server rotates RT2 → RT3.
+      mockFetch.mockReturnValueOnce(Promise.resolve({
+        ok: true,
+        json: () => ({ refresh_token: 'rt3', access_token: 'at3' }),
+        headers: new Headers()
+      }));
+      await sendAs('audience1', 'scope1', {
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: {
+          method: 'POST',
+          body: JSON.stringify({
+            grant_type: 'http://auth0.com/oauth/grant-type/mfa-otp',
+            mfa_token: 'mfa-token',
+            otp: '123456'
+          })
+        }
+      });
+
+      // audience2 must now refresh with RT3; presenting RT2 would trip reuse detection.
+      mockFetch.mockReturnValueOnce(Promise.resolve({
+        ok: true,
+        json: () => ({ refresh_token: 'rt4' }),
+        headers: new Headers()
+      }));
+      await sendAs('audience2', 'scope2', {
+        fetchUrl: TOKEN_ENDPOINT,
+        fetchOptions: { method: 'POST', body: JSON.stringify({ grant_type: 'refresh_token' }) }
+      });
+
+      const lastCallBody = JSON.parse(mockFetch.mock.calls[4][1].body);
+      expect(lastCallBody.refresh_token).toBe('rt3');
+    });
   });
 
   describe("useMrrt with default audience", () => {

--- a/src/worker/token.worker.ts
+++ b/src/worker/token.worker.ts
@@ -129,6 +129,13 @@ const messageHandler = async ({
           ...body,
           refresh_token: refreshToken
         });
+    } else if (body.mfa_token) {
+      // Capture the old RT so updateRefreshTokens can fan out the rotation
+      // to all MRRT entries after the completion grant rotates it.
+      refreshToken = getRefreshToken(audience, scope);
+      if (!refreshToken && useMrrt) {
+        refreshToken = refreshTokens['latest_refresh_token'];
+      }
     }
 
     let abortController: AbortController | undefined;


### PR DESCRIPTION
## Problem

When `useMrrt: true` and the worker is active (default memory cache + `useRefreshTokens: true`), MFA step-up leaves other audience entries holding the dead refresh token.

During MFA step-up, the worker evicts the initiating audience entry when `mfa_required` comes back. After `mfa.verify()` completes and the server rotates the RT, `updateRefreshTokens` is called to fan out the new RT — but the old RT was never captured for MFA grants, only for `grant_type=refresh_token`. So the fanout is a no-op and other entries are left with the stale token. Next refresh for any other audience trips reuse detection and revokes the whole family.

The main thread fix landed in #1752. This fixes the worker path.

## Fix

Add an `else if (body.mfa_token)` branch that captures the old RT before the MFA completion grant (falling back to `latest_refresh_token` when the entry was already evicted), so `updateRefreshTokens` has the right reference to fan out after the response.

Relates to #1742.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved refresh-token handling after MFA completion.
  - Ensured rotated tokens remain available for subsequent refreshes across supported audiences.

- **Tests**
  - Added regression coverage for refresh-token rotation during MFA flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->