### PR TITLE
feat: add typed Experiment Center override params to AuthorizationParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ const auth0 = await createAuth0Client({
 > [!NOTE]
 > Experiment Center support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
 
-[Experiment Center](https://auth0.com/docs/customize/universal-login-pages/experiment-center) lets you A/B test your login flow. Auth0 assigns each user to a variant server-side. When you need to force a specific variant — for testing or to apply a decision from a feature-flag tool — pass `experiment_id` and `variation_id` on the login call:
+[Experiment Center](https://auth0.com/docs/customize/experiment-center/overview) lets you A/B test your login flow. Auth0 assigns each user to a variant server-side. When you need to force a specific variant — for testing or to apply a decision from a feature-flag tool — pass `experiment_id` and `variation_id` on the login call:
 
 ```js
 await auth0.loginWithRedirect({

--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ const auth0 = await createAuth0Client({
 
 `refreshTokenMode` is a sub-option of `useRefreshTokens`: it defaults to `RefreshTokenMode.Offline` (the rotating refresh tokens described above) and must be set to `RefreshTokenMode.Online` for Online Refresh Tokens. Online mode requires both `useRefreshTokens: true` and `useDpop: true`. See [Online Access](https://github.com/auth0/auth0-spa-js/blob/main/examples/online-access.md) for the full guide.
 
+### Experiment Center
+
+> [!NOTE]
+> Experiment Center support via SDKs is currently in Early Access. To request access to this feature, contact your Auth0 representative.
+
+[Experiment Center](https://auth0.com/docs/customize/universal-login-pages/experiment-center) lets you A/B test your login flow. Auth0 assigns each user to a variant server-side. When you need to force a specific variant — for testing or to apply a decision from a feature-flag tool — pass `experiment_id` and `variation_id` on the login call:
+
+```js
+await auth0.loginWithRedirect({
+  authorizationParams: {
+    experiment_id: 'exp_passkeys_onboarding',
+    variation_id: 'var_passkey_enabled'
+  }
+});
+```
+
+The override applies to that request only. The next login without these params reverts to normal server-side assignment.
+
+Pass these **per-call** rather than in the `authorizationParams` at client construction time, so the override does not affect silent `prompt=none` token-renewal calls (Experiment Center does not run on those).
+
+**For testing:** drive from test automation (e.g. Cypress, Playwright) with IDs read from a CI environment variable against a staging tenant. Do not hard-code variant IDs in shipped application code.
+
+**For production:** pass the variant decision from a feature-flag tool (e.g. LaunchDarkly) that has already decided which variant the user should see.
+
 ### More Examples
 
 For comprehensive examples covering various scenarios including logging out, calling APIs, refresh tokens, online access, organizations, passkeys, MFA, DPoP, and more, see the [EXAMPLES.md](https://github.com/auth0/auth0-spa-js/blob/main/EXAMPLES.md) document.

--- a/__tests__/Auth0Client/loginWithRedirect.test.ts
+++ b/__tests__/Auth0Client/loginWithRedirect.test.ts
@@ -340,6 +340,58 @@ describe('Auth0Client', () => {
       );
     });
 
+    it('should include experiment override params on the authorize url', async () => {
+      const auth0 = setup();
+
+      await loginWithRedirect(auth0, {
+        authorizationParams: {
+          experiment_id: 'exp_passkeys_onboarding',
+          variation_id: 'var_passkey_enabled',
+          segment_id: 'seg_enterprise'
+        }
+      });
+
+      const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
+
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          experiment_id: 'exp_passkeys_onboarding',
+          variation_id: 'var_passkey_enabled',
+          segment_id: 'seg_enterprise'
+        },
+        false
+      );
+    });
+
+    it('should include experiment override params without segment_id on the authorize url', async () => {
+      const auth0 = setup();
+
+      await loginWithRedirect(auth0, {
+        authorizationParams: {
+          experiment_id: 'exp_passkeys_onboarding',
+          variation_id: 'var_passkey_enabled'
+        }
+      });
+
+      const url = new URL(mockWindow.location.assign.mock.calls[0][0]);
+
+      assertUrlEquals(
+        url,
+        TEST_DOMAIN,
+        '/authorize',
+        {
+          experiment_id: 'exp_passkeys_onboarding',
+          variation_id: 'var_passkey_enabled'
+        },
+        false
+      );
+
+      expect(url.searchParams.has('segment_id')).toBe(false);
+    });
+
     it('should log the user in using offline_access when using refresh tokens', async () => {
       const auth0 = setup({
         useRefreshTokens: true

--- a/src/global.ts
+++ b/src/global.ts
@@ -139,6 +139,39 @@ export interface AuthorizationParams {
   session_transfer_token?: string;
 
   /**
+   * Forces a specific Experiment Center variant for this `/authorize` request
+   * instead of letting Auth0 assign one via its hash. Use together with
+   * `variation_id`.
+   *
+   * Pass per-call (on `loginWithRedirect`/`loginWithPopup`) rather than at
+   * client construction time so the override does not bleed into silent
+   * `prompt=none` token-renewal calls, where Experiment Center does not run.
+   *
+   * **Testing:** drive from test automation (e.g. Cypress/Playwright) with IDs
+   * from a CI environment variable against a staging tenant. Do not hard-code
+   * this in shipped app code.
+   *
+   * **Production:** pass the variant decision from a feature-flag tool
+   * (e.g. LaunchDarkly) that has already decided which variant the user should
+   * see for this request.
+   */
+  experiment_id?: string;
+
+  /**
+   * The variation to force within the experiment identified by `experiment_id`.
+   * Auth0 uses this value instead of computing an assignment for the current
+   * request. The override applies to this request only; the next login without
+   * these params reverts to normal server-side assignment.
+   */
+  variation_id?: string;
+
+  /**
+   * An optional segment identifier to pass alongside `experiment_id` and
+   * `variation_id` when forcing a variant.
+   */
+  segment_id?: string;
+
+  /**
    * If you need to send custom parameters to the Authorization Server,
    * make sure to use the original parameter name.
    */


### PR DESCRIPTION
## Summary

- Adds `experiment_id`, `variation_id`, and `segment_id` as typed optional `string` fields on `AuthorizationParams`
- Auth0 already honors these as `/authorize` query params — this exposes them as named, documented properties instead of requiring callers to use the index signature
- JSDoc covers the override mechanism, per-call guidance, and testing vs. production caller split
- README gets an Experiment Center EA section with usage example

## Test plan

- [ ] `npm test` passes (no logic change, no new tests needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional authorization settings to select a specific Experiment Center experiment, variation, or segment.
  - Supports controlling experiment variants during authorization flows, including testing and production scenarios.

- **Documentation**
  - Added Early Access guidance for using Experiment Center overrides.
  - Documented how overrides interact with silent renewals and provided testing and production usage recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->